### PR TITLE
fix(#60): newrelic and sentry provider config schemas missing required env var fields

### DIFF
--- a/.changeset/newrelic-sentry-config-schema-missing-fields.md
+++ b/.changeset/newrelic-sentry-config-schema-missing-fields.md
@@ -1,0 +1,10 @@
+---
+"@sweny-ai/providers": patch
+---
+
+Fix NewRelic and Sentry provider config schemas missing required env var fields.
+
+`newrelicProviderConfigSchema` was missing `NR_ACCOUNT_ID` and `sentryProviderConfigSchema`
+was missing `SENTRY_ORG` and `SENTRY_PROJECT`. The engine's pre-flight validation checks
+only the fields listed in `configSchema.fields`, so these required env vars were silently
+skipped — causing cryptic mid-workflow runtime failures instead of a clear upfront error.

--- a/.github/triage-analysis/best-candidate.md
+++ b/.github/triage-analysis/best-candidate.md
@@ -1,83 +1,155 @@
 <!-- TRIAGE_FINGERPRINT
-error_pattern: Code style issues found in 6 files. Run Prettier with --write to fix.
-service: sweny-ci
-first_seen: 2026-03-17
-run_id: 23199468449
+error_pattern: provider configSchema.fields missing required env vars NR_ACCOUNT_ID SENTRY_ORG SENTRY_PROJECT
+service: sweny-providers
+first_seen: 2026-03-16
+run_id: direct-run-2026-03-16
 -->
 
 RECOMMENDATION: implement
 
-TARGET_SERVICE: sweny-ci
+TARGET_SERVICE: sweny-providers
 TARGET_REPO: swenyai/sweny
 
 **GitHub Issues Issue**: None found - New issue will be created
 
-# Prettier Format Violations Break CI on Main
+# NewRelic and Sentry Provider Config Schemas Missing Required Env Var Fields
 
 ## Summary
 
-6 files were committed without Prettier formatting, breaking the `format:check` CI step
-on every push to main. This prevents any PR from merging until fixed.
+The `ProviderConfigSchema.fields` arrays for the NewRelic and Sentry observability providers
+are incomplete: they each list only their auth token field, but their Zod schemas require
+additional fields (`accountId` for NewRelic; `organization` and `project` for Sentry).
+
+The engine's pre-flight validation in `runner-recipe.ts` uses `configSchema.fields` to check
+all required env vars before starting a workflow. Because these fields are missing, the engine
+gives users a false "all clear" — then the provider crashes mid-workflow when the missing env
+var is actually needed.
 
 ## Root Cause
 
-The `format:check` CI step runs `prettier --check .`. The following files did not conform
-to the project's Prettier config:
-
-- `packages/action/tests/mapToTriageConfig.test.ts`
-- `packages/providers/src/coding-agent/claude-code.ts`
-- `packages/providers/src/coding-agent/google-gemini.ts`
-- `packages/providers/src/coding-agent/openai-codex.ts`
-- `packages/providers/src/source-control/github.ts`
-- `packages/providers/src/source-control/gitlab.ts`
-
-No pre-commit hook exists to catch this locally, so violations reached CI.
-
-## Evidence
-
-CI run `23199468449` (main, 2026-03-17):
-```
-[warn] packages/action/tests/mapToTriageConfig.test.ts
-[warn] packages/providers/src/coding-agent/claude-code.ts
-[warn] packages/providers/src/coding-agent/google-gemini.ts
-[warn] packages/providers/src/coding-agent/openai-codex.ts
-[warn] packages/providers/src/source-control/github.ts
-[warn] packages/providers/src/source-control/gitlab.ts
-[error] Code style issues found in 6 files. Run Prettier with --write to fix.
-Process completed with exit code 1.
+`packages/providers/src/observability/newrelic.ts` line 17-21:
+```typescript
+// Zod schema (lines 8-13) requires apiKey AND accountId
+// But configSchema.fields only lists apiKey:
+fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
+// NR_ACCOUNT_ID is never checked in pre-flight
 ```
 
-Same failure repeated in runs: 23195029818, 23195412282, 23195001538.
+`packages/providers/src/observability/sentry.ts` line 18-22:
+```typescript
+// Zod schema (lines 8-14) requires authToken, organization, AND project
+// But configSchema.fields only lists authToken:
+fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
+// SENTRY_ORG and SENTRY_PROJECT are never checked in pre-flight
+```
 
-## Fix Applied
+Engine validation at `packages/engine/src/runner-recipe.ts` lines 56-58:
+```typescript
+const missing = provider.configSchema.fields
+  .filter((f) => f.required !== false && !process.env[f.envVar])
+  .map((f) => f.envVar);
+```
+Only the fields listed in `configSchema.fields` are checked. Missing fields are invisible to
+pre-flight validation.
 
-Ran `npx prettier --write` on all 6 files. Verified with `npx prettier --check` — all clean.
+## Exact Code Changes
 
-## Files Modified
+**File**: `packages/providers/src/observability/newrelic.ts`, lines 17-21
 
-| File | Package | Published |
-|------|---------|-----------|
-| `packages/action/tests/mapToTriageConfig.test.ts` | `@sweny-ai/action` | No (private) |
-| `packages/providers/src/coding-agent/claude-code.ts` | `@sweny-ai/providers` | Yes |
-| `packages/providers/src/coding-agent/google-gemini.ts` | `@sweny-ai/providers` | Yes |
-| `packages/providers/src/coding-agent/openai-codex.ts` | `@sweny-ai/providers` | Yes |
-| `packages/providers/src/source-control/github.ts` | `@sweny-ai/providers` | Yes |
-| `packages/providers/src/source-control/gitlab.ts` | `@sweny-ai/providers` | Yes |
+```typescript
+// Before:
+export const newrelicProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "New Relic",
+  fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
+};
 
-## Changeset
+// After:
+export const newrelicProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "New Relic",
+  fields: [
+    { key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" },
+    { key: "accountId", envVar: "NR_ACCOUNT_ID", description: "New Relic account ID" },
+  ],
+};
+```
 
-`@sweny-ai/providers` patch bump — formatting-only, no behavioral change.
+**File**: `packages/providers/src/observability/sentry.ts`, lines 18-22
+
+```typescript
+// Before:
+export const sentryProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "Sentry",
+  fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
+};
+
+// After:
+export const sentryProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "Sentry",
+  fields: [
+    { key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
+    { key: "organization", envVar: "SENTRY_ORG", description: "Sentry organization slug" },
+    { key: "project", envVar: "SENTRY_PROJECT", description: "Sentry project slug" },
+  ],
+};
+```
+
+## Evidence Confirming Correct Env Var Names
+
+`newrelic.ts` `getAgentEnv()` (line 163):
+```typescript
+return { NR_API_KEY: this.apiKey, NR_ACCOUNT_ID: this.accountId, NR_REGION: this.region };
+```
+
+`sentry.ts` `getAgentEnv()` (line 127):
+```typescript
+return { SENTRY_AUTH_TOKEN: this.authToken, SENTRY_ORG: this.org, SENTRY_PROJECT: this.project, ... };
+```
+
+`action/src/config.ts` `validateInputs()` (lines 233-241, 205-213):
+```typescript
+case "newrelic":
+  if (!config.observabilityCredentials.accountId)
+    errors.push("Missing required input: `newrelic-account-id` ...");
+case "sentry":
+  if (!config.observabilityCredentials.organization)
+    errors.push("Missing required input: `sentry-org` ...");
+  if (!config.observabilityCredentials.project)
+    errors.push("Missing required input: `sentry-project` ...");
+```
+
+## Files to Modify
+
+- `packages/providers/src/observability/newrelic.ts` — add `accountId`/`NR_ACCOUNT_ID` field
+- `packages/providers/src/observability/sentry.ts` — add `organization`/`SENTRY_ORG` and `project`/`SENTRY_PROJECT` fields
 
 ## Test Plan
 
-- [ ] `npm run format:check` passes
-- [ ] `npm test` passes (no regressions in source-control or coding-agent tests)
+- [ ] Run existing provider tests: `npm test --workspace packages/providers`
+- [ ] Verify `validateWorkflowConfig` catches missing `NR_ACCOUNT_ID` when NewRelic is used
+- [ ] Verify `validateWorkflowConfig` catches missing `SENTRY_ORG`/`SENTRY_PROJECT` when Sentry is used
+- [ ] Confirm no regression in providers that were already correct (Datadog, Splunk, Elastic)
 
 ## Rollback Plan
 
-Formatting changes are purely cosmetic. If needed, revert the commit. The only effect of
-reverting is CI fails the format check again.
+Config schema additions are purely additive metadata — they only cause pre-flight to report
+a new error when env vars are absent. Rolling back means removing the two new field entries.
+No runtime behavior changes beyond the pre-flight check.
 
 ## Confidence
 
-High. Direct evidence from CI logs. Mechanical Prettier fix — no logic changes.
+Very High. Code inspection directly confirms the mismatch. The env var names are verified
+from three independent sources (getAgentEnv, action config, Zod schemas). Fix is minimal
+(two array additions) with zero risk of regression in the happy path.
+
+## Other Providers Audited (All Clear)
+
+- Datadog: both `DD_API_KEY` + `DD_APPLICATION_KEY` in fields ✅
+- Splunk: both `SPLUNK_URL` + `SPLUNK_TOKEN` in fields ✅
+- Elastic: both `ELASTIC_URL` + `ELASTIC_API_KEY` in fields ✅
+- Loki: `LOKI_URL` only required (`apiKey`/`orgId` are optional) ✅
+- Linear: single required field `LINEAR_API_KEY` in fields ✅
+- Jira: all 3 required fields present ✅

--- a/.github/triage-analysis/fix-declined.md
+++ b/.github/triage-analysis/fix-declined.md
@@ -1,0 +1,27 @@
+# Fix Declined — LOCAL-2
+
+**Date**: 2026-03-12
+**Issue**: Auth Middleware Null Guard Missing on userId Access
+**Confidence in decline**: High
+
+## Reason
+
+The target file `/src/middleware/auth.ts` does not exist in this repository. The `api-gateway`
+service identified in the error logs is not part of the `swenyai/sweny` monorepo.
+
+The triage analysis itself acknowledges this uncertainty:
+
+> `.github/service-map.yml` was not found in this repository. The `api-gateway` service
+> referenced in the logs could not be matched to a specific repo. TARGET_REPO is set to
+> the current repo (`swenyai/sweny`) as a fallback.
+
+A glob search for `**/middleware/auth.ts` and `**/auth.ts` returned no results across the
+entire monorepo. There is no Express/HTTP server code in any published package here —
+this is a DAG engine + CLI + GitHub Action toolchain, not an API gateway service.
+
+## Action Required
+
+1. Create `.github/service-map.yml` mapping service names to repository owners.
+2. Re-dispatch this triage issue to the correct repository once `api-gateway` is mapped.
+3. The fix itself is valid and straightforward — a single null guard before `decodedToken.userId`
+   — it just needs to be applied in the right repo.

--- a/.github/triage-analysis/investigation-log.md
+++ b/.github/triage-analysis/investigation-log.md
@@ -1,65 +1,54 @@
-# Investigation Log — 2026-03-17
+# Investigation Log — 2026-03-16
 
 ## Approach
 
-Additional instructions direct improvement of the SWEny codebase itself.
-Primary inputs: CI failure logs at `/tmp/ci-failures.json` + holistic codebase review.
+Additional instructions: autonomous improvement agent, broad mandate.
+CI failures from `/tmp/ci-failures.json` show recurring `CI on main` and `Deploy Docs` failures.
+GitHub Actions API returned 404 for expired run details, so pivoted to holistic codebase exploration.
 
-## Step 1: Read CI Failure Log
+## Step 1 — Read CI Failures
 
-`/tmp/ci-failures.json` contains 20 entries, all from 2026-03-17.
+The CI failures log contained ~20 entries:
+- `CI on main` (run_id: 23132498377, 23131264950)
+- `Deploy Docs on main` (run_id: 23132498397, 23131264956)
+- Multiple dependabot branch failures
 
-Workflows failing:
-- **CI on main** (run IDs: 23199468449, 23195029818) — repeated failures
-- **Continuous Improvement on main** (run IDs: 23195412282, 23195001538)
-- **CI on dependabot branches** — multiple dependency update branches
+GitHub Actions API returned 404 — run details not accessible (likely expired).
 
-## Step 2: Inspect Most Recent Failure
+## Step 2 — Codebase Exploration
 
-Fetched logs for run `23199468449` (most recent CI failure on main).
+Ran broad exploration of:
+- `packages/providers/src/` — all 30+ provider implementations
+- `packages/engine/src/` — runner, validate, schema
+- `packages/cli/src/` — CLI main entry
+- `packages/action/src/` — GitHub Action entrypoint
 
-**Failure step**: `Format — Run npm run format:check`
+## Step 3 — Identify Provider Config Schema Mismatch Bug
 
-```
-[warn] packages/action/tests/mapToTriageConfig.test.ts
-[warn] packages/providers/src/coding-agent/claude-code.ts
-[warn] packages/providers/src/coding-agent/google-gemini.ts
-[warn] packages/providers/src/coding-agent/openai-codex.ts
-[warn] packages/providers/src/source-control/github.ts
-[warn] packages/providers/src/source-control/gitlab.ts
-[error] Code style issues found in 6 files. Run Prettier with --write to fix.
-Process completed with exit code 1.
-```
+Read `packages/engine/src/runner-recipe.ts` lines 44-66 — `validateWorkflowConfig()` checks
+env vars listed in `provider.configSchema.fields`. Found that several providers list FEWER
+fields than their Zod schemas require, causing silent pre-flight validation passes that lead
+to runtime crashes.
 
-## Step 3: Root Cause Analysis
+**Verified providers:**
 
-6 files were committed without running Prettier first. The `format:check` step in CI runs
-`prettier --check .` and fails the build when files don't conform to the project's formatting
-rules. These were likely new files added or modified in recent commits without running the
-formatter locally.
+| Provider | Zod required | configSchema.fields | Gap |
+|----------|-------------|---------------------|-----|
+| NewRelic | apiKey, accountId | NR_API_KEY only | NR_ACCOUNT_ID missing |
+| Sentry | authToken, organization, project | SENTRY_AUTH_TOKEN only | SENTRY_ORG, SENTRY_PROJECT missing |
+| Datadog | apiKey, appKey | DD_API_KEY, DD_APPLICATION_KEY | ✅ complete |
+| Splunk | baseUrl, token | SPLUNK_URL, SPLUNK_TOKEN | ✅ complete |
+| Elastic | baseUrl, apiKey | ELASTIC_URL, ELASTIC_API_KEY | ✅ complete |
+| Loki | baseUrl (apiKey/orgId optional) | LOKI_URL | ✅ complete |
+| Linear | apiKey | LINEAR_API_KEY | ✅ complete |
+| Jira | baseUrl, email, apiToken | all 3 listed | ✅ complete |
 
-## Step 4: Fix Applied
+Confirmed correct env var names from:
+- `newrelic.ts getAgentEnv()` → exports `NR_ACCOUNT_ID`
+- `sentry.ts getAgentEnv()` → exports `SENTRY_ORG`, `SENTRY_PROJECT`
+- `action/src/config.ts validateInputs()` → checks `newrelic-account-id`, `sentry-org`, `sentry-project`
 
-Ran `npx prettier --write` on all 6 offending files:
-- `packages/action/tests/mapToTriageConfig.test.ts`
-- `packages/providers/src/coding-agent/claude-code.ts`
-- `packages/providers/src/coding-agent/google-gemini.ts`
-- `packages/providers/src/coding-agent/openai-codex.ts`
-- `packages/providers/src/source-control/github.ts`
-- `packages/providers/src/source-control/gitlab.ts`
+## Conclusion
 
-Verified clean with `npx prettier --check` — all files now pass.
-
-## Step 5: Known Issues Cross-Check
-
-- PR #61 (open): newrelic/sentry config schemas — confirmed already committed (`7bd135a`); PR still open but fix is in main. Not related to this CI failure.
-- PR #44, #32, #34: closed, not re-introduced by this change.
-
-## Step 6: Changeset
-
-Files modified are in:
-- `packages/action` (private, not published) — no changeset needed
-- `packages/providers` (published as `@sweny-ai/providers`) — formatting-only = patch
-- `packages/providers/src/source-control/` and `packages/providers/src/coding-agent/` are published
-
-Created `.changeset/fix-prettier-format-violations.md` (patch).
+Best candidate: Fix `newrelicProviderConfigSchema` and `sentryProviderConfigSchema` to include
+all required env var fields. Small, targeted, high-impact fix affecting all users of these providers.

--- a/.github/triage-analysis/issues-report.md
+++ b/.github/triage-analysis/issues-report.md
@@ -1,58 +1,113 @@
-# Issues Report — 2026-03-17
+# Issues Report — 2026-03-16
 
-## Issue 1: Prettier Format Violations Block CI on Main
+## Issue 1: NewRelic and Sentry Provider Config Schemas Missing Required Env Var Fields
 
-- **Severity**: High (CI is broken — no PRs can merge)
-- **Environment**: CI
-- **Frequency**: Recurring — at least 4 CI failures on main on 2026-03-17
+- **Severity**: High
+- **Environment**: All (production and local — any env using these providers)
+- **Frequency**: Affects all users of NewRelic or Sentry providers
 
 ### Description
 
-6 source files were committed without Prettier formatting, causing `format:check` in CI
-to exit with code 1 and block all merges to main.
+The engine's pre-flight validation (`validateWorkflowConfig` in `runner-recipe.ts`) checks
+`provider.configSchema.fields` to verify required environment variables are set before the
+workflow starts. Two providers have incomplete `fields` arrays — they list fewer env vars than
+their Zod schemas require — causing the pre-flight check to silently pass when critical env vars
+are missing, producing confusing runtime failures mid-workflow instead of a clear upfront error.
+
+**NewRelic** (`packages/providers/src/observability/newrelic.ts`):
+- Zod schema requires: `apiKey`, `accountId`
+- `newrelicProviderConfigSchema.fields` lists: only `NR_API_KEY`
+- Missing: `NR_ACCOUNT_ID`
+
+**Sentry** (`packages/providers/src/observability/sentry.ts`):
+- Zod schema requires: `authToken`, `organization`, `project`
+- `sentryProviderConfigSchema.fields` lists: only `SENTRY_AUTH_TOKEN`
+- Missing: `SENTRY_ORG`, `SENTRY_PROJECT`
 
 ### Evidence
 
-From CI run `23199468449`:
+`newrelic.ts` line 17-21 — configSchema only lists one field:
+```typescript
+export const newrelicProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "New Relic",
+  fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
+  //       ^^^^^ missing accountId / NR_ACCOUNT_ID
+};
 ```
-[warn] packages/action/tests/mapToTriageConfig.test.ts
-[warn] packages/providers/src/coding-agent/claude-code.ts
-[warn] packages/providers/src/coding-agent/google-gemini.ts
-[warn] packages/providers/src/coding-agent/openai-codex.ts
-[warn] packages/providers/src/source-control/github.ts
-[warn] packages/providers/src/source-control/gitlab.ts
-[error] Code style issues found in 6 files. Run Prettier with --write to fix.
-Process completed with exit code 1.
+
+But `newrelic.ts` line 163-168 — `getAgentEnv()` shows the expected env vars:
+```typescript
+getAgentEnv(): Record<string, string> {
+  return {
+    NR_API_KEY: this.apiKey,
+    NR_ACCOUNT_ID: this.accountId,   // ← this IS required
+    NR_REGION: this.region,
+  };
+}
+```
+
+`sentry.ts` line 18-22 — configSchema only lists one field, but Zod requires three:
+```typescript
+export const sentryProviderConfigSchema: ProviderConfigSchema = {
+  role: "observability",
+  name: "Sentry",
+  fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
+  //       ^^^^^ missing organization/SENTRY_ORG, project/SENTRY_PROJECT
+};
+```
+
+`runner-recipe.ts` line 56-58 — the validation that is missed:
+```typescript
+const missing = provider.configSchema.fields
+  .filter((f) => f.required !== false && !process.env[f.envVar])
+  .map((f) => f.envVar);
 ```
 
 ### Root Cause Analysis
 
-Files were added/modified in commits without running Prettier locally. The project has no
-pre-commit hook enforcing format, so violations reach CI.
+When new required fields were added to the Zod schemas (accountId for NewRelic,
+organization/project for Sentry), the corresponding `ProviderConfigSchema.fields` arrays
+were not updated. The two validation paths (Zod and configSchema) became out of sync.
 
 ### Impact
 
-- All CI runs on main fail at the Format step
-- The Continuous Improvement workflow also fails (it depends on the CI workflow)
-- Dependabot PRs fail CI too (Prettier check runs on all branches)
+- Users running NewRelic or Sentry without `NR_ACCOUNT_ID` / `SENTRY_ORG` / `SENTRY_PROJECT`
+  pass pre-flight but get cryptic runtime failures when the provider actually executes API calls
+- Debug experience is poor: no clear error message pointing to the missing variable
+- All workflows using these providers are affected
 
 ### Suggested Fix
 
-Run `npx prettier --write` on all 6 offending files. **This fix has been applied.**
+Add the missing fields to each provider's `ProviderConfigSchema.fields`:
 
-### Files Modified
+**newrelic.ts**:
+```typescript
+fields: [
+  { key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" },
+  { key: "accountId", envVar: "NR_ACCOUNT_ID", description: "New Relic account ID" },
+],
+```
 
-- `packages/action/tests/mapToTriageConfig.test.ts`
-- `packages/providers/src/coding-agent/claude-code.ts`
-- `packages/providers/src/coding-agent/google-gemini.ts`
-- `packages/providers/src/coding-agent/openai-codex.ts`
-- `packages/providers/src/source-control/github.ts`
-- `packages/providers/src/source-control/gitlab.ts`
+**sentry.ts**:
+```typescript
+fields: [
+  { key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
+  { key: "organization", envVar: "SENTRY_ORG", description: "Sentry organization slug" },
+  { key: "project", envVar: "SENTRY_PROJECT", description: "Sentry project slug" },
+],
+```
+
+### Files to Modify
+
+- `packages/providers/src/observability/newrelic.ts` — line 20, add accountId field
+- `packages/providers/src/observability/sentry.ts` — line 21, add organization and project fields
 
 ### Confidence Level
 
-High — direct CI log evidence, mechanical fix, verified clean after applying.
+Very High — direct code inspection confirms the mismatch; env var names confirmed via
+`getAgentEnv()` and `action/src/config.ts` validation logic.
 
 ### GitHub Issues Status
 
-No existing GitHub Issues issue found — new issue will be created.
+No existing GitHub Issues issue found — New issue will be created.

--- a/.github/triage-analysis/known-issues-context.md
+++ b/.github/triage-analysis/known-issues-context.md
@@ -1,0 +1,15 @@
+# Known Triage History (Last 30 Days)
+
+These issues have already been identified by previous SWEny Triage runs.
+Do NOT create new issues or propose fixes for these same problems.
+
+## Tracked Issues
+- **LOCAL-1** [open] CLI Typecheck and Format Failures After DAG Spec v2 Migration — file:///Users/nate/src/swenyai/sweny/.sweny/output/issues/LOCAL-1.md
+
+## Pull Requests
+### Merged (fixed)
+_None_
+### Open (in progress)
+_None_
+### Closed (failed attempts)
+_None_

--- a/packages/providers/src/observability/newrelic.ts
+++ b/packages/providers/src/observability/newrelic.ts
@@ -17,7 +17,10 @@ export type NewRelicConfig = z.infer<typeof newrelicConfigSchema>;
 export const newrelicProviderConfigSchema: ProviderConfigSchema = {
   role: "observability",
   name: "New Relic",
-  fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
+  fields: [
+    { key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" },
+    { key: "accountId", envVar: "NR_ACCOUNT_ID", description: "New Relic account ID" },
+  ],
 };
 
 function escapeNrql(value: string): string {

--- a/packages/providers/src/observability/sentry.ts
+++ b/packages/providers/src/observability/sentry.ts
@@ -18,7 +18,11 @@ export type SentryConfig = z.infer<typeof sentryConfigSchema>;
 export const sentryProviderConfigSchema: ProviderConfigSchema = {
   role: "observability",
   name: "Sentry",
-  fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
+  fields: [
+    { key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
+    { key: "organization", envVar: "SENTRY_ORG", description: "Sentry organization slug" },
+    { key: "project", envVar: "SENTRY_PROJECT", description: "Sentry project slug" },
+  ],
 };
 
 export function sentry(config: SentryConfig): ObservabilityProvider & { configSchema: ProviderConfigSchema } {


### PR DESCRIPTION
## Summary

Fix NewRelic and Sentry provider config schemas to include all required environment variable
fields, so the engine's pre-flight validation catches missing credentials before a workflow
starts instead of crashing mid-run with a cryptic error.

## Issue Analysis

- **Severity**: High
- **Frequency**: Affects every workflow using NewRelic or Sentry providers (100% failure rate when env vars are absent)
- **Services affected**: `@sweny-ai/providers` (NewRelic, Sentry observability providers), `@sweny-ai/engine` (pre-flight validation)
- **Impact**: Users with missing `NR_ACCOUNT_ID`, `SENTRY_ORG`, or `SENTRY_PROJECT` receive a false pre-flight "all clear", then encounter a cryptic runtime failure mid-workflow rather than a clear upfront error message

## Root Cause

The engine's pre-flight validation in `runner-recipe.ts` checks only the env vars listed in
`provider.configSchema.fields`. Two providers had incomplete `fields` arrays — listing fewer
entries than their Zod schemas require — creating a mismatch between what Zod validates at
parse time and what the pre-flight check verifies at startup:

| Provider | Zod required fields | `configSchema.fields` | Gap |
|----------|--------------------|-----------------------|-----|
| NewRelic | `apiKey`, `accountId` | `NR_API_KEY` only | `NR_ACCOUNT_ID` missing |
| Sentry | `authToken`, `organization`, `project` | `SENTRY_AUTH_TOKEN` only | `SENTRY_ORG`, `SENTRY_PROJECT` missing |

The correct env var names were confirmed from three independent sources: each provider's
`getAgentEnv()` return value, the Zod config schemas, and `action/src/config.ts`
`validateInputs()`.

All other providers (Datadog, Splunk, Elastic, Loki, Linear, Jira) were audited and are
correct.

## Solution

Added the missing field entries to each provider's `ProviderConfigSchema.fields` array:

**`packages/providers/src/observability/newrelic.ts`** — added `accountId` / `NR_ACCOUNT_ID`:
```typescript
fields: [
  { key: "apiKey",     envVar: "NR_API_KEY",    description: "New Relic User API key" },
  { key: "accountId",  envVar: "NR_ACCOUNT_ID",  description: "New Relic account ID" },
],
```

**`packages/providers/src/observability/sentry.ts`** — added `organization` / `SENTRY_ORG` and `project` / `SENTRY_PROJECT`:
```typescript
fields: [
  { key: "authToken",    envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
  { key: "organization", envVar: "SENTRY_ORG",        description: "Sentry organization slug" },
  { key: "project",      envVar: "SENTRY_PROJECT",    description: "Sentry project slug" },
],
```

The changes are purely additive metadata — no runtime logic was altered. The only behavioral
change is that the pre-flight check now correctly reports an error when these env vars are absent.

## Testing

- [ ] Lint passes
- [ ] Build passes
- [ ] Tests pass
- [ ] `validateWorkflowConfig` catches missing `NR_ACCOUNT_ID` when NewRelic is configured
- [ ] `validateWorkflowConfig` catches missing `SENTRY_ORG`/`SENTRY_PROJECT` when Sentry is configured
- [ ] No regression in providers that were already correct (Datadog, Splunk, Elastic, Loki, Linear, Jira)

## Rollback Plan

The changes are purely additive (two new array entries in metadata-only config objects). To
roll back, remove the added field entries from `newrelicProviderConfigSchema.fields` and
`sentryProviderConfigSchema.fields`. No database migrations, no API changes, no state to unwind.
The only effect of rollback is restoring the previous silent-pass behavior for missing env vars.

---
Closes #60
> Generated by SWEny Triage
