### PR TITLE
fix(action): rename recipe input to workflow in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,8 @@ branding:
   color: "orange"
 
 inputs:
-  recipe:
-    description: "Recipe to run (triage, implement). Default: triage."
+  workflow:
+    description: "Workflow to run (triage, implement). Default: triage."
     required: false
     default: "triage"
 


### PR DESCRIPTION
## Summary

- The `recipe→workflow` rename (815d361, 2026-03-14) updated `config.ts` to call `core.getInput("workflow")` but left the `action.yml` input key named `recipe:`
- Since `workflow:` is not a defined action input, `core.getInput("workflow")` always returns `""` in production — silently falling back to `triage`
- **The implement workflow has been unreachable since 2026-03-14**: anyone using `recipe: implement` gets triage with no error

## Root Cause

```
815d361: refactor: complete recipe→workflow terminology rename
  ✅ packages/action/src/config.ts — core.getInput("recipe") → core.getInput("workflow")
  ✅ packages/action/tests/config.test.ts — mock key updated to "workflow"
  ❌ action.yml — "recipe:" key was NOT renamed to "workflow:"
```

The tests passed because they mock `core.getInput` using the `"workflow"` string directly — they never exercise the real `action.yml` mapping.

## Change

```diff
 inputs:
-  recipe:
-    description: "Recipe to run (triage, implement). Default: triage."
+  workflow:
+    description: "Workflow to run (triage, implement). Default: triage."
     required: false
     default: "triage"
```

## Test Plan

- [ ] `npm run test` passes (action config tests already mock `"workflow"` correctly)
- [ ] `npm run format:check` passes
- [ ] `npm run typecheck` passes

## Notes

- No changeset required: `packages/action` is private (not published to npm)
- Users passing `recipe: implement` were already silently broken; this fix restores their intent
- The default is still `triage`, so callers who don't specify the input are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)