### PR TITLE
fix(cli): replace nonexistent nodes property with definition.states count

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -100,7 +100,7 @@ triageCmd.action(async (options: Record<string, unknown>) => {
   let currentPhaseColor: (s: string) => string = chalk.cyan;
   let lastPhase: string | null = null;
   let stepIndex = 0;
-  const totalSteps = triageRecipe.nodes.length;
+  const totalSteps = Object.keys(triageRecipe.definition.states).length;
 
   function formatElapsed(ms: number): string {
     const s = Math.round(ms / 1000);


### PR DESCRIPTION
## Summary

- Fixes TS2339 build error: `Property 'nodes' does not exist on type 'Recipe<TriageConfig>'` in `packages/cli/src/main.ts:103`
- The spinner step counter used `triageRecipe.nodes.length` but `Recipe<TConfig>` has no `nodes` property — states live at `recipe.definition.states` (a `Record<string, StateDefinition>`)
- Replaces with `Object.keys(triageRecipe.definition.states).length` which correctly returns the count of triage states (9)

## Root Cause

The CLI was written referencing a `nodes` array that doesn't exist on the `Recipe` type. The engine uses a `states` map inside `recipe.definition`. This broke the Release workflow's "Build packages" step on every run.

## Test Plan

- [x] `npm run build --workspace=packages/cli` — passes with no TS errors (verified locally)
- [ ] `npm run typecheck` — should pass for all workspaces in CI
- [ ] Release workflow "Build packages" step should pass in CI
- [ ] Spinner shows correct `[x/9]` step counter during `sweny triage` runs

## Files Changed

- `packages/cli/src/main.ts` (line 103, one-line change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)