### PR TITLE
fix(#38): build engine before packaging action in release-action.yml

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build providers
         run: npm run build --workspace=packages/providers
 
+      - name: Build engine
+        run: npm run build --workspace=packages/engine
+
       - name: Build dist
         run: npm run package --workspace=packages/action
 


### PR DESCRIPTION
Closes #38

## Summary
- Add `Build engine` step between `Build providers` and `Build dist` in `release-action.yml`
- Without this, the ncc bundle shipped stale committed `dist/` (last built at `dd33707`), missing `observer.ts`, `validate.ts`, and the updated `runRecipe` with observer hooks
- Mirrors the build order already used in `release.yml`: providers → engine → action

## Test plan
- [ ] Trigger a release tag and verify the ncc bundle includes `dist/observer.js` and `dist/validate.js`
- [ ] Verify `packages/engine/dist/index.d.ts` in the bundle includes `CollectingObserver`, `RunObserver`, `ExecutionEvent`
- [ ] Confirm release workflow completes without error in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)