### PR TITLE
fix(#33): cli spinner step count uses nonexistent nodes property on recipe type

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -100,7 +100,7 @@ triageCmd.action(async (options: Record<string, unknown>) => {
   let currentPhaseColor: (s: string) => string = chalk.cyan;
   let lastPhase: string | null = null;
   let stepIndex = 0;
-  const totalSteps = triageRecipe.nodes.length;
+  const totalSteps = Object.keys(triageRecipe.definition.states).length;
 
   function formatElapsed(ms: number): string {
     const s = Math.round(ms / 1000);


### PR DESCRIPTION
## Summary

Fixes a TypeScript compile error that was blocking the Release workflow. The CLI spinner step counter was reading `triageRecipe.nodes.length`, but `nodes` does not exist on the `Recipe<TConfig>` type. States live at `recipe.definition.states` as a `Record<string, StateDefinition>`, so the fix replaces the broken access with `Object.keys(triageRecipe.definition.states).length`.

## Issue Analysis

- **Severity**: Critical — Release workflow completely blocked; no CLI builds could be published
- **Frequency**: Every Release run since the code was introduced
- **Services affected**: `packages/cli` (`@sweny-ai/cli@0.2.0`), Release CI workflow
- **Impact**: CLI package could not be built or released; spinner displayed no valid step count

## Root Cause

`packages/cli/src/main.ts:103` referenced `triageRecipe.nodes.length` to compute the total spinner step count. The `Recipe<TConfig>` interface (defined in `packages/engine/src/types.ts`) has no `nodes` property — it exposes `definition: RecipeDefinition` and `implementations: StateImplementations<TConfig>`. The state list is keyed under `recipe.definition.states` as a `Record<string, StateDefinition>`. TypeScript caught the mismatch at compile time with TS2339, failing the build.

## Solution

Replace the nonexistent `nodes` property access with the correct path:

```diff
-  const totalSteps = triageRecipe.nodes.length;
+  const totalSteps = Object.keys(triageRecipe.definition.states).length;
```

`Object.keys(triageRecipe.definition.states)` returns the IDs of all 9 triage states (`verify-access`, `build-context`, `investigate`, `novelty-gate`, `create-issue`, `cross-repo-check`, `implement-fix`, `create-pr`, `notify`), giving the spinner the correct `[x/9]` counter. The change is a single line in a single file with no type or API surface changes.

## Testing

- [ ] Lint passes
- [ ] Build passes
- [ ] Tests pass

## Rollback Plan

Revert the single-line change in `packages/cli/src/main.ts:103`. The spinner will revert to the broken/undefined step count display, but the underlying triage workflow logic is unaffected and will continue to function.

---
Closes #33
> Generated by SWEny Triage
