### PR TITLE
fix(web): update RecipeViewer → WorkflowViewer import in RecipeExplorer

### DIFF
--- a/.github/triage-analysis/best-candidate.md
+++ b/.github/triage-analysis/best-candidate.md
@@ -1,155 +1,96 @@
 <!-- TRIAGE_FINGERPRINT
-error_pattern: provider configSchema.fields missing required env vars NR_ACCOUNT_ID SENTRY_ORG SENTRY_PROJECT
-service: sweny-providers
-first_seen: 2026-03-16
-run_id: direct-run-2026-03-16
+error_pattern: "RecipeViewer" is not exported by "../studio/dist-lib/viewer.js"
+service: sweny-web
+first_seen: 2026-03-17
+run_id: 23204701005
 -->
 
 RECOMMENDATION: implement
 
-TARGET_SERVICE: sweny-providers
+TARGET_SERVICE: sweny-web
 TARGET_REPO: swenyai/sweny
 
 **GitHub Issues Issue**: None found - New issue will be created
 
-# NewRelic and Sentry Provider Config Schemas Missing Required Env Var Fields
+# RecipeViewer Stale Import Breaks Deploy Docs Build
 
 ## Summary
 
-The `ProviderConfigSchema.fields` arrays for the NewRelic and Sentry observability providers
-are incomplete: they each list only their auth token field, but their Zod schemas require
-additional fields (`accountId` for NewRelic; `organization` and `project` for Sentry).
-
-The engine's pre-flight validation in `runner-recipe.ts` uses `configSchema.fields` to check
-all required env vars before starting a workflow. Because these fields are missing, the engine
-gives users a false "all clear" — then the provider crashes mid-workflow when the missing env
-var is actually needed.
+`packages/web/src/components/RecipeExplorer.tsx` still imports `RecipeViewer` from
+`@sweny-ai/studio/viewer`, but studio v3.0.0 renamed this export to `WorkflowViewer`.
+Every push to `main` fails the Deploy Docs workflow with a Rollup build error.
 
 ## Root Cause
 
-`packages/providers/src/observability/newrelic.ts` line 17-21:
-```typescript
-// Zod schema (lines 8-13) requires apiKey AND accountId
-// But configSchema.fields only lists apiKey:
-fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
-// NR_ACCOUNT_ID is never checked in pre-flight
+Studio v3.0.0 introduced a documented breaking change (CHANGELOG.md):
+
+> **Breaking**: Studio public exports renamed to workflow terminology.
+> `RecipeViewer` → `WorkflowViewer`
+
+`packages/studio/src/lib-viewer.ts` now exports only `WorkflowViewer`. However,
+`packages/web/src/components/RecipeExplorer.tsx` was never updated to match.
+
+The Deploy Docs workflow runs `build:lib` (studio) before building `packages/web`.
+When Rollup resolves `@sweny-ai/studio/viewer`, it finds `dist-lib/viewer.js` with no
+`RecipeViewer` export, and fails with exit code 1.
+
+## CI Evidence
+
+```
+[ERROR] [vite] ✗ Build failed in 2.11s
+src/components/RecipeExplorer.tsx (2:9): "RecipeViewer" is not exported by
+"../studio/dist-lib/viewer.js", imported by "src/components/RecipeExplorer.tsx".
+
+  1: import { useState, useRef, useCallback, useEffect } from "react";
+  2: import { RecipeViewer } from "@sweny-ai/studio/viewer";
+              ^
+  3: import { triageDefinition, implementDefinition } from "@sweny-ai/engine/browser";
 ```
 
-`packages/providers/src/observability/sentry.ts` line 18-22:
-```typescript
-// Zod schema (lines 8-14) requires authToken, organization, AND project
-// But configSchema.fields only lists authToken:
-fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
-// SENTRY_ORG and SENTRY_PROJECT are never checked in pre-flight
-```
-
-Engine validation at `packages/engine/src/runner-recipe.ts` lines 56-58:
-```typescript
-const missing = provider.configSchema.fields
-  .filter((f) => f.required !== false && !process.env[f.envVar])
-  .map((f) => f.envVar);
-```
-Only the fields listed in `configSchema.fields` are checked. Missing fields are invisible to
-pre-flight validation.
+Run 23204701005, job 67436666701 ("build"), step "Build site".
 
 ## Exact Code Changes
 
-**File**: `packages/providers/src/observability/newrelic.ts`, lines 17-21
+**File**: `packages/web/src/components/RecipeExplorer.tsx`
 
-```typescript
-// Before:
-export const newrelicProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "New Relic",
-  fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
-};
-
-// After:
-export const newrelicProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "New Relic",
-  fields: [
-    { key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" },
-    { key: "accountId", envVar: "NR_ACCOUNT_ID", description: "New Relic account ID" },
-  ],
-};
+Change 1 — line 2, import statement:
+```diff
+-import { RecipeViewer } from "@sweny-ai/studio/viewer";
++import { WorkflowViewer } from "@sweny-ai/studio/viewer";
 ```
 
-**File**: `packages/providers/src/observability/sentry.ts`, lines 18-22
-
-```typescript
-// Before:
-export const sentryProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "Sentry",
-  fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
-};
-
-// After:
-export const sentryProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "Sentry",
-  fields: [
-    { key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
-    { key: "organization", envVar: "SENTRY_ORG", description: "Sentry organization slug" },
-    { key: "project", envVar: "SENTRY_PROJECT", description: "Sentry project slug" },
-  ],
-};
+Change 2 — line 1179, JSX usage:
+```diff
+-      <RecipeViewer
++      <WorkflowViewer
 ```
 
-## Evidence Confirming Correct Env Var Names
+The props are identical (`definition`, `executionState`, `height`, `onNodeClick`) — no
+prop name changes are needed.
 
-`newrelic.ts` `getAgentEnv()` (line 163):
-```typescript
-return { NR_API_KEY: this.apiKey, NR_ACCOUNT_ID: this.accountId, NR_REGION: this.region };
-```
+## Changeset Required
 
-`sentry.ts` `getAgentEnv()` (line 127):
-```typescript
-return { SENTRY_AUTH_TOKEN: this.authToken, SENTRY_ORG: this.org, SENTRY_PROJECT: this.project, ... };
-```
-
-`action/src/config.ts` `validateInputs()` (lines 233-241, 205-213):
-```typescript
-case "newrelic":
-  if (!config.observabilityCredentials.accountId)
-    errors.push("Missing required input: `newrelic-account-id` ...");
-case "sentry":
-  if (!config.observabilityCredentials.organization)
-    errors.push("Missing required input: `sentry-org` ...");
-  if (!config.observabilityCredentials.project)
-    errors.push("Missing required input: `sentry-project` ...");
-```
-
-## Files to Modify
-
-- `packages/providers/src/observability/newrelic.ts` — add `accountId`/`NR_ACCOUNT_ID` field
-- `packages/providers/src/observability/sentry.ts` — add `organization`/`SENTRY_ORG` and `project`/`SENTRY_PROJECT` fields
+No — `packages/web` is a private package (not published to npm per CLAUDE.md).
 
 ## Test Plan
 
-- [ ] Run existing provider tests: `npm test --workspace packages/providers`
-- [ ] Verify `validateWorkflowConfig` catches missing `NR_ACCOUNT_ID` when NewRelic is used
-- [ ] Verify `validateWorkflowConfig` catches missing `SENTRY_ORG`/`SENTRY_PROJECT` when Sentry is used
-- [ ] Confirm no regression in providers that were already correct (Datadog, Splunk, Elastic)
+1. Confirm the fix locally: `npm run build:lib --workspace=packages/studio` then
+   `npm run build --workspace=packages/web` — should succeed.
+2. Confirm TypeScript is happy: `npm run typecheck` from root.
+3. Push to a branch and verify the Deploy Docs workflow passes.
 
 ## Rollback Plan
 
-Config schema additions are purely additive metadata — they only cause pre-flight to report
-a new error when env vars are absent. Rolling back means removing the two new field entries.
-No runtime behavior changes beyond the pre-flight check.
+Revert the two-line change in `RecipeExplorer.tsx`. The only risk is the current broken
+state (build fails), so rollback simply restores the broken state — not applicable.
+
+## Impact
+
+- **Unblocks** the Deploy Docs workflow on every push to main.
+- **No published package changes** — web is private.
+- **No API surface or behavior changes** — purely a component name update.
 
 ## Confidence
 
-Very High. Code inspection directly confirms the mismatch. The env var names are verified
-from three independent sources (getAgentEnv, action config, Zod schemas). Fix is minimal
-(two array additions) with zero risk of regression in the happy path.
-
-## Other Providers Audited (All Clear)
-
-- Datadog: both `DD_API_KEY` + `DD_APPLICATION_KEY` in fields ✅
-- Splunk: both `SPLUNK_URL` + `SPLUNK_TOKEN` in fields ✅
-- Elastic: both `ELASTIC_URL` + `ELASTIC_API_KEY` in fields ✅
-- Loki: `LOKI_URL` only required (`apiKey`/`orgId` are optional) ✅
-- Linear: single required field `LINEAR_API_KEY` in fields ✅
-- Jira: all 3 required fields present ✅
+High — the rename is unambiguous (CHANGELOG, lib-viewer.ts), the props are identical,
+and the fix is two lines.

--- a/.github/triage-analysis/investigation-log.md
+++ b/.github/triage-analysis/investigation-log.md
@@ -1,54 +1,79 @@
-# Investigation Log — 2026-03-16
+# Investigation Log — 2026-03-17
 
 ## Approach
+Direct run (no issue override). Followed additional instructions to investigate CI failures
+in `/tmp/ci-failures.json`, then look holistically for the highest-value fix.
 
-Additional instructions: autonomous improvement agent, broad mandate.
-CI failures from `/tmp/ci-failures.json` show recurring `CI on main` and `Deploy Docs` failures.
-GitHub Actions API returned 404 for expired run details, so pivoted to holistic codebase exploration.
+## Step 1 — Parse CI failure log
 
-## Step 1 — Read CI Failures
+Read `/tmp/ci-failures.json`. Failures observed (2026-03-17):
 
-The CI failures log contained ~20 entries:
-- `CI on main` (run_id: 23132498377, 23131264950)
-- `Deploy Docs on main` (run_id: 23132498397, 23131264956)
-- Multiple dependabot branch failures
+| Workflow | Branch | Run ID |
+|----------|--------|--------|
+| Deploy Docs | main | 23204701005 |
+| Post-Release Docs Update | v3 | 23203365068 |
+| CI (×3) | dependabot/npm_and_yarn/types/react-dom-19.2.3 | various |
+| Release | main | 23200577502 |
+| CI (×4) | various dependabot branches | various |
+| CI (×2) | main | 23199604384, 23199468449 |
+| Continuous Improvement | main | 23195412282 |
+| CI | main | 23195029818 |
 
-GitHub Actions API returned 404 — run details not accessible (likely expired).
+## Step 2 — Get job-level failure details via GitHub API
 
-## Step 2 — Codebase Exploration
+```
+GET /repos/swenyai/sweny/actions/runs/23199604384/jobs
+```
 
-Ran broad exploration of:
-- `packages/providers/src/` — all 30+ provider implementations
-- `packages/engine/src/` — runner, validate, schema
-- `packages/cli/src/` — CLI main entry
-- `packages/action/src/` — GitHub Action entrypoint
+Results:
+- **Format** job → FAILURE: `Run npm run format:check`
+  - Files flagged: `packages/action/tests/mapToTriageConfig.test.ts`,
+    `packages/providers/src/coding-agent/claude-code.ts`,
+    `packages/providers/src/coding-agent/google-gemini.ts`
+- All other CI jobs (Typecheck, Lint, Test Node 20, Test Node 22) → SUCCESS
 
-## Step 3 — Identify Provider Config Schema Mismatch Bug
+```
+GET /repos/swenyai/sweny/actions/runs/23204701005/jobs
+```
 
-Read `packages/engine/src/runner-recipe.ts` lines 44-66 — `validateWorkflowConfig()` checks
-env vars listed in `provider.configSchema.fields`. Found that several providers list FEWER
-fields than their Zod schemas require, causing silent pre-flight validation passes that lead
-to runtime crashes.
+Results:
+- **build** job → FAILURE: `Build site`
+  - Error: `"RecipeViewer" is not exported by "../studio/dist-lib/viewer.js"`
+  - File: `packages/web/src/components/RecipeExplorer.tsx:2:9`
 
-**Verified providers:**
+## Step 3 — Cross-reference with known issues
 
-| Provider | Zod required | configSchema.fields | Gap |
-|----------|-------------|---------------------|-----|
-| NewRelic | apiKey, accountId | NR_API_KEY only | NR_ACCOUNT_ID missing |
-| Sentry | authToken, organization, project | SENTRY_AUTH_TOKEN only | SENTRY_ORG, SENTRY_PROJECT missing |
-| Datadog | apiKey, appKey | DD_API_KEY, DD_APPLICATION_KEY | ✅ complete |
-| Splunk | baseUrl, token | SPLUNK_URL, SPLUNK_TOKEN | ✅ complete |
-| Elastic | baseUrl, apiKey | ELASTIC_URL, ELASTIC_API_KEY | ✅ complete |
-| Loki | baseUrl (apiKey/orgId optional) | LOKI_URL | ✅ complete |
-| Linear | apiKey | LINEAR_API_KEY | ✅ complete |
-| Jira | baseUrl, email, apiToken | all 3 listed | ✅ complete |
+- **Format violations**: Already tracked as issue #65 / PR #66 (closed failed attempt).
+  → SKIP per instructions.
+- **RecipeViewer not exported**: No existing issue found. NEW.
 
-Confirmed correct env var names from:
-- `newrelic.ts getAgentEnv()` → exports `NR_ACCOUNT_ID`
-- `sentry.ts getAgentEnv()` → exports `SENTRY_ORG`, `SENTRY_PROJECT`
-- `action/src/config.ts validateInputs()` → checks `newrelic-account-id`, `sentry-org`, `sentry-project`
+## Step 4 — Root cause analysis for RecipeViewer
 
-## Conclusion
+Searched `RecipeViewer` across the codebase:
+- `packages/studio/CHANGELOG.md` confirms: in studio v3.0.0 (major release),
+  `RecipeViewer` was renamed to `WorkflowViewer` as a breaking change:
+  > "Breaking: Studio public exports renamed to workflow terminology.
+  > RecipeViewer → WorkflowViewer"
+- `packages/studio/src/lib-viewer.ts` exports only `WorkflowViewer` (confirmed by read).
+- `packages/web/src/components/RecipeExplorer.tsx` still imports `RecipeViewer` at line 2
+  and uses `<RecipeViewer` at line 1179.
 
-Best candidate: Fix `newrelicProviderConfigSchema` and `sentryProviderConfigSchema` to include
-all required env var fields. Small, targeted, high-impact fix affecting all users of these providers.
+**Root cause**: `RecipeExplorer.tsx` was not updated when studio's public API was renamed
+in v3.0.0. The import references a symbol that no longer exists in `dist-lib/viewer.js`.
+
+## Step 5 — Proposed fix
+
+Update `RecipeExplorer.tsx`:
+1. Line 2: `import { RecipeViewer }` → `import { WorkflowViewer }`
+2. Line 1179: `<RecipeViewer` → `<WorkflowViewer`
+   (JSX is self-closing, so no closing tag needs updating)
+
+The `WorkflowViewer` props interface (`definition`, `executionState`, `height`, `onNodeClick`)
+is fully compatible with how `RecipeViewer` was used — same props, same behavior.
+
+## Step 6 — Scope and risk
+
+- Change is entirely in `packages/web` (private, non-published package).
+- No changeset required (per CLAUDE.md: web is private).
+- No type or API surface changes; purely a name update.
+- Low risk: straightforward rename, TypeScript will catch regressions.

--- a/.github/triage-analysis/issues-report.md
+++ b/.github/triage-analysis/issues-report.md
@@ -1,113 +1,68 @@
-# Issues Report — 2026-03-16
+# Issues Report — 2026-03-17
 
-## Issue 1: NewRelic and Sentry Provider Config Schemas Missing Required Env Var Fields
+## Issue 1: RecipeViewer Import Breaks Deploy Docs Build
 
 - **Severity**: High
-- **Environment**: All (production and local — any env using these providers)
-- **Frequency**: Affects all users of NewRelic or Sentry providers
+- **Environment**: CI (Deploy Docs workflow on main)
+- **Frequency**: Every push to main since studio v3.0.0 rename
 
 ### Description
-
-The engine's pre-flight validation (`validateWorkflowConfig` in `runner-recipe.ts`) checks
-`provider.configSchema.fields` to verify required environment variables are set before the
-workflow starts. Two providers have incomplete `fields` arrays — they list fewer env vars than
-their Zod schemas require — causing the pre-flight check to silently pass when critical env vars
-are missing, producing confusing runtime failures mid-workflow instead of a clear upfront error.
-
-**NewRelic** (`packages/providers/src/observability/newrelic.ts`):
-- Zod schema requires: `apiKey`, `accountId`
-- `newrelicProviderConfigSchema.fields` lists: only `NR_API_KEY`
-- Missing: `NR_ACCOUNT_ID`
-
-**Sentry** (`packages/providers/src/observability/sentry.ts`):
-- Zod schema requires: `authToken`, `organization`, `project`
-- `sentryProviderConfigSchema.fields` lists: only `SENTRY_AUTH_TOKEN`
-- Missing: `SENTRY_ORG`, `SENTRY_PROJECT`
+`packages/web/src/components/RecipeExplorer.tsx` imports `RecipeViewer` from
+`@sweny-ai/studio/viewer`, but this export was renamed to `WorkflowViewer` in studio v3.0.0.
+Rollup cannot resolve the import and the Deploy Docs build fails with exit code 1.
 
 ### Evidence
-
-`newrelic.ts` line 17-21 — configSchema only lists one field:
-```typescript
-export const newrelicProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "New Relic",
-  fields: [{ key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" }],
-  //       ^^^^^ missing accountId / NR_ACCOUNT_ID
-};
 ```
+[ERROR] [vite] ✗ Build failed in 2.11s
+src/components/RecipeExplorer.tsx (2:9): "RecipeViewer" is not exported by
+"../studio/dist-lib/viewer.js", imported by "src/components/RecipeExplorer.tsx".
 
-But `newrelic.ts` line 163-168 — `getAgentEnv()` shows the expected env vars:
-```typescript
-getAgentEnv(): Record<string, string> {
-  return {
-    NR_API_KEY: this.apiKey,
-    NR_ACCOUNT_ID: this.accountId,   // ← this IS required
-    NR_REGION: this.region,
-  };
-}
+file: /home/runner/work/sweny/sweny/packages/web/src/components/RecipeExplorer.tsx:2:9
+  1: import { useState, useRef, useCallback, useEffect } from "react";
+  2: import { RecipeViewer } from "@sweny-ai/studio/viewer";
+              ^
 ```
-
-`sentry.ts` line 18-22 — configSchema only lists one field, but Zod requires three:
-```typescript
-export const sentryProviderConfigSchema: ProviderConfigSchema = {
-  role: "observability",
-  name: "Sentry",
-  fields: [{ key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" }],
-  //       ^^^^^ missing organization/SENTRY_ORG, project/SENTRY_PROJECT
-};
-```
-
-`runner-recipe.ts` line 56-58 — the validation that is missed:
-```typescript
-const missing = provider.configSchema.fields
-  .filter((f) => f.required !== false && !process.env[f.envVar])
-  .map((f) => f.envVar);
-```
+Run ID: 23204701005, Job: build (67436666701)
 
 ### Root Cause Analysis
-
-When new required fields were added to the Zod schemas (accountId for NewRelic,
-organization/project for Sentry), the corresponding `ProviderConfigSchema.fields` arrays
-were not updated. The two validation paths (Zod and configSchema) became out of sync.
+Studio v3.0.0 renamed `RecipeViewer` → `WorkflowViewer` (breaking change documented in
+CHANGELOG.md). The `packages/web` package was not updated when this rename happened.
+`lib-viewer.ts` now exports only `WorkflowViewer`.
 
 ### Impact
-
-- Users running NewRelic or Sentry without `NR_ACCOUNT_ID` / `SENTRY_ORG` / `SENTRY_PROJECT`
-  pass pre-flight but get cryptic runtime failures when the provider actually executes API calls
-- Debug experience is poor: no clear error message pointing to the missing variable
-- All workflows using these providers are affected
+- Deploy Docs workflow fails on every push to main.
+- Documentation site cannot be rebuilt or deployed.
+- The `packages/web` SPA (RecipeExplorer page) is broken at build time.
 
 ### Suggested Fix
-
-Add the missing fields to each provider's `ProviderConfigSchema.fields`:
-
-**newrelic.ts**:
-```typescript
-fields: [
-  { key: "apiKey", envVar: "NR_API_KEY", description: "New Relic User API key" },
-  { key: "accountId", envVar: "NR_ACCOUNT_ID", description: "New Relic account ID" },
-],
-```
-
-**sentry.ts**:
-```typescript
-fields: [
-  { key: "authToken", envVar: "SENTRY_AUTH_TOKEN", description: "Sentry authentication token" },
-  { key: "organization", envVar: "SENTRY_ORG", description: "Sentry organization slug" },
-  { key: "project", envVar: "SENTRY_PROJECT", description: "Sentry project slug" },
-],
-```
+In `packages/web/src/components/RecipeExplorer.tsx`:
+1. Line 2: Change `import { RecipeViewer }` to `import { WorkflowViewer }`
+2. Line 1179: Change `<RecipeViewer` to `<WorkflowViewer`
 
 ### Files to Modify
-
-- `packages/providers/src/observability/newrelic.ts` — line 20, add accountId field
-- `packages/providers/src/observability/sentry.ts` — line 21, add organization and project fields
+- `packages/web/src/components/RecipeExplorer.tsx`
 
 ### Confidence Level
-
-Very High — direct code inspection confirms the mismatch; env var names confirmed via
-`getAgentEnv()` and `action/src/config.ts` validation logic.
+High — the rename in studio is documented, the old symbol provably does not exist in
+`dist-lib/viewer.js`, and the props interface is identical.
 
 ### GitHub Issues Status
-
 No existing GitHub Issues issue found — New issue will be created.
+
+---
+
+## Issue 2: Prettier Format Violations Break CI on Main (Known Issue)
+
+- **Severity**: Medium
+- **Environment**: CI (main branch)
+- **Frequency**: Every push to main
+
+### Description
+`npm run format:check` fails on three files with prettier violations.
+Files: `packages/action/tests/mapToTriageConfig.test.ts`,
+`packages/providers/src/coding-agent/claude-code.ts`,
+`packages/providers/src/coding-agent/google-gemini.ts`
+
+### GitHub Issues Status
+**Existing issue #65** — already tracked. PR #66 closed as failed attempt.
+→ No new issue or fix proposed for this. Recommend +1 on issue #65.

--- a/packages/web/src/components/RecipeExplorer.tsx
+++ b/packages/web/src/components/RecipeExplorer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { RecipeViewer } from "@sweny-ai/studio/viewer";
+import { WorkflowViewer } from "@sweny-ai/studio/viewer";
 import { triageDefinition, implementDefinition } from "@sweny-ai/engine/browser";
 import "@sweny-ai/studio/style.css";
 import type { RecipeDefinition, StateDefinition } from "@sweny-ai/engine/browser";
@@ -1176,7 +1176,7 @@ export function RecipeExplorer() {
 
   const graphPane = (
     <div style={{ flex: 1, minWidth: 0, minHeight: 0 }}>
-      <RecipeViewer
+      <WorkflowViewer
         key={activeIdx}
         definition={liveDefinition}
         height={bodyHeight}


### PR DESCRIPTION
## Summary

- `RecipeExplorer.tsx` imported `RecipeViewer` from `@sweny-ai/studio/viewer`, but this export was renamed to `WorkflowViewer` in studio v3.0.0
- This caused the Deploy Docs workflow to fail on every push to `main` with a Rollup missing-export error
- Two-line fix: update the import and the JSX usage

## Root Cause

Studio v3.0.0 documented a breaking rename (`RecipeViewer` → `WorkflowViewer`) in CHANGELOG.md, but `packages/web/src/components/RecipeExplorer.tsx` was never updated to match. The `dist-lib/viewer.js` built from `lib-viewer.ts` no longer exports the old name.

## CI Evidence

```
"RecipeViewer" is not exported by "../studio/dist-lib/viewer.js",
imported by "src/components/RecipeExplorer.tsx".
  2: import { RecipeViewer } from "@sweny-ai/studio/viewer";
              ^
```

Run 23204701005 ("Deploy Docs"), job "build".

## Test plan

- [ ] Deploy Docs workflow passes on merge to main
- [ ] TypeScript typecheck (`npm run typecheck`) passes — `WorkflowViewer` is a known export with identical props
- [ ] No changeset needed: `packages/web` is a private package

🤖 Generated with [Claude Code](https://claude.com/claude-code)