### PR TITLE
ci: split monolithic job into parallel lint / format / typecheck / test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,60 @@ on:
     branches: [main]
 
 jobs:
-  build-and-test:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run format:check
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build providers
+        run: npm run build --workspace=packages/providers
+
+      - run: npm run typecheck
+
+  test:
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [20, 22]
-
     steps:
       - uses: actions/checkout@v6
 
@@ -26,14 +74,4 @@ jobs:
       - name: Build providers
         run: npm run build --workspace=packages/providers
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Test
-        run: npm run test
+      - run: npm run test


### PR DESCRIPTION
## Summary

- **Before**: a single `build-and-test` job ran lint → format → typecheck → test sequentially. A lint failure blocked seeing test results and vice versa.
- **After**: four independent jobs run in parallel on every push/PR, each failing independently for clearer signal.

## Jobs

| Job | Runs on | Build providers? | Notes |
|-----|---------|-----------------|-------|
| `lint` | Node 22 | No | ESLint doesn't need compiled output |
| `format` | Node 22 | No | Prettier doesn't need compiled output |
| `typecheck` | Node 22 | Yes | Needs `packages/providers` dist for subpath imports |
| `test` | Node 20 + 22 | Yes | Matrix across both LTS versions |

## Test plan

- [ ] All 4 job types appear as separate checks on this PR
- [ ] Each can fail without blocking the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)