### PR TITLE
fix(#65): prettier format violations break ci on main

### DIFF
--- a/.changeset/fix-prettier-format-violations.md
+++ b/.changeset/fix-prettier-format-violations.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/providers": patch
+---
+
+Fix Prettier formatting violations in coding-agent and source-control provider files. No behavioral changes — formatting only.

--- a/.github/triage-analysis/best-candidate.md
+++ b/.github/triage-analysis/best-candidate.md
@@ -1,105 +1,83 @@
 <!-- TRIAGE_FINGERPRINT
-error_pattern: TypeError: Cannot read properties of undefined (reading 'userId') at auth.ts:42
-service: api-gateway
-first_seen: 2026-03-12
-run_id: direct-run-2026-03-12
+error_pattern: Code style issues found in 6 files. Run Prettier with --write to fix.
+service: sweny-ci
+first_seen: 2026-03-17
+run_id: 23199468449
 -->
 
 RECOMMENDATION: implement
 
-TARGET_SERVICE: api-gateway
+TARGET_SERVICE: sweny-ci
 TARGET_REPO: swenyai/sweny
 
-**Issue Tracker Issue**: None found - New issue will be created
+**GitHub Issues Issue**: None found - New issue will be created
 
-# Auth Middleware Null Guard Missing on userId Access
+# Prettier Format Violations Break CI on Main
 
 ## Summary
 
-`AuthMiddleware.verify` at `auth.ts:42` crashes with a TypeError when the decoded JWT/session
-object is `undefined`. This produces 500s on all authenticated routes instead of the correct
-401/403. The error appeared 3 times in 24h across profile, settings, and orders endpoints.
+6 files were committed without Prettier formatting, breaking the `format:check` CI step
+on every push to main. This prevents any PR from merging until fixed.
 
 ## Root Cause
 
-Line 42 of `auth.ts` accesses `.userId` directly without a null guard:
+The `format:check` CI step runs `prettier --check .`. The following files did not conform
+to the project's Prettier config:
 
-```typescript
-// Current (crashes when decodedToken is undefined/null):
-const userId = decodedToken.userId;
-```
+- `packages/action/tests/mapToTriageConfig.test.ts`
+- `packages/providers/src/coding-agent/claude-code.ts`
+- `packages/providers/src/coding-agent/google-gemini.ts`
+- `packages/providers/src/coding-agent/openai-codex.ts`
+- `packages/providers/src/source-control/github.ts`
+- `packages/providers/src/source-control/gitlab.ts`
 
-When `jwt.verify()` returns a falsy value (e.g., on an invalid or expired token in some
-library configurations) instead of throwing, the subsequent property access throws an
-unhandled TypeError that bubbles up as a 500.
-
-## Exact Code Change
-
-**File**: `/src/middleware/auth.ts`, line ~42
-
-```typescript
-// Before:
-const userId = decodedToken.userId;
-
-// After:
-if (!decodedToken) {
-  return next(new UnauthorizedError('Invalid or missing authentication token'));
-}
-const userId = decodedToken.userId;
-```
-
-If the codebase uses `res.status()` directly instead of error middleware:
-
-```typescript
-// Alternative (express-style):
-if (!decodedToken) {
-  return res.status(401).json({ error: 'Unauthorized' });
-}
-const userId = decodedToken.userId;
-```
-
-The guard should be placed immediately before the `.userId` access (line 42) and should
-return a 401, not a 500, to correctly signal an authentication failure.
+No pre-commit hook exists to catch this locally, so violations reached CI.
 
 ## Evidence
 
+CI run `23199468449` (main, 2026-03-17):
 ```
-TypeError: Cannot read properties of undefined (reading 'userId')
-    at AuthMiddleware.verify (/src/middleware/auth.ts:42:28)
-    at processRequest (/src/server.ts:118:5)
-
-Affected requests (24h):
-  GET  /api/v1/users/profile   -> 500  (req_abc123)
-  GET  /api/v1/users/settings  -> 500  (req_def456)
-  POST /api/v1/orders          -> 500  (req_ghi789)
+[warn] packages/action/tests/mapToTriageConfig.test.ts
+[warn] packages/providers/src/coding-agent/claude-code.ts
+[warn] packages/providers/src/coding-agent/google-gemini.ts
+[warn] packages/providers/src/coding-agent/openai-codex.ts
+[warn] packages/providers/src/source-control/github.ts
+[warn] packages/providers/src/source-control/gitlab.ts
+[error] Code style issues found in 6 files. Run Prettier with --write to fix.
+Process completed with exit code 1.
 ```
 
-## Files to Modify
+Same failure repeated in runs: 23195029818, 23195412282, 23195001538.
 
-- `/src/middleware/auth.ts` — add null guard at line ~42 before `decodedToken.userId` access
+## Fix Applied
+
+Ran `npx prettier --write` on all 6 files. Verified with `npx prettier --check` — all clean.
+
+## Files Modified
+
+| File | Package | Published |
+|------|---------|-----------|
+| `packages/action/tests/mapToTriageConfig.test.ts` | `@sweny-ai/action` | No (private) |
+| `packages/providers/src/coding-agent/claude-code.ts` | `@sweny-ai/providers` | Yes |
+| `packages/providers/src/coding-agent/google-gemini.ts` | `@sweny-ai/providers` | Yes |
+| `packages/providers/src/coding-agent/openai-codex.ts` | `@sweny-ai/providers` | Yes |
+| `packages/providers/src/source-control/github.ts` | `@sweny-ai/providers` | Yes |
+| `packages/providers/src/source-control/gitlab.ts` | `@sweny-ai/providers` | Yes |
+
+## Changeset
+
+`@sweny-ai/providers` patch bump — formatting-only, no behavioral change.
 
 ## Test Plan
 
-- [ ] Send a request with an intentionally malformed JWT — expect 401, not 500
-- [ ] Send a request with no Authorization header — expect 401
-- [ ] Send a request with a valid JWT — expect normal response (auth passes through)
-- [ ] Send a request with an expired JWT — expect 401
-- [ ] Confirm no new TypeErrors appear in error logs after deploy
+- [ ] `npm run format:check` passes
+- [ ] `npm test` passes (no regressions in source-control or coding-agent tests)
 
 ## Rollback Plan
 
-The change is additive (only adds a guard before existing logic). If the guard introduces
-unexpected behavior, revert by removing the `if (!decodedToken)` block. The underlying crash
-will return but without causing regressions in other paths.
+Formatting changes are purely cosmetic. If needed, revert the commit. The only effect of
+reverting is CI fails the format check again.
 
 ## Confidence
 
-High. Stack trace pinpoints the exact line; the fix is a single null guard — minimal blast
-radius, standard defensive pattern, fully reversible.
-
-## Note on Service Map
-
-`.github/service-map.yml` was not found in this repository. The `api-gateway` service
-referenced in the logs could not be matched to a specific repo. TARGET_REPO is set to
-the current repo (`swenyai/sweny`) as a fallback. If `api-gateway` lives in a different
-repository, this issue should be dispatched there once the service map is created.
+High. Direct evidence from CI logs. Mechanical Prettier fix — no logic changes.

--- a/.github/triage-analysis/investigation-log.md
+++ b/.github/triage-analysis/investigation-log.md
@@ -1,87 +1,65 @@
-# Investigation Log — 2026-03-12
+# Investigation Log — 2026-03-17
 
 ## Approach
 
-Default mode (no Issue Tracker issue, no additional instructions). Read local log file at
-`packages/cli/fixtures/sample-errors.json` and investigate top errors by frequency and severity.
+Additional instructions direct improvement of the SWEny codebase itself.
+Primary inputs: CI failure logs at `/tmp/ci-failures.json` + holistic codebase review.
 
-## Step 1 — Read log file
+## Step 1: Read CI Failure Log
 
-```bash
-cat "packages/cli/fixtures/sample-errors.json"
+`/tmp/ci-failures.json` contains 20 entries, all from 2026-03-17.
+
+Workflows failing:
+- **CI on main** (run IDs: 23199468449, 23195029818) — repeated failures
+- **Continuous Improvement on main** (run IDs: 23195412282, 23195001538)
+- **CI on dependabot branches** — multiple dependency update branches
+
+## Step 2: Inspect Most Recent Failure
+
+Fetched logs for run `23199468449` (most recent CI failure on main).
+
+**Failure step**: `Format — Run npm run format:check`
+
+```
+[warn] packages/action/tests/mapToTriageConfig.test.ts
+[warn] packages/providers/src/coding-agent/claude-code.ts
+[warn] packages/providers/src/coding-agent/google-gemini.ts
+[warn] packages/providers/src/coding-agent/openai-codex.ts
+[warn] packages/providers/src/source-control/github.ts
+[warn] packages/providers/src/source-control/gitlab.ts
+[error] Code style issues found in 6 files. Run Prettier with --write to fix.
+Process completed with exit code 1.
 ```
 
-**Result**: JSON array with 8 entries (7 error/warning level) covering 3 services:
-`api-gateway`, `payment-service`, `worker`.
+## Step 3: Root Cause Analysis
 
-## Step 2 — Read service map
+6 files were committed without running Prettier first. The `format:check` step in CI runs
+`prettier --check .` and fails the build when files don't conform to the project's formatting
+rules. These were likely new files added or modified in recent commits without running the
+formatter locally.
 
-```bash
-cat ".github/service-map.yml"
-```
+## Step 4: Fix Applied
 
-**Result**: File not found. Service-to-repo ownership mapping is unavailable.
-TARGET_REPO defaults to current repo (`swenyai/sweny`).
+Ran `npx prettier --write` on all 6 offending files:
+- `packages/action/tests/mapToTriageConfig.test.ts`
+- `packages/providers/src/coding-agent/claude-code.ts`
+- `packages/providers/src/coding-agent/google-gemini.ts`
+- `packages/providers/src/coding-agent/openai-codex.ts`
+- `packages/providers/src/source-control/github.ts`
+- `packages/providers/src/source-control/gitlab.ts`
 
-## Step 3 — Check known issues
+Verified clean with `npx prettier --check` — all files now pass.
 
-Known issue LOCAL-1: _CLI Typecheck and Format Failures After DAG Spec v2 Migration_ (open).
-None of the production errors in the sample log match LOCAL-1 — these are distinct runtime errors
-from different services.
+## Step 5: Known Issues Cross-Check
 
-## Step 4 — Error triage by frequency and severity
+- PR #61 (open): newrelic/sentry config schemas — confirmed already committed (`7bd135a`); PR still open but fix is in main. Not related to this CI failure.
+- PR #44, #32, #34: closed, not re-introduced by this change.
 
-| Rank | Service | Error | Count | Status |
-|------|---------|-------|-------|--------|
-| 1 | `api-gateway` | `TypeError: Cannot read properties of undefined (reading 'userId')` at `auth.ts:42` | 3 | 500 |
-| 2 | `worker` | `ECONNREFUSED 127.0.0.1:5432` — PostgreSQL connection refused | 2 | — |
-| 3 | `payment-service` | Stripe webhook signature verification failed | 1 | 400 |
+## Step 6: Changeset
 
-One additional warning (payment retry 3/5) not classified as an error.
+Files modified are in:
+- `packages/action` (private, not published) — no changeset needed
+- `packages/providers` (published as `@sweny-ai/providers`) — formatting-only = patch
+- `packages/providers/src/source-control/` and `packages/providers/src/coding-agent/` are published
 
-## Step 5 — Root cause analysis: api-gateway auth TypeError
-
-Stack trace (present in 2 of 3 occurrences):
-```
-TypeError: Cannot read properties of undefined (reading 'userId')
-    at AuthMiddleware.verify (/src/middleware/auth.ts:42:28)
-    at processRequest (/src/server.ts:118:5)
-```
-
-Affected endpoints:
-- `GET /api/v1/users/profile` (req_abc123)
-- `GET /api/v1/users/settings` (req_def456)
-- `POST /api/v1/orders` (req_ghi789)
-
-All three are authenticated routes. The middleware accesses `.userId` on a value that is
-`undefined` — the decoded JWT/session object. The guard is missing before the property
-access on line 42 of `auth.ts`.
-
-Canonical fix pattern:
-```typescript
-// Before (line 42 — crashes when decodedToken/session is undefined):
-const userId = decodedToken.userId;
-
-// After:
-if (!decodedToken) throw new UnauthorizedError('Missing or invalid token');
-const userId = decodedToken.userId;
-```
-
-## Step 6 — Root cause analysis: worker PostgreSQL ECONNREFUSED
-
-Two jobs (`job_abc` / `send_notification`, `job_def` / `process_payment`) failed immediately
-(retry_count: 0) with `ECONNREFUSED 127.0.0.1:5432`. This points to a PostgreSQL instance
-that is either down or not reachable at localhost. Likely infrastructure issue rather than
-a code bug — though the worker should be retrying rather than failing immediately.
-
-## Step 7 — Root cause analysis: payment-service Stripe webhook failure
-
-Single occurrence — Stripe signature mismatch on `/webhooks/stripe`. Most commonly caused
-by a rotated webhook secret that was not updated in the service's environment config.
-Low frequency (1 hit), lower priority.
-
-## Conclusion
-
-Best candidate for fixing: `api-gateway` auth middleware null guard at `auth.ts:42`.
-Highest frequency (3 of 8 log entries = 37%), direct user-facing 500 errors on core endpoints,
-clear and minimal code fix with high confidence.
+Created `.changeset/fix-prettier-format-violations.md` (patch).

--- a/.github/triage-analysis/issues-report.md
+++ b/.github/triage-analysis/issues-report.md
@@ -1,152 +1,58 @@
-# Issues Report — 2026-03-12
+# Issues Report — 2026-03-17
 
-## Issue 1: Auth Middleware Null Guard Missing — userId Access on Undefined
+## Issue 1: Prettier Format Violations Block CI on Main
 
-- **Severity**: Critical
-- **Environment**: Production
-- **Frequency**: 3 occurrences in 24h window — all user-facing endpoints returning 500
-
-### Description
-
-`AuthMiddleware.verify` at `/src/middleware/auth.ts:42` reads `.userId` from an object
-(decoded JWT or session) without first checking whether it is defined. When the object is
-`undefined` (e.g., malformed token, expired session, missing Authorization header edge case),
-the middleware throws an unhandled TypeError that propagates as a 500 to the client.
-
-### Evidence
-
-```
-TypeError: Cannot read properties of undefined (reading 'userId')
-    at AuthMiddleware.verify (/src/middleware/auth.ts:42:28)
-    at processRequest (/src/server.ts:118:5)
-```
-
-- `GET /api/v1/users/profile` → 500 (req_abc123)
-- `GET /api/v1/users/settings` → 500 (req_def456)
-- `POST /api/v1/orders` → 500 (req_ghi789)
-
-### Root Cause Analysis
-
-Line 42 of `auth.ts` performs a direct property access (`decodedToken.userId` or similar)
-without guarding against a nullish `decodedToken`. When JWT verification returns `undefined`
-or `null` instead of throwing (e.g., `jwt.verify` with `complete: false` returning null on
-an invalid token in some library versions), the subsequent property access crashes.
-
-### Impact
-
-- All authenticated routes are susceptible: 500s instead of 401/403 for invalid tokens
-- Users with edge-case token states (e.g., transitioning between sessions) get opaque errors
-- No differentiation between "invalid token" (should be 401) and server error (500)
-
-### Suggested Fix
-
-```typescript
-// auth.ts line 42 (approximate, before userId access):
-if (!decodedToken) {
-  throw new UnauthorizedError('Invalid or missing authentication token');
-}
-const userId = decodedToken.userId;
-```
-
-Or, if the function returns early instead of throwing:
-```typescript
-if (!decodedToken || !decodedToken.userId) {
-  return res.status(401).json({ error: 'Unauthorized' });
-}
-```
-
-### Files to Modify
-
-- `/src/middleware/auth.ts` — line ~42, add null guard before `.userId` access
-
-### Confidence Level
-
-High — direct stack trace pinpoints the exact line; the fix pattern is standard defensive programming.
-
-### Issue Tracker Status
-
-No existing Issue Tracker issue found — new issue will be created.
-
----
-
-## Issue 2: Worker — PostgreSQL ECONNREFUSED (Infrastructure)
-
-- **Severity**: High
-- **Environment**: Production
-- **Frequency**: 2 occurrences in 24h window
+- **Severity**: High (CI is broken — no PRs can merge)
+- **Environment**: CI
+- **Frequency**: Recurring — at least 4 CI failures on main on 2026-03-17
 
 ### Description
 
-Two worker jobs failed immediately with `ECONNREFUSED 127.0.0.1:5432` (PostgreSQL).
-Both jobs had `retry_count: 0`, suggesting no retry policy is in place for connection errors.
+6 source files were committed without Prettier formatting, causing `format:check` in CI
+to exit with code 1 and block all merges to main.
 
 ### Evidence
 
+From CI run `23199468449`:
 ```
-Job processing failed: ECONNREFUSED 127.0.0.1:5432 - Connection refused to PostgreSQL
-  job_id: job_abc, job_type: send_notification
-  job_id: job_def, job_type: process_payment
+[warn] packages/action/tests/mapToTriageConfig.test.ts
+[warn] packages/providers/src/coding-agent/claude-code.ts
+[warn] packages/providers/src/coding-agent/google-gemini.ts
+[warn] packages/providers/src/coding-agent/openai-codex.ts
+[warn] packages/providers/src/source-control/github.ts
+[warn] packages/providers/src/source-control/gitlab.ts
+[error] Code style issues found in 6 files. Run Prettier with --write to fix.
+Process completed with exit code 1.
 ```
 
 ### Root Cause Analysis
 
-Primary cause is likely infrastructure (PostgreSQL instance unavailable at localhost).
-Secondary code issue: the worker makes no retry attempt on `ECONNREFUSED` — jobs fail
-immediately. A connection error is typically transient and should trigger retries.
+Files were added/modified in commits without running Prettier locally. The project has no
+pre-commit hook enforcing format, so violations reach CI.
 
 ### Impact
 
-Notifications and payment processing jobs silently dropped.
+- All CI runs on main fail at the Format step
+- The Continuous Improvement workflow also fails (it depends on the CI workflow)
+- Dependabot PRs fail CI too (Prettier check runs on all branches)
 
 ### Suggested Fix
 
-1. (Infrastructure) Ensure PostgreSQL is accessible and healthy.
-2. (Code) Add retry-with-backoff for `ECONNREFUSED` before marking the job failed.
+Run `npx prettier --write` on all 6 offending files. **This fix has been applied.**
+
+### Files Modified
+
+- `packages/action/tests/mapToTriageConfig.test.ts`
+- `packages/providers/src/coding-agent/claude-code.ts`
+- `packages/providers/src/coding-agent/google-gemini.ts`
+- `packages/providers/src/coding-agent/openai-codex.ts`
+- `packages/providers/src/source-control/github.ts`
+- `packages/providers/src/source-control/gitlab.ts`
 
 ### Confidence Level
 
-Medium for infrastructure cause, high for the missing retry policy.
+High — direct CI log evidence, mechanical fix, verified clean after applying.
 
-### Issue Tracker Status
+### GitHub Issues Status
 
-No existing Issue Tracker issue found.
-
----
-
-## Issue 3: Payment Service — Stripe Webhook Signature Mismatch
-
-- **Severity**: Medium
-- **Environment**: Production
-- **Frequency**: 1 occurrence in 24h window
-
-### Description
-
-Stripe webhook signature verification failed for event `evt_1234567890` on `/webhooks/stripe`.
-
-### Evidence
-
-```
-Stripe webhook signature verification failed: No signatures found matching the expected signature
-  webhook_id: evt_1234567890, status_code: 400
-```
-
-### Root Cause Analysis
-
-Most likely cause: webhook signing secret was rotated in the Stripe dashboard but the
-environment variable `STRIPE_WEBHOOK_SECRET` in the payment service was not updated.
-
-### Impact
-
-Stripe events (payment confirmations, refunds, disputes) are not being processed.
-
-### Suggested Fix
-
-Rotate / resync `STRIPE_WEBHOOK_SECRET` env var to match the current secret in Stripe dashboard.
-
-### Confidence Level
-
-Medium — single occurrence, may be a one-time replay or key rotation event.
-
-### Issue Tracker Status
-
-No existing Issue Tracker issue found.
+No existing GitHub Issues issue found — new issue will be created.

--- a/packages/action/tests/mapToTriageConfig.test.ts
+++ b/packages/action/tests/mapToTriageConfig.test.ts
@@ -391,9 +391,7 @@ describe("mapToTriageConfig — buildAutoMcpServers", () => {
       githubToken: "",
     };
     const { mcpServers } = mapToTriageConfig(config) as { mcpServers: Record<string, unknown> };
-    expect((mcpServers?.["newrelic"] as Record<string, unknown>)?.["url"]).toBe(
-      "https://mcp.eu.newrelic.com/mcp/",
-    );
+    expect((mcpServers?.["newrelic"] as Record<string, unknown>)?.["url"]).toBe("https://mcp.eu.newrelic.com/mcp/");
   });
 
   it("does not inject Sentry MCP when authToken is absent", () => {
@@ -443,7 +441,13 @@ describe("mapToTriageConfig — buildAutoMcpServers", () => {
 
   it("does not inject Slack MCP when tool is declared but token is absent", () => {
     delete process.env.SLACK_BOT_TOKEN;
-    const { mcpServers } = mapToTriageConfig({ ...BASE, githubToken: "", botToken: "", mcpServers: {}, workspaceTools: ["slack"] }) as {
+    const { mcpServers } = mapToTriageConfig({
+      ...BASE,
+      githubToken: "",
+      botToken: "",
+      mcpServers: {},
+      workspaceTools: ["slack"],
+    }) as {
       mcpServers: Record<string, unknown> | undefined;
     };
     expect(mcpServers?.["slack"]).toBeUndefined();
@@ -453,7 +457,13 @@ describe("mapToTriageConfig — buildAutoMcpServers", () => {
     process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
     try {
       // workspaceTools is empty — no slack declared
-      const { mcpServers } = mapToTriageConfig({ ...BASE, githubToken: "", botToken: "", mcpServers: {}, workspaceTools: [] }) as {
+      const { mcpServers } = mapToTriageConfig({
+        ...BASE,
+        githubToken: "",
+        botToken: "",
+        mcpServers: {},
+        workspaceTools: [],
+      }) as {
         mcpServers: Record<string, unknown> | undefined;
       };
       expect(mcpServers?.["slack"]).toBeUndefined();
@@ -497,7 +507,13 @@ describe("mapToTriageConfig — buildAutoMcpServers", () => {
   it("does not inject Notion MCP when tool not declared (even if token present)", () => {
     process.env.NOTION_TOKEN = "secret_notion_key";
     try {
-      const { mcpServers } = mapToTriageConfig({ ...BASE, githubToken: "", botToken: "", mcpServers: {}, workspaceTools: [] }) as {
+      const { mcpServers } = mapToTriageConfig({
+        ...BASE,
+        githubToken: "",
+        botToken: "",
+        mcpServers: {},
+        workspaceTools: [],
+      }) as {
         mcpServers: Record<string, unknown> | undefined;
       };
       expect(mcpServers?.["notion"]).toBeUndefined();
@@ -509,7 +525,13 @@ describe("mapToTriageConfig — buildAutoMcpServers", () => {
   it("does not inject Notion MCP when tool is declared but neither token is set", () => {
     delete process.env.NOTION_TOKEN;
     delete process.env.NOTION_API_KEY;
-    const { mcpServers } = mapToTriageConfig({ ...BASE, githubToken: "", botToken: "", mcpServers: {}, workspaceTools: ["notion"] }) as {
+    const { mcpServers } = mapToTriageConfig({
+      ...BASE,
+      githubToken: "",
+      botToken: "",
+      mcpServers: {},
+      workspaceTools: ["notion"],
+    }) as {
       mcpServers: Record<string, unknown> | undefined;
     };
     expect(mcpServers?.["notion"]).toBeUndefined();

--- a/packages/providers/src/coding-agent/claude-code.ts
+++ b/packages/providers/src/coding-agent/claude-code.ts
@@ -118,71 +118,74 @@ export function claudeCode(config?: ClaudeCodeConfig): CodingAgent & { configSch
   const quiet = config?.quiet ?? false;
   const onEvent = config?.onEvent;
 
-  return Object.assign({
-    async install(): Promise<void> {
-      if (isCliInstalled("claude")) {
-        log.info("Claude Code CLI already installed, skipping");
-        return;
-      }
-      log.info("Installing Claude Code CLI...");
-      await execCommand("npm", ["install", "-g", "@anthropic-ai/claude-code"], { quiet });
-      log.info("Claude Code CLI installed");
-    },
+  return Object.assign(
+    {
+      async install(): Promise<void> {
+        if (isCliInstalled("claude")) {
+          log.info("Claude Code CLI already installed, skipping");
+          return;
+        }
+        log.info("Installing Claude Code CLI...");
+        await execCommand("npm", ["install", "-g", "@anthropic-ai/claude-code"], { quiet });
+        log.info("Claude Code CLI installed");
+      },
 
-    async run(opts: CodingAgentRunOptions): Promise<number> {
-      log.info("Running Claude Code agent...");
+      async run(opts: CodingAgentRunOptions): Promise<number> {
+        log.info("Running Claude Code agent...");
 
-      const args = [
-        "-p",
-        opts.prompt,
-        "--allowedTools",
-        "*",
-        "--dangerously-skip-permissions",
-        "--max-turns",
-        String(opts.maxTurns),
-        ...extraFlags,
-      ];
+        const args = [
+          "-p",
+          opts.prompt,
+          "--allowedTools",
+          "*",
+          "--dangerously-skip-permissions",
+          "--max-turns",
+          String(opts.maxTurns),
+          ...extraFlags,
+        ];
 
-      const mcpServers = opts.mcpServers;
-      const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
+        const mcpServers = opts.mcpServers;
+        const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
 
-      if (mcpConfig && mcpServers) {
-        args.push("--mcp-config", mcpConfig.path);
-        log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
-      }
-
-      try {
-        if (onEvent) {
-          // --output-format stream-json requires --verbose; omitting it causes
-          // the CLI to exit with "stream-json requires --verbose" error.
-          args.push("--output-format", "stream-json", "--verbose");
-          const parse = makeClaudeEventParser();
-          return await spawnLines("claude", args, {
-            env: opts.env,
-            timeoutMs: opts.timeoutMs,
-            logger: log,
-            onLine(line) {
-              try {
-                const evt = JSON.parse(line);
-                const mapped = parse(evt);
-                if (mapped) return onEvent(mapped);
-              } catch {
-                /* skip malformed JSON lines */
-              }
-            },
-          });
+        if (mcpConfig && mcpServers) {
+          args.push("--mcp-config", mcpConfig.path);
+          log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
         }
 
-        return await execCommand("claude", args, {
-          env: { ...process.env, ...opts.env } as Record<string, string>,
-          ignoreReturnCode: true,
-          quiet,
-          timeoutMs: opts.timeoutMs,
-          onStderr: quiet ? (line) => log.debug(line) : undefined,
-        });
-      } finally {
-        mcpConfig?.cleanup();
-      }
+        try {
+          if (onEvent) {
+            // --output-format stream-json requires --verbose; omitting it causes
+            // the CLI to exit with "stream-json requires --verbose" error.
+            args.push("--output-format", "stream-json", "--verbose");
+            const parse = makeClaudeEventParser();
+            return await spawnLines("claude", args, {
+              env: opts.env,
+              timeoutMs: opts.timeoutMs,
+              logger: log,
+              onLine(line) {
+                try {
+                  const evt = JSON.parse(line);
+                  const mapped = parse(evt);
+                  if (mapped) return onEvent(mapped);
+                } catch {
+                  /* skip malformed JSON lines */
+                }
+              },
+            });
+          }
+
+          return await execCommand("claude", args, {
+            env: { ...process.env, ...opts.env } as Record<string, string>,
+            ignoreReturnCode: true,
+            quiet,
+            timeoutMs: opts.timeoutMs,
+            onStderr: quiet ? (line) => log.debug(line) : undefined,
+          });
+        } finally {
+          mcpConfig?.cleanup();
+        }
+      },
     },
-  }, { configSchema: claudeCodeProviderConfigSchema });
+    { configSchema: claudeCodeProviderConfigSchema },
+  );
 }

--- a/packages/providers/src/coding-agent/google-gemini.ts
+++ b/packages/providers/src/coding-agent/google-gemini.ts
@@ -28,51 +28,54 @@ export function googleGemini(config?: GoogleGeminiConfig): CodingAgent & { confi
   const quiet = config?.quiet ?? false;
   const onEvent = config?.onEvent;
 
-  return Object.assign({
-    async install(): Promise<void> {
-      if (isCliInstalled("gemini")) {
-        log.info("Google Gemini CLI already installed, skipping");
-        return;
-      }
-      log.info("Installing Google Gemini CLI...");
-      await execCommand("npm", ["install", "-g", "@google/gemini-cli"], { quiet });
-      log.info("Google Gemini CLI installed");
-    },
+  return Object.assign(
+    {
+      async install(): Promise<void> {
+        if (isCliInstalled("gemini")) {
+          log.info("Google Gemini CLI already installed, skipping");
+          return;
+        }
+        log.info("Installing Google Gemini CLI...");
+        await execCommand("npm", ["install", "-g", "@google/gemini-cli"], { quiet });
+        log.info("Google Gemini CLI installed");
+      },
 
-    async run(opts: CodingAgentRunOptions): Promise<number> {
-      log.info("Running Google Gemini agent...");
+      async run(opts: CodingAgentRunOptions): Promise<number> {
+        log.info("Running Google Gemini agent...");
 
-      // Gemini CLI uses --mcp-config <path> with the same JSON format as Claude Code.
-      const args = ["-y", "-p", opts.prompt, ...extraFlags];
+        // Gemini CLI uses --mcp-config <path> with the same JSON format as Claude Code.
+        const args = ["-y", "-p", opts.prompt, ...extraFlags];
 
-      const mcpServers = opts.mcpServers;
-      const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
+        const mcpServers = opts.mcpServers;
+        const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
 
-      if (mcpConfig && mcpServers) {
-        args.push("--mcp-config", mcpConfig.path);
-        log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
-      }
-
-      try {
-        if (onEvent) {
-          return await spawnLines("gemini", args, {
-            env: opts.env,
-            timeoutMs: opts.timeoutMs,
-            logger: log,
-            onLine: (line) => onEvent({ type: "text", text: line }),
-          });
+        if (mcpConfig && mcpServers) {
+          args.push("--mcp-config", mcpConfig.path);
+          log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
         }
 
-        return await execCommand("gemini", args, {
-          env: { ...process.env, ...opts.env } as Record<string, string>,
-          ignoreReturnCode: true,
-          quiet,
-          timeoutMs: opts.timeoutMs,
-          onStderr: quiet ? (line) => log.debug(line) : undefined,
-        });
-      } finally {
-        mcpConfig?.cleanup();
-      }
+        try {
+          if (onEvent) {
+            return await spawnLines("gemini", args, {
+              env: opts.env,
+              timeoutMs: opts.timeoutMs,
+              logger: log,
+              onLine: (line) => onEvent({ type: "text", text: line }),
+            });
+          }
+
+          return await execCommand("gemini", args, {
+            env: { ...process.env, ...opts.env } as Record<string, string>,
+            ignoreReturnCode: true,
+            quiet,
+            timeoutMs: opts.timeoutMs,
+            onStderr: quiet ? (line) => log.debug(line) : undefined,
+          });
+        } finally {
+          mcpConfig?.cleanup();
+        }
+      },
     },
-  }, { configSchema: googleGeminiProviderConfigSchema });
+    { configSchema: googleGeminiProviderConfigSchema },
+  );
 }

--- a/packages/providers/src/coding-agent/openai-codex.ts
+++ b/packages/providers/src/coding-agent/openai-codex.ts
@@ -28,51 +28,54 @@ export function openaiCodex(config?: OpenAICodexConfig): CodingAgent & { configS
   const quiet = config?.quiet ?? false;
   const onEvent = config?.onEvent;
 
-  return Object.assign({
-    async install(): Promise<void> {
-      if (isCliInstalled("codex")) {
-        log.info("OpenAI Codex CLI already installed, skipping");
-        return;
-      }
-      log.info("Installing OpenAI Codex CLI...");
-      await execCommand("npm", ["install", "-g", "@openai/codex"], { quiet });
-      log.info("OpenAI Codex CLI installed");
-    },
+  return Object.assign(
+    {
+      async install(): Promise<void> {
+        if (isCliInstalled("codex")) {
+          log.info("OpenAI Codex CLI already installed, skipping");
+          return;
+        }
+        log.info("Installing OpenAI Codex CLI...");
+        await execCommand("npm", ["install", "-g", "@openai/codex"], { quiet });
+        log.info("OpenAI Codex CLI installed");
+      },
 
-    async run(opts: CodingAgentRunOptions): Promise<number> {
-      log.info("Running OpenAI Codex agent...");
+      async run(opts: CodingAgentRunOptions): Promise<number> {
+        log.info("Running OpenAI Codex agent...");
 
-      // Codex CLI uses --mcp-config <path> with the same JSON format as Claude Code.
-      const args = ["exec", "--full-auto", opts.prompt, ...extraFlags];
+        // Codex CLI uses --mcp-config <path> with the same JSON format as Claude Code.
+        const args = ["exec", "--full-auto", opts.prompt, ...extraFlags];
 
-      const mcpServers = opts.mcpServers;
-      const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
+        const mcpServers = opts.mcpServers;
+        const mcpConfig = mcpServers && Object.keys(mcpServers).length > 0 ? writeMcpConfig(mcpServers) : null;
 
-      if (mcpConfig && mcpServers) {
-        args.push("--mcp-config", mcpConfig.path);
-        log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
-      }
-
-      try {
-        if (onEvent) {
-          return await spawnLines("codex", args, {
-            env: opts.env,
-            timeoutMs: opts.timeoutMs,
-            logger: log,
-            onLine: (line) => onEvent({ type: "text", text: line }),
-          });
+        if (mcpConfig && mcpServers) {
+          args.push("--mcp-config", mcpConfig.path);
+          log.info(`Injecting ${Object.keys(mcpServers).length} MCP server(s): ${Object.keys(mcpServers).join(", ")}`);
         }
 
-        return await execCommand("codex", args, {
-          env: { ...process.env, ...opts.env } as Record<string, string>,
-          ignoreReturnCode: true,
-          quiet,
-          timeoutMs: opts.timeoutMs,
-          onStderr: quiet ? (line) => log.debug(line) : undefined,
-        });
-      } finally {
-        mcpConfig?.cleanup();
-      }
+        try {
+          if (onEvent) {
+            return await spawnLines("codex", args, {
+              env: opts.env,
+              timeoutMs: opts.timeoutMs,
+              logger: log,
+              onLine: (line) => onEvent({ type: "text", text: line }),
+            });
+          }
+
+          return await execCommand("codex", args, {
+            env: { ...process.env, ...opts.env } as Record<string, string>,
+            ignoreReturnCode: true,
+            quiet,
+            timeoutMs: opts.timeoutMs,
+            onStderr: quiet ? (line) => log.debug(line) : undefined,
+          });
+        } finally {
+          mcpConfig?.cleanup();
+        }
+      },
     },
-  }, { configSchema: openaiCodexProviderConfigSchema });
+    { configSchema: openaiCodexProviderConfigSchema },
+  );
 }

--- a/packages/providers/src/source-control/github.ts
+++ b/packages/providers/src/source-control/github.ts
@@ -56,200 +56,211 @@ export const githubProviderConfigSchema: ProviderConfigSchema = {
   fields: [{ key: "token", envVar: "GITHUB_TOKEN", description: "GitHub personal access token" }],
 };
 
-export function github(config: GitHubSourceControlConfig): SourceControlProvider & { configSchema: ProviderConfigSchema } {
+export function github(
+  config: GitHubSourceControlConfig,
+): SourceControlProvider & { configSchema: ProviderConfigSchema } {
   const { token, owner, repo, baseBranch = "main" } = config;
   const log = config.logger ?? consoleLogger;
 
-  return Object.assign({
-    async verifyAccess(): Promise<void> {
-      await ghApi("GET", `/repos/${owner}/${repo}`, token);
-      log.info(`Verified access to ${owner}/${repo}`);
-    },
+  return Object.assign(
+    {
+      async verifyAccess(): Promise<void> {
+        await ghApi("GET", `/repos/${owner}/${repo}`, token);
+        log.info(`Verified access to ${owner}/${repo}`);
+      },
 
-    async configureBotIdentity(): Promise<void> {
-      await git(["config", "user.name", "github-actions[bot]"]);
-      await git(["config", "user.email", "github-actions[bot]@users.noreply.github.com"]);
-      log.debug("Configured git bot identity");
-    },
+      async configureBotIdentity(): Promise<void> {
+        await git(["config", "user.name", "github-actions[bot]"]);
+        await git(["config", "user.email", "github-actions[bot]@users.noreply.github.com"]);
+        log.debug("Configured git bot identity");
+      },
 
-    async createBranch(name: string): Promise<void> {
-      await git(["checkout", "-b", name]);
-      log.info(`Created branch: ${name}`);
-    },
+      async createBranch(name: string): Promise<void> {
+        await git(["checkout", "-b", name]);
+        log.info(`Created branch: ${name}`);
+      },
 
-    async pushBranch(name: string): Promise<void> {
-      await git(["remote", "set-url", "origin", `https://x-access-token:${token}@github.com/${owner}/${repo}.git`]);
-      await git(["push", "origin", name]);
-      log.info(`Pushed branch: ${name}`);
-    },
+      async pushBranch(name: string): Promise<void> {
+        await git(["remote", "set-url", "origin", `https://x-access-token:${token}@github.com/${owner}/${repo}.git`]);
+        await git(["push", "origin", name]);
+        log.info(`Pushed branch: ${name}`);
+      },
 
-    async hasChanges(): Promise<boolean> {
-      const unstaged = await git(["diff", "--name-only", "--", ".", ":!.github/workflows"], { ignoreReturnCode: true });
-      const staged = await git(["diff", "--cached", "--name-only", "--", ".", ":!.github/workflows"], {
-        ignoreReturnCode: true,
-      });
-      return unstaged.trim().length > 0 || staged.trim().length > 0;
-    },
-
-    async hasNewCommits(): Promise<boolean> {
-      const output = await git(["rev-list", "--count", `HEAD`, `^origin/${baseBranch}`], { ignoreReturnCode: true });
-      const count = parseInt(output.trim(), 10);
-      return !isNaN(count) && count > 0;
-    },
-
-    async getChangedFiles(): Promise<string[]> {
-      const output = await git(["diff", "--name-only", `origin/${baseBranch}..HEAD`], { ignoreReturnCode: true });
-      return output.trim().split("\n").filter(Boolean);
-    },
-
-    async resetPaths(paths: string[]): Promise<void> {
-      for (const p of paths) {
-        await git(["checkout", "HEAD", "--", p], { ignoreReturnCode: true });
-      }
-      log.debug(`Reset paths: ${paths.join(", ")}`);
-    },
-
-    async stageAndCommit(message: string): Promise<void> {
-      await git(["add", "-A", "--", ".", ":!.github/workflows"]);
-      await git(["commit", "-m", message]);
-    },
-
-    async createPullRequest(opts: PrCreateOptions): Promise<PullRequest> {
-      const body: Record<string, unknown> = {
-        title: opts.title,
-        head: opts.head,
-        base: opts.base || baseBranch,
-        body: opts.body,
-      };
-
-      const pr = (await ghApi("POST", `/repos/${owner}/${repo}/pulls`, token, body)) as {
-        number: number;
-        html_url: string;
-        state: string;
-      };
-      log.info(`Created PR #${pr.number}: ${pr.html_url}`);
-
-      if (opts.labels && opts.labels.length > 0) {
-        await ghApi("POST", `/repos/${owner}/${repo}/issues/${pr.number}/labels`, token, { labels: opts.labels });
-      }
-
-      return { number: pr.number, url: pr.html_url, state: "open", title: opts.title };
-    },
-
-    async listPullRequests(opts?: PrListOptions): Promise<PullRequest[]> {
-      const state = opts?.state ?? "open";
-      const limit = opts?.limit ?? 30;
-      const params = new URLSearchParams({
-        state: state === "merged" ? "closed" : state,
-        per_page: String(limit),
-        sort: "updated",
-        direction: "desc",
-      });
-
-      const prs = (await ghApi("GET", `/repos/${owner}/${repo}/pulls?${params}`, token)) as {
-        number: number;
-        html_url: string;
-        title: string;
-        state: string;
-        merged_at: string | null;
-        closed_at: string | null;
-        labels: { name: string }[];
-      }[];
-
-      const labelFilter = opts?.labels?.length ? new Set(opts.labels.map((l) => l.toLowerCase())) : null;
-
-      const results: PullRequest[] = [];
-      for (const pr of prs) {
-        // Determine normalized state
-        const prState: PullRequest["state"] = pr.merged_at ? "merged" : pr.state === "open" ? "open" : "closed";
-
-        // Filter by requested state (handle "merged" vs "closed")
-        if (state === "merged" && !pr.merged_at) continue;
-
-        // Filter by labels
-        if (labelFilter) {
-          const prLabels = pr.labels.map((l) => l.name.toLowerCase());
-          if (!prLabels.some((l) => labelFilter.has(l))) continue;
-        }
-
-        results.push({
-          number: pr.number,
-          url: pr.html_url,
-          state: prState,
-          title: pr.title,
-          mergedAt: pr.merged_at,
-          closedAt: pr.closed_at,
+      async hasChanges(): Promise<boolean> {
+        const unstaged = await git(["diff", "--name-only", "--", ".", ":!.github/workflows"], {
+          ignoreReturnCode: true,
         });
-      }
+        const staged = await git(["diff", "--cached", "--name-only", "--", ".", ":!.github/workflows"], {
+          ignoreReturnCode: true,
+        });
+        return unstaged.trim().length > 0 || staged.trim().length > 0;
+      },
 
-      return results;
-    },
+      async hasNewCommits(): Promise<boolean> {
+        const output = await git(["rev-list", "--count", `HEAD`, `^origin/${baseBranch}`], { ignoreReturnCode: true });
+        const count = parseInt(output.trim(), 10);
+        return !isNaN(count) && count > 0;
+      },
 
-    async findExistingPr(searchTerm: string): Promise<PullRequest | null> {
-      if (!searchTerm) return null;
-      // Search open PRs
-      const openPrs = (await ghApi("GET", `/repos/${owner}/${repo}/pulls?state=open&per_page=20`, token)) as {
-        number: number;
-        html_url: string;
-        title: string;
-        body: string | null;
-      }[];
+      async getChangedFiles(): Promise<string[]> {
+        const output = await git(["diff", "--name-only", `origin/${baseBranch}..HEAD`], { ignoreReturnCode: true });
+        return output.trim().split("\n").filter(Boolean);
+      },
 
-      for (const pr of openPrs) {
-        const text = `${pr.title} ${pr.body || ""}`;
-        if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
-          log.info(`Found open PR with match: ${pr.html_url}`);
-          return { number: pr.number, url: pr.html_url, state: "open", title: pr.title };
+      async resetPaths(paths: string[]): Promise<void> {
+        for (const p of paths) {
+          await git(["checkout", "HEAD", "--", p], { ignoreReturnCode: true });
         }
-      }
+        log.debug(`Reset paths: ${paths.join(", ")}`);
+      },
 
-      // Search recently merged PRs (last 30 days)
-      const closedPrs = (await ghApi(
-        "GET",
-        `/repos/${owner}/${repo}/pulls?state=closed&per_page=20&sort=updated&direction=desc`,
-        token,
-      )) as {
-        number: number;
-        html_url: string;
-        title: string;
-        body: string | null;
-        merged_at: string | null;
-      }[];
+      async stageAndCommit(message: string): Promise<void> {
+        await git(["add", "-A", "--", ".", ":!.github/workflows"]);
+        await git(["commit", "-m", message]);
+      },
 
-      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-      for (const pr of closedPrs) {
-        if (pr.merged_at && new Date(pr.merged_at) > cutoff) {
+      async createPullRequest(opts: PrCreateOptions): Promise<PullRequest> {
+        const body: Record<string, unknown> = {
+          title: opts.title,
+          head: opts.head,
+          base: opts.base || baseBranch,
+          body: opts.body,
+        };
+
+        const pr = (await ghApi("POST", `/repos/${owner}/${repo}/pulls`, token, body)) as {
+          number: number;
+          html_url: string;
+          state: string;
+        };
+        log.info(`Created PR #${pr.number}: ${pr.html_url}`);
+
+        if (opts.labels && opts.labels.length > 0) {
+          await ghApi("POST", `/repos/${owner}/${repo}/issues/${pr.number}/labels`, token, { labels: opts.labels });
+        }
+
+        return { number: pr.number, url: pr.html_url, state: "open", title: opts.title };
+      },
+
+      async listPullRequests(opts?: PrListOptions): Promise<PullRequest[]> {
+        const state = opts?.state ?? "open";
+        const limit = opts?.limit ?? 30;
+        const params = new URLSearchParams({
+          state: state === "merged" ? "closed" : state,
+          per_page: String(limit),
+          sort: "updated",
+          direction: "desc",
+        });
+
+        const prs = (await ghApi("GET", `/repos/${owner}/${repo}/pulls?${params}`, token)) as {
+          number: number;
+          html_url: string;
+          title: string;
+          state: string;
+          merged_at: string | null;
+          closed_at: string | null;
+          labels: { name: string }[];
+        }[];
+
+        const labelFilter = opts?.labels?.length ? new Set(opts.labels.map((l) => l.toLowerCase())) : null;
+
+        const results: PullRequest[] = [];
+        for (const pr of prs) {
+          // Determine normalized state
+          const prState: PullRequest["state"] = pr.merged_at ? "merged" : pr.state === "open" ? "open" : "closed";
+
+          // Filter by requested state (handle "merged" vs "closed")
+          if (state === "merged" && !pr.merged_at) continue;
+
+          // Filter by labels
+          if (labelFilter) {
+            const prLabels = pr.labels.map((l) => l.name.toLowerCase());
+            if (!prLabels.some((l) => labelFilter.has(l))) continue;
+          }
+
+          results.push({
+            number: pr.number,
+            url: pr.html_url,
+            state: prState,
+            title: pr.title,
+            mergedAt: pr.merged_at,
+            closedAt: pr.closed_at,
+          });
+        }
+
+        return results;
+      },
+
+      async findExistingPr(searchTerm: string): Promise<PullRequest | null> {
+        if (!searchTerm) return null;
+        // Search open PRs
+        const openPrs = (await ghApi("GET", `/repos/${owner}/${repo}/pulls?state=open&per_page=20`, token)) as {
+          number: number;
+          html_url: string;
+          title: string;
+          body: string | null;
+        }[];
+
+        for (const pr of openPrs) {
           const text = `${pr.title} ${pr.body || ""}`;
           if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
-            log.info(`Found merged PR with match: ${pr.html_url}`);
-            return { number: pr.number, url: pr.html_url, state: "merged", title: pr.title };
+            log.info(`Found open PR with match: ${pr.html_url}`);
+            return { number: pr.number, url: pr.html_url, state: "open", title: pr.title };
           }
         }
-      }
 
-      return null;
+        // Search recently merged PRs (last 30 days)
+        const closedPrs = (await ghApi(
+          "GET",
+          `/repos/${owner}/${repo}/pulls?state=closed&per_page=20&sort=updated&direction=desc`,
+          token,
+        )) as {
+          number: number;
+          html_url: string;
+          title: string;
+          body: string | null;
+          merged_at: string | null;
+        }[];
+
+        const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+        for (const pr of closedPrs) {
+          if (pr.merged_at && new Date(pr.merged_at) > cutoff) {
+            const text = `${pr.title} ${pr.body || ""}`;
+            if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
+              log.info(`Found merged PR with match: ${pr.html_url}`);
+              return { number: pr.number, url: pr.html_url, state: "merged", title: pr.title };
+            }
+          }
+        }
+
+        return null;
+      },
+
+      async dispatchWorkflow(opts: DispatchWorkflowOptions): Promise<void> {
+        const targetParts = opts.targetRepo.split("/");
+        const targetOwner = targetParts[0] ?? owner;
+        const targetRepoName = targetParts[1] ?? opts.targetRepo;
+
+        await ghApi(
+          "POST",
+          `/repos/${targetOwner}/${targetRepoName}/actions/workflows/${encodeURIComponent(opts.workflow)}/dispatches`,
+          token,
+          { ref: baseBranch, inputs: opts.inputs ?? {} },
+        );
+        log.info(`Dispatched workflow "${opts.workflow}" to ${opts.targetRepo}`);
+      },
+
+      async enableAutoMerge(prNumber: number): Promise<void> {
+        // Requires "Allow auto-merge" enabled in repo settings and branch protection with status checks.
+        await execFileAsync(
+          "gh",
+          ["pr", "merge", String(prNumber), "--auto", "--squash", "--repo", `${owner}/${repo}`],
+          {
+            env: { ...process.env, GH_TOKEN: token },
+          },
+        );
+        log.info(`Auto-merge enabled on PR #${prNumber}`);
+      },
     },
-
-    async dispatchWorkflow(opts: DispatchWorkflowOptions): Promise<void> {
-      const targetParts = opts.targetRepo.split("/");
-      const targetOwner = targetParts[0] ?? owner;
-      const targetRepoName = targetParts[1] ?? opts.targetRepo;
-
-      await ghApi(
-        "POST",
-        `/repos/${targetOwner}/${targetRepoName}/actions/workflows/${encodeURIComponent(opts.workflow)}/dispatches`,
-        token,
-        { ref: baseBranch, inputs: opts.inputs ?? {} },
-      );
-      log.info(`Dispatched workflow "${opts.workflow}" to ${opts.targetRepo}`);
-    },
-
-    async enableAutoMerge(prNumber: number): Promise<void> {
-      // Requires "Allow auto-merge" enabled in repo settings and branch protection with status checks.
-      await execFileAsync("gh", ["pr", "merge", String(prNumber), "--auto", "--squash", "--repo", `${owner}/${repo}`], {
-        env: { ...process.env, GH_TOKEN: token },
-      });
-      log.info(`Auto-merge enabled on PR #${prNumber}`);
-    },
-  }, { configSchema: githubProviderConfigSchema });
+    { configSchema: githubProviderConfigSchema },
+  );
 }

--- a/packages/providers/src/source-control/gitlab.ts
+++ b/packages/providers/src/source-control/gitlab.ts
@@ -85,7 +85,9 @@ export const gitlabProviderConfigSchema: ProviderConfigSchema = {
   fields: [{ key: "token", envVar: "GITLAB_TOKEN", description: "GitLab personal access token" }],
 };
 
-export function gitlab(config: GitLabSourceControlConfig): SourceControlProvider & { configSchema: ProviderConfigSchema } {
+export function gitlab(
+  config: GitLabSourceControlConfig,
+): SourceControlProvider & { configSchema: ProviderConfigSchema } {
   const parsed = gitlabConfigSchema.parse(config);
   const { token, baseBranch } = parsed;
   const baseUrl = parsed.baseUrl.replace(/\/+$/, "");
@@ -93,226 +95,229 @@ export function gitlab(config: GitLabSourceControlConfig): SourceControlProvider
     typeof parsed.projectId === "number" ? String(parsed.projectId) : encodeURIComponent(parsed.projectId);
   const log = parsed.logger ?? consoleLogger;
 
-  return Object.assign({
-    async verifyAccess(): Promise<void> {
-      const project = (await glApi("GET", `/projects/${projectId}`, baseUrl, token)) as {
-        path_with_namespace: string;
-      };
-      log.info(`Verified access to ${project.path_with_namespace}`);
-    },
+  return Object.assign(
+    {
+      async verifyAccess(): Promise<void> {
+        const project = (await glApi("GET", `/projects/${projectId}`, baseUrl, token)) as {
+          path_with_namespace: string;
+        };
+        log.info(`Verified access to ${project.path_with_namespace}`);
+      },
 
-    async configureBotIdentity(): Promise<void> {
-      await git(["config", "user.name", "gitlab-bot"]);
-      await git(["config", "user.email", "gitlab-bot@noreply.gitlab.com"]);
-      log.debug("Configured git bot identity");
-    },
+      async configureBotIdentity(): Promise<void> {
+        await git(["config", "user.name", "gitlab-bot"]);
+        await git(["config", "user.email", "gitlab-bot@noreply.gitlab.com"]);
+        log.debug("Configured git bot identity");
+      },
 
-    async createBranch(name: string): Promise<void> {
-      await git(["checkout", "-b", name]);
-      log.info(`Created branch: ${name}`);
-    },
+      async createBranch(name: string): Promise<void> {
+        await git(["checkout", "-b", name]);
+        log.info(`Created branch: ${name}`);
+      },
 
-    async pushBranch(name: string): Promise<void> {
-      // Retrieve the project path for constructing the remote URL
-      const project = (await glApi("GET", `/projects/${projectId}`, baseUrl, token)) as {
-        path_with_namespace: string;
-      };
-      const host = new URL(baseUrl).host;
-      const remoteUrl = `https://gitlab-ci-token@${host}/${project.path_with_namespace}.git`;
-      await git(["remote", "set-url", "origin", remoteUrl]);
-      // Push using http.extraheader to provide the token without exposing it in the URL
-      await execFileAsync("git", ["-c", `http.extraheader=PRIVATE-TOKEN: ${token}`, "push", "origin", name]);
-      log.info(`Pushed branch: ${name}`);
-    },
+      async pushBranch(name: string): Promise<void> {
+        // Retrieve the project path for constructing the remote URL
+        const project = (await glApi("GET", `/projects/${projectId}`, baseUrl, token)) as {
+          path_with_namespace: string;
+        };
+        const host = new URL(baseUrl).host;
+        const remoteUrl = `https://gitlab-ci-token@${host}/${project.path_with_namespace}.git`;
+        await git(["remote", "set-url", "origin", remoteUrl]);
+        // Push using http.extraheader to provide the token without exposing it in the URL
+        await execFileAsync("git", ["-c", `http.extraheader=PRIVATE-TOKEN: ${token}`, "push", "origin", name]);
+        log.info(`Pushed branch: ${name}`);
+      },
 
-    async hasChanges(): Promise<boolean> {
-      const unstaged = await git(["diff", "--name-only"], { ignoreReturnCode: true });
-      const staged = await git(["diff", "--cached", "--name-only"], { ignoreReturnCode: true });
-      return unstaged.trim().length > 0 || staged.trim().length > 0;
-    },
+      async hasChanges(): Promise<boolean> {
+        const unstaged = await git(["diff", "--name-only"], { ignoreReturnCode: true });
+        const staged = await git(["diff", "--cached", "--name-only"], { ignoreReturnCode: true });
+        return unstaged.trim().length > 0 || staged.trim().length > 0;
+      },
 
-    async hasNewCommits(): Promise<boolean> {
-      const output = await git(["rev-list", "--count", "HEAD", `^origin/${baseBranch}`], { ignoreReturnCode: true });
-      const count = parseInt(output.trim(), 10);
-      return !isNaN(count) && count > 0;
-    },
+      async hasNewCommits(): Promise<boolean> {
+        const output = await git(["rev-list", "--count", "HEAD", `^origin/${baseBranch}`], { ignoreReturnCode: true });
+        const count = parseInt(output.trim(), 10);
+        return !isNaN(count) && count > 0;
+      },
 
-    async getChangedFiles(): Promise<string[]> {
-      const output = await git(["diff", "--name-only", `origin/${baseBranch}..HEAD`], { ignoreReturnCode: true });
-      return output.trim().split("\n").filter(Boolean);
-    },
+      async getChangedFiles(): Promise<string[]> {
+        const output = await git(["diff", "--name-only", `origin/${baseBranch}..HEAD`], { ignoreReturnCode: true });
+        return output.trim().split("\n").filter(Boolean);
+      },
 
-    async resetPaths(paths: string[]): Promise<void> {
-      for (const p of paths) {
-        await git(["checkout", "HEAD", "--", p], { ignoreReturnCode: true });
-      }
-      log.debug(`Reset paths: ${paths.join(", ")}`);
-    },
-
-    async stageAndCommit(message: string): Promise<void> {
-      await git(["add", "-A"]);
-      await git(["commit", "-m", message]);
-    },
-
-    async createPullRequest(opts: PrCreateOptions): Promise<PullRequest> {
-      const body: Record<string, unknown> = {
-        title: opts.title,
-        description: opts.body,
-        source_branch: opts.head,
-        target_branch: opts.base || baseBranch,
-      };
-
-      if (opts.labels && opts.labels.length > 0) {
-        body.labels = opts.labels.join(",");
-      }
-
-      const mr = (await glApi("POST", `/projects/${projectId}/merge_requests`, baseUrl, token, body)) as {
-        iid: number;
-        web_url: string;
-        state: string;
-        title: string;
-      };
-      log.info(`Created MR !${mr.iid}: ${mr.web_url}`);
-
-      return {
-        number: mr.iid,
-        url: mr.web_url,
-        state: "open",
-        title: mr.title,
-      };
-    },
-
-    async listPullRequests(opts?: PrListOptions): Promise<PullRequest[]> {
-      const state = opts?.state ?? "open";
-      const limit = opts?.limit ?? 30;
-      const params = new URLSearchParams({
-        state: toGitLabState(state),
-        per_page: String(limit),
-        order_by: "updated_at",
-        sort: "desc",
-      });
-
-      if (opts?.labels && opts.labels.length > 0) {
-        params.set("labels", opts.labels.join(","));
-      }
-
-      const mrs = (await glApi("GET", `/projects/${projectId}/merge_requests?${params}`, baseUrl, token)) as {
-        iid: number;
-        web_url: string;
-        title: string;
-        state: string;
-        merged_at: string | null;
-        closed_at: string | null;
-        labels: string[];
-      }[];
-
-      return mrs.map((mr) => ({
-        number: mr.iid,
-        url: mr.web_url,
-        state: mapMrState(mr.state, mr.merged_at),
-        title: mr.title,
-        mergedAt: mr.merged_at,
-        closedAt: mr.closed_at,
-      }));
-    },
-
-    async findExistingPr(searchTerm: string): Promise<PullRequest | null> {
-      // Search open MRs
-      const openParams = new URLSearchParams({
-        state: "opened",
-        search: searchTerm,
-        per_page: "20",
-      });
-
-      const openMrs = (await glApi("GET", `/projects/${projectId}/merge_requests?${openParams}`, baseUrl, token)) as {
-        iid: number;
-        web_url: string;
-        title: string;
-        description: string | null;
-        state: string;
-        merged_at: string | null;
-      }[];
-
-      for (const mr of openMrs) {
-        const text = `${mr.title} ${mr.description || ""}`;
-        if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
-          log.info(`Found open MR with match: ${mr.web_url}`);
-          return {
-            number: mr.iid,
-            url: mr.web_url,
-            state: "open",
-            title: mr.title,
-          };
+      async resetPaths(paths: string[]): Promise<void> {
+        for (const p of paths) {
+          await git(["checkout", "HEAD", "--", p], { ignoreReturnCode: true });
         }
-      }
+        log.debug(`Reset paths: ${paths.join(", ")}`);
+      },
 
-      // Search recently merged MRs
-      const mergedParams = new URLSearchParams({
-        state: "merged",
-        search: searchTerm,
-        order_by: "updated_at",
-        sort: "desc",
-        per_page: "20",
-      });
+      async stageAndCommit(message: string): Promise<void> {
+        await git(["add", "-A"]);
+        await git(["commit", "-m", message]);
+      },
 
-      const mergedMrs = (await glApi(
-        "GET",
-        `/projects/${projectId}/merge_requests?${mergedParams}`,
-        baseUrl,
-        token,
-      )) as {
-        iid: number;
-        web_url: string;
-        title: string;
-        description: string | null;
-        state: string;
-        merged_at: string | null;
-      }[];
+      async createPullRequest(opts: PrCreateOptions): Promise<PullRequest> {
+        const body: Record<string, unknown> = {
+          title: opts.title,
+          description: opts.body,
+          source_branch: opts.head,
+          target_branch: opts.base || baseBranch,
+        };
 
-      const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-      for (const mr of mergedMrs) {
-        if (mr.merged_at && new Date(mr.merged_at) > cutoff) {
+        if (opts.labels && opts.labels.length > 0) {
+          body.labels = opts.labels.join(",");
+        }
+
+        const mr = (await glApi("POST", `/projects/${projectId}/merge_requests`, baseUrl, token, body)) as {
+          iid: number;
+          web_url: string;
+          state: string;
+          title: string;
+        };
+        log.info(`Created MR !${mr.iid}: ${mr.web_url}`);
+
+        return {
+          number: mr.iid,
+          url: mr.web_url,
+          state: "open",
+          title: mr.title,
+        };
+      },
+
+      async listPullRequests(opts?: PrListOptions): Promise<PullRequest[]> {
+        const state = opts?.state ?? "open";
+        const limit = opts?.limit ?? 30;
+        const params = new URLSearchParams({
+          state: toGitLabState(state),
+          per_page: String(limit),
+          order_by: "updated_at",
+          sort: "desc",
+        });
+
+        if (opts?.labels && opts.labels.length > 0) {
+          params.set("labels", opts.labels.join(","));
+        }
+
+        const mrs = (await glApi("GET", `/projects/${projectId}/merge_requests?${params}`, baseUrl, token)) as {
+          iid: number;
+          web_url: string;
+          title: string;
+          state: string;
+          merged_at: string | null;
+          closed_at: string | null;
+          labels: string[];
+        }[];
+
+        return mrs.map((mr) => ({
+          number: mr.iid,
+          url: mr.web_url,
+          state: mapMrState(mr.state, mr.merged_at),
+          title: mr.title,
+          mergedAt: mr.merged_at,
+          closedAt: mr.closed_at,
+        }));
+      },
+
+      async findExistingPr(searchTerm: string): Promise<PullRequest | null> {
+        // Search open MRs
+        const openParams = new URLSearchParams({
+          state: "opened",
+          search: searchTerm,
+          per_page: "20",
+        });
+
+        const openMrs = (await glApi("GET", `/projects/${projectId}/merge_requests?${openParams}`, baseUrl, token)) as {
+          iid: number;
+          web_url: string;
+          title: string;
+          description: string | null;
+          state: string;
+          merged_at: string | null;
+        }[];
+
+        for (const mr of openMrs) {
           const text = `${mr.title} ${mr.description || ""}`;
           if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
-            log.info(`Found merged MR with match: ${mr.web_url}`);
+            log.info(`Found open MR with match: ${mr.web_url}`);
             return {
               number: mr.iid,
               url: mr.web_url,
-              state: "merged",
+              state: "open",
               title: mr.title,
-              mergedAt: mr.merged_at,
             };
           }
         }
-      }
 
-      return null;
+        // Search recently merged MRs
+        const mergedParams = new URLSearchParams({
+          state: "merged",
+          search: searchTerm,
+          order_by: "updated_at",
+          sort: "desc",
+          per_page: "20",
+        });
+
+        const mergedMrs = (await glApi(
+          "GET",
+          `/projects/${projectId}/merge_requests?${mergedParams}`,
+          baseUrl,
+          token,
+        )) as {
+          iid: number;
+          web_url: string;
+          title: string;
+          description: string | null;
+          state: string;
+          merged_at: string | null;
+        }[];
+
+        const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+        for (const mr of mergedMrs) {
+          if (mr.merged_at && new Date(mr.merged_at) > cutoff) {
+            const text = `${mr.title} ${mr.description || ""}`;
+            if (new RegExp(`\\b${searchTerm}\\b`, "i").test(text)) {
+              log.info(`Found merged MR with match: ${mr.web_url}`);
+              return {
+                number: mr.iid,
+                url: mr.web_url,
+                state: "merged",
+                title: mr.title,
+                mergedAt: mr.merged_at,
+              };
+            }
+          }
+        }
+
+        return null;
+      },
+
+      async enableAutoMerge(_prNumber: number): Promise<void> {
+        log.warn(
+          "Auto-merge is not supported by the GitLab provider. Enable 'Merge when pipeline succeeds' on the MR manually.",
+        );
+      },
+
+      async dispatchWorkflow(opts: DispatchWorkflowOptions): Promise<void> {
+        // GitLab triggers pipelines via POST /projects/:id/pipeline
+        // The targetRepo can override the project; the workflow field is used as the ref
+        const targetProjectId = opts.targetRepo ? encodeURIComponent(opts.targetRepo) : projectId;
+
+        const variables = opts.inputs
+          ? Object.entries(opts.inputs).map(([key, value]) => ({
+              key,
+              value,
+              variable_type: "env_var" as const,
+            }))
+          : [];
+
+        await glApi("POST", `/projects/${targetProjectId}/pipeline`, baseUrl, token, {
+          ref: opts.workflow || baseBranch,
+          variables,
+        });
+        log.info(`Triggered pipeline on ref "${opts.workflow}" for project ${opts.targetRepo || projectId}`);
+      },
     },
-
-    async enableAutoMerge(_prNumber: number): Promise<void> {
-      log.warn(
-        "Auto-merge is not supported by the GitLab provider. Enable 'Merge when pipeline succeeds' on the MR manually.",
-      );
-    },
-
-    async dispatchWorkflow(opts: DispatchWorkflowOptions): Promise<void> {
-      // GitLab triggers pipelines via POST /projects/:id/pipeline
-      // The targetRepo can override the project; the workflow field is used as the ref
-      const targetProjectId = opts.targetRepo ? encodeURIComponent(opts.targetRepo) : projectId;
-
-      const variables = opts.inputs
-        ? Object.entries(opts.inputs).map(([key, value]) => ({
-            key,
-            value,
-            variable_type: "env_var" as const,
-          }))
-        : [];
-
-      await glApi("POST", `/projects/${targetProjectId}/pipeline`, baseUrl, token, {
-        ref: opts.workflow || baseBranch,
-        variables,
-      });
-      log.info(`Triggered pipeline on ref "${opts.workflow}" for project ${opts.targetRepo || projectId}`);
-    },
-  }, { configSchema: gitlabProviderConfigSchema });
+    { configSchema: gitlabProviderConfigSchema },
+  );
 }


### PR DESCRIPTION
## Summary

Fixes a broken CI pipeline on `main` caused by 6 files committed without Prettier formatting. The `format:check` step was failing on every push, blocking all PR merges until resolved. This PR applies the mechanical Prettier fix to restore CI to green.

## Issue Analysis

- **Severity**: High — CI blocked on `main`, no PRs could merge
- **Frequency**: Repeated across 4 CI runs (23199468449, 23195029818, 23195412282, 23195001538) on 2026-03-17
- **Services affected**: `sweny-ci` (CI pipeline), `@sweny-ai/providers` (published package, source files affected)
- **Impact**: All contributors blocked from merging to `main` until formatting was corrected

## Root Cause

6 files were committed without running Prettier first. The `format:check` CI step runs `prettier --check .` and exits with code 1 when any file deviates from the project's formatting rules. No pre-commit hook exists locally to catch this, so violations reached CI undetected.

Offending files:
- `packages/action/tests/mapToTriageConfig.test.ts`
- `packages/providers/src/coding-agent/claude-code.ts`
- `packages/providers/src/coding-agent/google-gemini.ts`
- `packages/providers/src/coding-agent/openai-codex.ts`
- `packages/providers/src/source-control/github.ts`
- `packages/providers/src/source-control/gitlab.ts`

## Solution

Ran `npx prettier --write` on all 6 offending files and verified clean output with `npx prettier --check`. No logic, behavior, or API surface was changed — formatting only.

A patch-level changeset (`fix-prettier-format-violations.md`) was added for `@sweny-ai/providers` since 5 of the 6 files belong to that published package.

## Testing

- [ ] Lint passes
- [ ] Build passes
- [ ] Tests pass

## Rollback Plan

All changes are purely cosmetic (whitespace/formatting). If a rollback is needed, revert the commit. The only consequence is CI will fail the `format:check` step again — no functional regression is possible.

---
Closes #65
> Generated by SWEny Triage
