### PR TITLE
fix(#43): engine schema missing provider field breaks schema validation tests

### DIFF
--- a/.changeset/engine-schema-provider-field.md
+++ b/.changeset/engine-schema-provider-field.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/engine": patch
+---
+
+Fix JSON schema for StateDefinition to include the `provider` field that was already present in the TypeScript type. The schema had `additionalProperties: false` but omitted `provider`, causing AJV to reject all built-in recipe definitions in schema validation tests.

--- a/.github/triage-analysis/best-candidate.md
+++ b/.github/triage-analysis/best-candidate.md
@@ -1,8 +1,8 @@
 <!-- TRIAGE_FINGERPRINT
-error_pattern: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'
-service: sweny-ci / packages/cli
-first_seen: 2026-03-09
-run_id: 22841195318
+error_pattern: AssertionError: expected [ { …(5) } ] to be null — validate.errors not null for triageDefinition/implementDefinition
+service: sweny-ci / packages/engine
+first_seen: 2026-03-12
+run_id: 22982090505
 -->
 
 RECOMMENDATION: implement
@@ -12,76 +12,71 @@ TARGET_REPO: swenyai/sweny
 
 **GitHub Issues Issue**: None found - New issue will be created
 
-# CLI Typecheck and Format Failures After DAG Spec v2 Migration
+# Engine Schema Missing provider Field Breaks Schema Validation Tests
 
 ## Summary
 
-Two CI-blocking issues introduced by the DAG spec v2 migration are preventing every CI run and the Release pipeline from passing:
-
-1. `packages/cli/src/main.ts:103` references `triageRecipe.nodes.length` — a property that no longer exists after the `Recipe` type was refactored to use `definition.states` (a `Record<string, StateDefinition>`) instead of a flat `nodes[]` array.
-2. Seven recently committed files were not run through Prettier before commit, causing the format check to fail on all branches.
+`packages/engine/src/schema.test.ts` validates the built-in recipe definitions against a JSON schema. The tests fail because the JSON schema's `StateDefinition` object has `additionalProperties: false` but omits the `provider` field that was added to the TypeScript `StateDefinition` interface. Every state node that uses `provider` (9 in triage, 4 in implement) causes an AJV validation error, making both schema tests fail on every CI run.
 
 ## Root Cause
 
-The DAG spec v2 migration (`b0958d3`) restructured the `Recipe<TConfig>` type:
+The TypeScript type and JSON schema diverged. `packages/engine/src/types.ts` defines:
 
-**Before:**
 ```typescript
-// Old (implied): Recipe had a nodes: Node[] property
-const totalSteps = triageRecipe.nodes.length;
-```
-
-**After (current `types.ts`):**
-```typescript
-export interface Recipe<TConfig = unknown> {
-  definition: RecipeDefinition;    // ← states map lives here
-  implementations: StateImplementations<TConfig>;
-}
-
-export interface RecipeDefinition {
-  // ...
-  states: Record<string, StateDefinition>;  // ← no `nodes` array
+export interface StateDefinition {
+  phase: WorkflowPhase;
+  description?: string;
+  critical?: boolean;
+  next?: string;
+  on?: Record<string, string>;
+  provider?: string;  // ← present in TS type
 }
 ```
 
-The CLI spinner at `main.ts:103` was not updated to use the new API shape.
+But `packages/engine/schema/recipe-definition.schema.json` defines:
+
+```json
+"StateDefinition": {
+  "type": "object",
+  "required": ["phase"],
+  "additionalProperties": false,
+  "properties": {
+    "phase": { ... },
+    "description": { ... },
+    "critical": { ... },
+    "next": { ... },
+    "on": { ... }
+    // ← provider is missing!
+  }
+}
+```
+
+`additionalProperties: false` causes AJV to emit one error per state that uses `provider`. Both `triageDefinition` (9 states with `provider`) and `implementDefinition` (4 states with `provider`) fail validation.
 
 ## Exact Code Change
 
-**`packages/cli/src/main.ts` line 103:**
-```typescript
-// Before:
-const totalSteps = triageRecipe.nodes.length;
+**File**: `packages/engine/schema/recipe-definition.schema.json`
 
-// After:
-const totalSteps = Object.keys(triageRecipe.definition.states).length;
+Add a `provider` entry to the `StateDefinition.properties` block (after `on`):
+
+```json
+"provider": {
+  "type": "string",
+  "description": "Provider category this state primarily relies on (e.g. 'observability', 'issueTracking', 'sourceControl', 'codingAgent', 'notification'). Pure metadata — no runtime effect. Used by Studio to surface required env vars per step."
+}
 ```
-
-This produces the same count (9 states in the triage recipe) while using the correct API.
-
-## Formatting Fix
-
-Ran `npx prettier --write` on the 7 files identified by the CI format check:
-- `packages/engine/src/runner-recipe.ts`
-- `packages/engine/src/types.ts`
-- `packages/providers/src/observability/pagerduty.ts`
-- `packages/providers/src/observability/prometheus.ts`
-- `packages/providers/tests/observability/pagerduty.test.ts`
-- `packages/providers/tests/observability/prometheus.test.ts`
-- `packages/studio/index.html`
 
 ## Test Plan
 
-- [ ] `npm run typecheck` passes with no `TS2339` error on `main.ts:103`
-- [ ] `npm run format:check` passes (all 7 files now Prettier-compliant)
-- [ ] `npm run build` in `packages/cli` succeeds
-- [ ] `sweny triage --dry-run` spinner shows correct step count (`[N/9]`)
-- [ ] CI passes on main branch
+- [ ] `npm test` in `packages/engine` passes — both `triageDefinition passes schema validation` and `implementDefinition passes schema validation` green
+- [ ] `npm run typecheck` in `packages/engine` still passes (no TS changes)
+- [ ] Existing negative schema tests still pass (missing fields, invalid phase, empty states, bad semver)
+- [ ] CI green on main branch
 
 ## Rollback Plan
 
-Revert the single-line change in `main.ts:103` and re-run `prettier --write` on the 7 files. The change is fully backward-safe — `Object.keys(recipe.definition.states).length` is semantically identical to the old `recipe.nodes.length`.
+Remove the `provider` property addition from the JSON schema. The only effect is the two tests will fail again — no runtime behavior is affected since the schema is only used in tests.
 
 ## Confidence
 
-Very high. Direct, minimal, well-scoped fix to a clear type error introduced by a known migration.
+Very high. Single-property additive change to JSON schema that makes it match the existing TypeScript type. No logic changes. Cannot break any existing passing test.

--- a/.github/triage-analysis/investigation-log.md
+++ b/.github/triage-analysis/investigation-log.md
@@ -1,63 +1,85 @@
-# Investigation Log — 2026-03-09
+# Investigation Log — 2026-03-12
 
 ## Approach
-Following Additional Instructions: autonomous improvement agent for the SWEny codebase.
-Primary input: CI failure logs at `/tmp/ci-logs.json`.
+Direct run (no GitHub issue provided, no dispatcher). Followed the autonomous improvement agent mandate:
+1. Parse CI failure logs from `/tmp/ci-logs.json`
+2. Investigate the codebase holistically
+3. Identify the highest-value fix
 
-## Step 1: Analyze CI Logs
+---
 
-Parsed CI logs and extracted unique error patterns:
+## Step 1: Parse CI Logs
 
-### Error 1: TypeScript type error (critical, blocking CI + Release)
-```
-src/main.ts(103,35): error TS2339: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'
-```
-- Affects: packages/cli
-- Observed on: main, all dependabot branches
-- CI jobs failed: typecheck, Release/Build packages
+**Command**: Parsed 28,988 log entries from `/tmp/ci-logs.json`.
 
-### Error 2: Format check failure
-```
-Code style issues found in 7 files. Run Prettier with --write to fix.
-```
-Files:
-- `packages/engine/src/runner-recipe.ts`
-- `packages/engine/src/types.ts`
-- `packages/providers/src/observability/pagerduty.ts`
-- `packages/providers/src/observability/prometheus.ts`
-- `packages/providers/tests/observability/pagerduty.test.ts`
-- `packages/providers/tests/observability/prometheus.test.ts`
-- `packages/studio/index.html`
+**Breakdown by workflow**:
+- CI: 19,649 entries
+- Release: 8,347 entries
+- Deploy Docs: 785 entries
+- Auto Changeset: 207 entries
 
-## Step 2: Root Cause Analysis
+**Meaningful errors filtered on main branch (2026-03-12)**:
 
-### Issue 1: `triageRecipe.nodes` does not exist
+1. `src/schema.test.ts > triageDefinition passes schema validation` — FAIL (every run)
+2. `src/schema.test.ts > implementDefinition passes schema validation` — FAIL (every run)
+3. `AssertionError: expected [ { …(5) }, { …(5) }, { …(5) }, …(6) ] to be null`
+4. `AssertionError: expected [ { …(5) }, { …(5) }, { …(5) }, …(1) ] to be null`
+5. `Cannot read properties of undefined (reading 'find')` in action `tests/main.test.ts`
+6. `src/model/adapter.ts(13,72): error TS2345` — TypeScript in agent package (2026-03-11)
 
-Examined `packages/engine/src/types.ts`:
-- `Recipe<TConfig>` interface has two fields: `definition: RecipeDefinition` and `implementations: StateImplementations<TConfig>`
-- `RecipeDefinition` has `states: Record<string, StateDefinition>` — NOT a `nodes` array
+**Focus**: The `schema.test.ts` failures are consistent across every run on main (confirmed at 00:30, 00:32, 01:11 on 2026-03-12). High confidence this is the right target.
 
-Examined `packages/cli/src/main.ts:103`:
+---
+
+## Step 2: Reproduce Root Cause
+
+**Read**: `packages/engine/src/schema.test.ts`
+- Compiles AJV from `schema/recipe-definition.schema.json`
+- Validates `triageDefinition` and `implementDefinition` against it
+- Expects `validate.errors` to be `null` (passes = null errors)
+
+**Read**: `packages/engine/schema/recipe-definition.schema.json`
+- `StateDefinition.$defs` has `additionalProperties: false`
+- Allowed properties: `phase`, `description`, `critical`, `next`, `on`
+- **Missing**: `provider`
+
+**Read**: `packages/engine/src/recipes/triage/definition.ts`
+- 9 states have `provider: "<role>"` (observability, codingAgent, issueTracking, sourceControl, notification)
+- Only `verify-access` has no `provider` field
+
+**Read**: `packages/engine/src/recipes/implement/definition.ts`
+- 4 states have `provider: "<role>"`
+- Only `verify-access` has no `provider` field
+
+**Read**: `packages/engine/src/types.ts` line 197:
 ```typescript
-const totalSteps = triageRecipe.nodes.length;
+provider?: string;
+// "Pure metadata — no runtime effect. Used by Studio to surface configuration
+// options and required env vars for each step."
 ```
 
-Root cause: The DAG spec v2 migration (commit `b0958d3 feat(engine): DAG spec v2 — states{} map, createRecipe factory, explicit routing`) changed the `Recipe` shape from a `nodes[]` array to `definition.states` record, but line 103 in `main.ts` was not updated.
+**Root Cause**: The `provider?: string` field was added to the TypeScript `StateDefinition` interface but the JSON Schema was not updated to match. `additionalProperties: false` causes AJV to reject the `provider` field as an unknown property.
 
-Fix: `Object.keys(triageRecipe.definition.states).length`
+**Validation error count matches**:
+- triage: 9 states with `provider` → 9 AJV errors → `[…(5), …(5), …(5), …(6)]` array
+- implement: 4 states with `provider` → 4 AJV errors → `[…(5), …(5), …(5), …(1)]` array
 
-### Issue 2: Prettier formatting not applied to newly added files
+---
 
-The 7 flagged files were added/modified recently (pagerduty/prometheus providers, studio HTML, engine types/runner) but were not run through prettier before commit.
+## Step 3: Confirm No Duplicate Issue
 
-Fix: Run `npx prettier --write` on the affected files.
+Checked known triage history (KNOWN ISSUES section) — no existing PR or issue for this schema/provider mismatch.
 
-## Step 3: Verify Fix Scope
+---
 
-- The `nodes` reference is only on line 103 of `main.ts` — verified via code read
-- `triageRecipe.definition.states` has 9 states (verify-access, build-context, investigate, novelty-gate, create-issue, cross-repo-check, implement-fix, create-pr, notify)
-- The fix preserves the spinner counter logic correctly
+## Decision: Fix the Schema
 
-## Conclusion
+**Target file**: `packages/engine/schema/recipe-definition.schema.json`
 
-Both issues are on the same repo (swenyai/sweny). TypeScript error is the primary blocking issue; formatting is secondary but also blocks CI. Both can be fixed in a single PR.
+**Fix**: Add `provider` property to `StateDefinition` in the JSON schema to match the TypeScript type.
+
+This fix:
+- Is minimal (one property added to JSON schema)
+- Unblocks CI on every push to main
+- Keeps the JSON schema in sync with the TypeScript `StateDefinition` interface
+- Purely additive to the schema — cannot break any existing code

--- a/.github/triage-analysis/issues-report.md
+++ b/.github/triage-analysis/issues-report.md
@@ -1,86 +1,77 @@
-# Issues Report — 2026-03-09
+# Issues Report — 2026-03-12
 
-## Issue 1: TypeScript Error — `triageRecipe.nodes` does not exist
+## Issue 1: JSON Schema Missing `provider` Field Causes Engine Schema Tests to Fail
 
-- **Severity**: Critical
-- **Environment**: Production (main branch + all dependabot branches)
-- **Frequency**: Every CI run — 100% failure rate
+- **Severity**: High (CI-blocking on main)
+- **Environment**: Production (main branch, every CI run)
+- **Frequency**: 100% — every CI run on main since `provider` was added to `StateDefinition`
 
 ### Description
-`packages/cli/src/main.ts:103` references `triageRecipe.nodes.length` but the `Recipe<TConfig>` type has no `nodes` property. The property is `definition.states` (a `Record<string, StateDefinition>`).
+
+`packages/engine/src/schema.test.ts` validates `triageDefinition` and `implementDefinition` against the AJV-compiled JSON schema at `packages/engine/schema/recipe-definition.schema.json`. Both definitions include `provider` fields on their state nodes, but the JSON schema's `StateDefinition` object has `additionalProperties: false` and does not list `provider` as a valid property. AJV rejects the definitions and returns 9 and 4 validation errors respectively.
 
 ### Evidence
-```
-src/main.ts(103,35): error TS2339: Property 'nodes' does not exist on type 'Recipe<TriageConfig>'.
-npm error code 2
-npm error workspace @sweny-ai/cli@0.2.0
-npm error command sh -c tsc --noEmit
-```
-Observed on: main, dependabot/github_actions/actions/checkout-6, dependabot/github_actions/peter-evans/create-pull-request-8, dependabot/npm_and_yarn/* branches.
 
-Also causes: **Release pipeline build failure** (`npm run build` in CLI package fails).
+CI logs (2026-03-12T01:11 run, run_id 22982090505):
+```
+FAIL src/schema.test.ts > recipe-definition.schema.json > triageDefinition passes schema validation
+AssertionError: expected [ { …(5) }, { …(5) }, { …(5) }, …(6) ] to be null
+
+FAIL src/schema.test.ts > recipe-definition.schema.json > implementDefinition passes schema validation
+AssertionError: expected [ { …(5) }, { …(5) }, { …(5) }, …(1) ] to be null
+
+Test Files  1 failed | 22 passed (23)
+      Tests  2 failed | 377 passed (379)
+```
+
+Observed on every CI run on main: 00:30, 00:32, 01:11 on 2026-03-12.
 
 ### Root Cause Analysis
-Commit `b0958d3` introduced DAG spec v2, migrating `Recipe` from a flat `nodes[]` array to `{ definition: RecipeDefinition, implementations: StateImplementations<TConfig> }`. The `main.ts` spinner logic at line 103 used `triageRecipe.nodes.length` to determine total step count for the progress counter but was never updated to reflect the new API.
+
+The TypeScript `StateDefinition` interface in `packages/engine/src/types.ts` has (line 197):
+```typescript
+provider?: string;
+```
+
+But the JSON schema (`packages/engine/schema/recipe-definition.schema.json`) `StateDefinition` block:
+```json
+{
+  "additionalProperties": false,
+  "properties": {
+    "phase": { ... },
+    "description": { ... },
+    "critical": { ... },
+    "next": { ... },
+    "on": { ... }
+  }
+}
+```
+does NOT include `provider`. The TypeScript type and JSON schema diverged when `provider` was added to the TS type.
 
 ### Impact
-- CI fails on every push to main and all dependabot branches
-- Release pipeline is broken — no new releases can be cut
-- The `sweny triage` CLI command cannot be type-checked
+
+- `npm test` fails in `packages/engine` on every CI run
+- CI status on main is red on every push
+- Engine package tests show 2 failing / 377 passing
 
 ### Suggested Fix
-```typescript
-// Before (line 103):
-const totalSteps = triageRecipe.nodes.length;
 
-// After:
-const totalSteps = Object.keys(triageRecipe.definition.states).length;
+Add `provider` to `StateDefinition` properties in the JSON schema:
+```json
+"provider": {
+  "type": "string",
+  "description": "Provider category this state primarily relies on (e.g. 'observability', 'issueTracking', 'sourceControl', 'codingAgent', 'notification'). Pure metadata — no runtime effect."
+}
 ```
 
 ### Files to Modify
-- `packages/cli/src/main.ts` — line 103
+
+- `packages/engine/schema/recipe-definition.schema.json`
 
 ### Confidence Level
-Very high — direct, single-line fix with clear causal chain.
+
+Very high — direct schema/type mismatch, single property addition.
 
 ### GitHub Issues Status
+
 No existing GitHub Issues issue found — new issue will be created.
-
----
-
-## Issue 2: Prettier Formatting Not Applied to 7 Recently Added Files
-
-- **Severity**: High (CI-blocking)
-- **Environment**: Production (all branches)
-- **Frequency**: Every CI run — 100% failure rate
-
-### Description
-7 files added/modified in recent commits were not run through Prettier before committing, causing the format check step to fail.
-
-### Evidence
-```
-[warn] packages/engine/src/runner-recipe.ts
-[warn] packages/engine/src/types.ts
-[warn] packages/providers/src/observability/pagerduty.ts
-[warn] packages/providers/src/observability/prometheus.ts
-[warn] packages/providers/tests/observability/pagerduty.test.ts
-[warn] packages/providers/tests/observability/prometheus.test.ts
-[warn] packages/studio/index.html
-[warn] Code style issues found in 7 files. Run Prettier with --write to fix.
-```
-
-### Root Cause Analysis
-The pagerduty and prometheus providers (and their tests), plus studio HTML and engine runner/types files, were committed without running `prettier --write`. No pre-commit hook is configured to enforce formatting automatically.
-
-### Impact
-- CI format check fails on every branch
-- Combined with Issue 1, CI has zero passing checks on main
-
-### Suggested Fix
-Run `npx prettier --write` on the 7 affected files.
-
-### Confidence Level
-Very high — formatting-only change, no logic impact.
-
-### GitHub Issues Status
-No existing GitHub Issues issue found — bundling with Issue 1 fix.

--- a/packages/engine/schema/recipe-definition.schema.json
+++ b/packages/engine/schema/recipe-definition.schema.json
@@ -71,6 +71,10 @@
             "type": "string",
             "minLength": 1
           }
+        },
+        "provider": {
+          "type": "string",
+          "description": "Provider category this state primarily relies on (e.g. 'observability', 'issueTracking', 'sourceControl', 'codingAgent', 'notification'). Pure metadata — no runtime effect. Used by Studio to surface required env vars per step."
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds the missing `provider` field to the `StateDefinition` object in the engine's JSON schema. The field was already present in the TypeScript `StateDefinition` interface but was never added to the JSON schema, causing AJV to reject every built-in recipe definition that uses `provider` — breaking both schema validation tests on every CI run.

## Issue Analysis

- **Severity**: High — CI-blocking on main branch
- **Frequency**: 100% failure rate; every CI push to main since `provider` was added to `StateDefinition`
- **Services affected**: `packages/engine` (schema validation tests), CI workflow
- **Impact**: `npm test` in `packages/engine` fails with 2 test failures (377 passing); CI status on main is always red

## Root Cause

The TypeScript `StateDefinition` interface (`packages/engine/src/types.ts:197`) defines `provider?: string`, but the JSON schema at `packages/engine/schema/recipe-definition.schema.json` uses `additionalProperties: false` and does not list `provider` as a valid property. AJV rejects any state node that includes `provider`, producing one validation error per state:

- `triageDefinition`: 9 states with `provider` → 9 AJV errors
- `implementDefinition`: 4 states with `provider` → 4 AJV errors

## Solution

Added a `provider` string property to the `StateDefinition` block in the JSON schema, matching the existing TypeScript type. This is a purely additive, one-property change — no logic, no runtime behavior, no TypeScript changes.

**File changed**: `packages/engine/schema/recipe-definition.schema.json`

```json
"provider": {
  "type": "string",
  "description": "Provider category this state primarily relies on (e.g. 'observability', 'issueTracking', 'sourceControl', 'codingAgent', 'notification'). Pure metadata — no runtime effect. Used by Studio to surface required env vars per step."
}
```

A `patch` changeset for `@sweny-ai/engine` is included.

## Testing

- [ ] Lint passes
- [ ] Build passes
- [ ] Tests pass

## Rollback Plan

Remove the `provider` property from the `StateDefinition` block in `packages/engine/schema/recipe-definition.schema.json`. The only effect is the two schema tests will fail again — no runtime behavior is affected since the schema is only used in tests.

---
Closes #43
> Generated by SWEny Triage
