### PR TITLE
fix(cli): update triageRecipe.nodes to definition.states after DAG spec v2 migration, fix formatting

### DIFF
--- a/.github/triage-analysis/best-candidate.md
+++ b/.github/triage-analysis/best-candidate.md
@@ -1,0 +1,87 @@
+<!-- TRIAGE_FINGERPRINT
+error_pattern: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'
+service: sweny-ci / packages/cli
+first_seen: 2026-03-09
+run_id: 22841195318
+-->
+
+RECOMMENDATION: implement
+
+TARGET_SERVICE: sweny
+TARGET_REPO: swenyai/sweny
+
+**GitHub Issues Issue**: None found - New issue will be created
+
+# CLI Typecheck and Format Failures After DAG Spec v2 Migration
+
+## Summary
+
+Two CI-blocking issues introduced by the DAG spec v2 migration are preventing every CI run and the Release pipeline from passing:
+
+1. `packages/cli/src/main.ts:103` references `triageRecipe.nodes.length` — a property that no longer exists after the `Recipe` type was refactored to use `definition.states` (a `Record<string, StateDefinition>`) instead of a flat `nodes[]` array.
+2. Seven recently committed files were not run through Prettier before commit, causing the format check to fail on all branches.
+
+## Root Cause
+
+The DAG spec v2 migration (`b0958d3`) restructured the `Recipe<TConfig>` type:
+
+**Before:**
+```typescript
+// Old (implied): Recipe had a nodes: Node[] property
+const totalSteps = triageRecipe.nodes.length;
+```
+
+**After (current `types.ts`):**
+```typescript
+export interface Recipe<TConfig = unknown> {
+  definition: RecipeDefinition;    // ← states map lives here
+  implementations: StateImplementations<TConfig>;
+}
+
+export interface RecipeDefinition {
+  // ...
+  states: Record<string, StateDefinition>;  // ← no `nodes` array
+}
+```
+
+The CLI spinner at `main.ts:103` was not updated to use the new API shape.
+
+## Exact Code Change
+
+**`packages/cli/src/main.ts` line 103:**
+```typescript
+// Before:
+const totalSteps = triageRecipe.nodes.length;
+
+// After:
+const totalSteps = Object.keys(triageRecipe.definition.states).length;
+```
+
+This produces the same count (9 states in the triage recipe) while using the correct API.
+
+## Formatting Fix
+
+Ran `npx prettier --write` on the 7 files identified by the CI format check:
+- `packages/engine/src/runner-recipe.ts`
+- `packages/engine/src/types.ts`
+- `packages/providers/src/observability/pagerduty.ts`
+- `packages/providers/src/observability/prometheus.ts`
+- `packages/providers/tests/observability/pagerduty.test.ts`
+- `packages/providers/tests/observability/prometheus.test.ts`
+- `packages/studio/index.html`
+
+## Test Plan
+
+- [ ] `npm run typecheck` passes with no `TS2339` error on `main.ts:103`
+- [ ] `npm run format:check` passes (all 7 files now Prettier-compliant)
+- [ ] `npm run build` in `packages/cli` succeeds
+- [ ] `sweny triage --dry-run` spinner shows correct step count (`[N/9]`)
+- [ ] CI passes on main branch
+
+## Rollback Plan
+
+Revert the single-line change in `main.ts:103` and re-run `prettier --write` on the 7 files. The change is fully backward-safe — `Object.keys(recipe.definition.states).length` is semantically identical to the old `recipe.nodes.length`.
+
+## Confidence
+
+Very high. Direct, minimal, well-scoped fix to a clear type error introduced by a known migration.

--- a/.github/triage-analysis/investigation-log.md
+++ b/.github/triage-analysis/investigation-log.md
@@ -1,0 +1,63 @@
+# Investigation Log — 2026-03-09
+
+## Approach
+Following Additional Instructions: autonomous improvement agent for the SWEny codebase.
+Primary input: CI failure logs at `/tmp/ci-logs.json`.
+
+## Step 1: Analyze CI Logs
+
+Parsed CI logs and extracted unique error patterns:
+
+### Error 1: TypeScript type error (critical, blocking CI + Release)
+```
+src/main.ts(103,35): error TS2339: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'
+```
+- Affects: packages/cli
+- Observed on: main, all dependabot branches
+- CI jobs failed: typecheck, Release/Build packages
+
+### Error 2: Format check failure
+```
+Code style issues found in 7 files. Run Prettier with --write to fix.
+```
+Files:
+- `packages/engine/src/runner-recipe.ts`
+- `packages/engine/src/types.ts`
+- `packages/providers/src/observability/pagerduty.ts`
+- `packages/providers/src/observability/prometheus.ts`
+- `packages/providers/tests/observability/pagerduty.test.ts`
+- `packages/providers/tests/observability/prometheus.test.ts`
+- `packages/studio/index.html`
+
+## Step 2: Root Cause Analysis
+
+### Issue 1: `triageRecipe.nodes` does not exist
+
+Examined `packages/engine/src/types.ts`:
+- `Recipe<TConfig>` interface has two fields: `definition: RecipeDefinition` and `implementations: StateImplementations<TConfig>`
+- `RecipeDefinition` has `states: Record<string, StateDefinition>` — NOT a `nodes` array
+
+Examined `packages/cli/src/main.ts:103`:
+```typescript
+const totalSteps = triageRecipe.nodes.length;
+```
+
+Root cause: The DAG spec v2 migration (commit `b0958d3 feat(engine): DAG spec v2 — states{} map, createRecipe factory, explicit routing`) changed the `Recipe` shape from a `nodes[]` array to `definition.states` record, but line 103 in `main.ts` was not updated.
+
+Fix: `Object.keys(triageRecipe.definition.states).length`
+
+### Issue 2: Prettier formatting not applied to newly added files
+
+The 7 flagged files were added/modified recently (pagerduty/prometheus providers, studio HTML, engine types/runner) but were not run through prettier before commit.
+
+Fix: Run `npx prettier --write` on the affected files.
+
+## Step 3: Verify Fix Scope
+
+- The `nodes` reference is only on line 103 of `main.ts` — verified via code read
+- `triageRecipe.definition.states` has 9 states (verify-access, build-context, investigate, novelty-gate, create-issue, cross-repo-check, implement-fix, create-pr, notify)
+- The fix preserves the spinner counter logic correctly
+
+## Conclusion
+
+Both issues are on the same repo (swenyai/sweny). TypeScript error is the primary blocking issue; formatting is secondary but also blocks CI. Both can be fixed in a single PR.

--- a/.github/triage-analysis/issues-report.md
+++ b/.github/triage-analysis/issues-report.md
@@ -1,0 +1,86 @@
+# Issues Report — 2026-03-09
+
+## Issue 1: TypeScript Error — `triageRecipe.nodes` does not exist
+
+- **Severity**: Critical
+- **Environment**: Production (main branch + all dependabot branches)
+- **Frequency**: Every CI run — 100% failure rate
+
+### Description
+`packages/cli/src/main.ts:103` references `triageRecipe.nodes.length` but the `Recipe<TConfig>` type has no `nodes` property. The property is `definition.states` (a `Record<string, StateDefinition>`).
+
+### Evidence
+```
+src/main.ts(103,35): error TS2339: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'.
+npm error code 2
+npm error workspace @sweny-ai/cli@0.2.0
+npm error command sh -c tsc --noEmit
+```
+Observed on: main, dependabot/github_actions/actions/checkout-6, dependabot/github_actions/peter-evans/create-pull-request-8, dependabot/npm_and_yarn/* branches.
+
+Also causes: **Release pipeline build failure** (`npm run build` in CLI package fails).
+
+### Root Cause Analysis
+Commit `b0958d3` introduced DAG spec v2, migrating `Recipe` from a flat `nodes[]` array to `{ definition: RecipeDefinition, implementations: StateImplementations<TConfig> }`. The `main.ts` spinner logic at line 103 used `triageRecipe.nodes.length` to determine total step count for the progress counter but was never updated to reflect the new API.
+
+### Impact
+- CI fails on every push to main and all dependabot branches
+- Release pipeline is broken — no new releases can be cut
+- The `sweny triage` CLI command cannot be type-checked
+
+### Suggested Fix
+```typescript
+// Before (line 103):
+const totalSteps = triageRecipe.nodes.length;
+
+// After:
+const totalSteps = Object.keys(triageRecipe.definition.states).length;
+```
+
+### Files to Modify
+- `packages/cli/src/main.ts` — line 103
+
+### Confidence Level
+Very high — direct, single-line fix with clear causal chain.
+
+### GitHub Issues Status
+No existing GitHub Issues issue found — new issue will be created.
+
+---
+
+## Issue 2: Prettier Formatting Not Applied to 7 Recently Added Files
+
+- **Severity**: High (CI-blocking)
+- **Environment**: Production (all branches)
+- **Frequency**: Every CI run — 100% failure rate
+
+### Description
+7 files added/modified in recent commits were not run through Prettier before committing, causing the format check step to fail.
+
+### Evidence
+```
+[warn] packages/engine/src/runner-recipe.ts
+[warn] packages/engine/src/types.ts
+[warn] packages/providers/src/observability/pagerduty.ts
+[warn] packages/providers/src/observability/prometheus.ts
+[warn] packages/providers/tests/observability/pagerduty.test.ts
+[warn] packages/providers/tests/observability/prometheus.test.ts
+[warn] packages/studio/index.html
+[warn] Code style issues found in 7 files. Run Prettier with --write to fix.
+```
+
+### Root Cause Analysis
+The pagerduty and prometheus providers (and their tests), plus studio HTML and engine runner/types files, were committed without running `prettier --write`. No pre-commit hook is configured to enforce formatting automatically.
+
+### Impact
+- CI format check fails on every branch
+- Combined with Issue 1, CI has zero passing checks on main
+
+### Suggested Fix
+Run `npx prettier --write` on the 7 affected files.
+
+### Confidence Level
+Very high — formatting-only change, no logic impact.
+
+### GitHub Issues Status
+No existing GitHub Issues issue found — bundling with Issue 1 fix.

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -100,7 +100,7 @@ triageCmd.action(async (options: Record<string, unknown>) => {
   let currentPhaseColor: (s: string) => string = chalk.cyan;
   let lastPhase: string | null = null;
   let stepIndex = 0;
-  const totalSteps = triageRecipe.nodes.length;
+  const totalSteps = Object.keys(triageRecipe.definition.states).length;
 
   function formatElapsed(ms: number): string {
     const s = Math.round(ms / 1000);

--- a/packages/engine/src/runner-recipe.ts
+++ b/packages/engine/src/runner-recipe.ts
@@ -68,8 +68,7 @@ export function createRecipe<TConfig>(
   const defErrors = validateDefinition(definition);
   if (defErrors.length > 0) {
     throw new Error(
-      `Invalid recipe definition "${definition.id}":\n` +
-        defErrors.map((e) => `  [${e.code}] ${e.message}`).join("\n"),
+      `Invalid recipe definition "${definition.id}":\n` + defErrors.map((e) => `  [${e.code}] ${e.message}`).join("\n"),
     );
   }
 
@@ -217,11 +216,7 @@ export async function runRecipe<TConfig>(
  *   4. next (success/skipped only)
  *   5. undefined — stop the recipe
  */
-function resolveNext(
-  stateId: string,
-  state: StateDefinition,
-  result: StepResult,
-): string | undefined {
+function resolveNext(stateId: string, state: StateDefinition, result: StepResult): string | undefined {
   const outcome = typeof result.data?.outcome === "string" ? result.data.outcome : undefined;
 
   if (state.on) {

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -135,10 +135,7 @@ export interface StateDefinition {
  * Implementation functions keyed by state id.
  * Every state id in RecipeDefinition.states must have an entry here.
  */
-export type StateImplementations<TConfig> = Record<
-  string,
-  (ctx: WorkflowContext<TConfig>) => Promise<StepResult>
->;
+export type StateImplementations<TConfig> = Record<string, (ctx: WorkflowContext<TConfig>) => Promise<StepResult>>;
 
 /**
  * A complete wired recipe ready to run.
@@ -152,8 +149,8 @@ export interface Recipe<TConfig = unknown> {
 /** Validation error describing a structural problem with a RecipeDefinition. */
 export interface DefinitionError {
   code:
-    | "MISSING_INITIAL"      // initial does not exist in states
-    | "UNKNOWN_TARGET"       // an on/next target does not exist in states and isn't "end"
+    | "MISSING_INITIAL" // initial does not exist in states
+    | "UNKNOWN_TARGET" // an on/next target does not exist in states and isn't "end"
     | "MISSING_IMPLEMENTATION"; // a state id has no implementation (checked by createRecipe)
   message: string;
   stateId?: string;

--- a/packages/providers/src/observability/pagerduty.ts
+++ b/packages/providers/src/observability/pagerduty.ts
@@ -71,12 +71,7 @@ class PagerDutyProvider implements ObservabilityProvider {
     if (!match) return new Date(now - 24 * 60 * 60 * 1000).toISOString();
     const value = parseInt(match[1], 10);
     const unit = match[2];
-    const ms =
-      unit === "m"
-        ? value * 60 * 1000
-        : unit === "h"
-          ? value * 60 * 60 * 1000
-          : value * 24 * 60 * 60 * 1000;
+    const ms = unit === "m" ? value * 60 * 1000 : unit === "h" ? value * 60 * 60 * 1000 : value * 24 * 60 * 60 * 1000;
     return new Date(now - ms).toISOString();
   }
 
@@ -104,9 +99,7 @@ class PagerDutyProvider implements ObservabilityProvider {
       params.append("service_names[]", opts.serviceFilter);
     }
 
-    const result = await this.get<{ incidents: PagerDutyIncident[] }>(
-      `/incidents?${params.toString()}`,
-    );
+    const result = await this.get<{ incidents: PagerDutyIncident[] }>(`/incidents?${params.toString()}`);
 
     const logs: LogEntry[] = (result.incidents ?? []).map((incident) => ({
       timestamp: incident.created_at,

--- a/packages/providers/src/observability/prometheus.ts
+++ b/packages/providers/src/observability/prometheus.ts
@@ -141,9 +141,7 @@ class PrometheusProvider implements ObservabilityProvider {
   }
 
   getPromptInstructions(): string {
-    const authHeader = this.token
-      ? `  -H "Authorization: Bearer $PROMETHEUS_TOKEN" \\`
-      : "";
+    const authHeader = this.token ? `  -H "Authorization: Bearer $PROMETHEUS_TOKEN" \\` : "";
     const authNote = this.token
       ? `- \`PROMETHEUS_TOKEN\` - Bearer token (include as \`Authorization: Bearer $PROMETHEUS_TOKEN\` header)`
       : "";

--- a/packages/providers/tests/observability/pagerduty.test.ts
+++ b/packages/providers/tests/observability/pagerduty.test.ts
@@ -252,9 +252,33 @@ describe("PagerDutyProvider", () => {
   // aggregate
   it("aggregate groups incidents by service and returns counts", async () => {
     const incidents = [
-      { id: "1", title: "A", status: "triggered", urgency: "high", created_at: "2026-03-08T10:00:00Z", html_url: "", service: { summary: "api" } },
-      { id: "2", title: "B", status: "triggered", urgency: "low", created_at: "2026-03-08T09:00:00Z", html_url: "", service: { summary: "api" } },
-      { id: "3", title: "C", status: "acknowledged", urgency: "high", created_at: "2026-03-08T08:00:00Z", html_url: "", service: { summary: "database" } },
+      {
+        id: "1",
+        title: "A",
+        status: "triggered",
+        urgency: "high",
+        created_at: "2026-03-08T10:00:00Z",
+        html_url: "",
+        service: { summary: "api" },
+      },
+      {
+        id: "2",
+        title: "B",
+        status: "triggered",
+        urgency: "low",
+        created_at: "2026-03-08T09:00:00Z",
+        html_url: "",
+        service: { summary: "api" },
+      },
+      {
+        id: "3",
+        title: "C",
+        status: "acknowledged",
+        urgency: "high",
+        created_at: "2026-03-08T08:00:00Z",
+        html_url: "",
+        service: { summary: "database" },
+      },
     ];
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => ({
@@ -280,8 +304,8 @@ describe("PagerDutyProvider", () => {
       text: async () => "",
     }));
 
-    await expect(
-      makeProvider().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "error" }),
-    ).rejects.toThrow("PagerDuty API error: 403 Forbidden");
+    await expect(makeProvider().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "error" })).rejects.toThrow(
+      "PagerDuty API error: 403 Forbidden",
+    );
   });
 });

--- a/packages/providers/tests/observability/prometheus.test.ts
+++ b/packages/providers/tests/observability/prometheus.test.ts
@@ -146,10 +146,7 @@ describe("PrometheusProvider", () => {
 
   it("queryLogs maps firing alerts to LogEntry[]", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "*" });
@@ -170,10 +167,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert, criticalAlert] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert, criticalAlert] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "critical" });
@@ -190,10 +184,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert, workerAlert] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert, workerAlert] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "worker", severity: "*" });
@@ -211,10 +202,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert, alertWithJob] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert, alertWithJob] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "database", severity: "*" });
@@ -241,10 +229,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [alertNoService] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [alertNoService] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "*" });
@@ -260,10 +245,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [alertNoLabels] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [alertNoLabels] } }), { status: 200 });
     });
 
     const logs = await makePrometheus().queryLogs({ timeRange: "1h", serviceFilter: "*", severity: "*" });
@@ -282,10 +264,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert, alert2, alert3] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert, alert2, alert3] } }), { status: 200 });
     });
 
     const results = await makePrometheus().aggregate({ timeRange: "1h", serviceFilter: "*" });
@@ -313,10 +292,7 @@ describe("PrometheusProvider", () => {
     };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      return new Response(
-        JSON.stringify({ data: { alerts: [firingAlert, workerAlert] } }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ data: { alerts: [firingAlert, workerAlert] } }), { status: 200 });
     });
 
     const results = await makePrometheus().aggregate({ timeRange: "1h", serviceFilter: "api" });

--- a/packages/studio/index.html
+++ b/packages/studio/index.html
@@ -5,8 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sweny Studio — Recipe Visualizer</title>
     <style>
-      * { box-sizing: border-box; }
-      body { margin: 0; padding: 0; overflow: hidden; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary

Two CI-blocking regressions introduced by the DAG spec v2 migration:

- **TypeScript error** (`TS2339`): `packages/cli/src/main.ts:103` referenced `triageRecipe.nodes.length` — but the `Recipe<TConfig>` type no longer has a `nodes` array after the DAG spec v2 refactor. States now live under `recipe.definition.states`. Fixed by using `Object.keys(triageRecipe.definition.states).length`.
- **Format failures**: 7 files (`runner-recipe.ts`, `types.ts`, `pagerduty.ts`, `prometheus.ts`, their test files, `studio/index.html`) were committed without running Prettier. Fixed by running `npx prettier --write` on all 7.

## Test plan

- [ ] CI typecheck passes — no `TS2339: Property nodes does not exist on type Recipe<TriageConfig>`
- [ ] CI format check passes — all 7 files Prettier-compliant
- [ ] Release pipeline build step passes
- [ ] `sweny triage --dry-run` spinner shows correct `[N/9]` step counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)