### PR TITLE
[#127] fix: propagate logger to resolveNext safeObserve calls in executor

### DIFF
--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -112,7 +112,7 @@ export async function execute(
     }
 
     // Resolve next node via edge conditions
-    currentId = await resolveNext(workflow, currentId, results, input, claude, observer, edgeCounts);
+    currentId = await resolveNext(workflow, currentId, results, input, claude, observer, edgeCounts, logger);
   }
 
   safeObserve(
@@ -223,6 +223,7 @@ async function resolveNext(
   claude: Claude,
   observer?: Observer,
   edgeCounts?: Map<string, number>,
+  logger?: Logger,
 ): Promise<string | null> {
   // Filter out edges that have exceeded their max_iterations
   const outEdges = workflow.edges.filter((e) => {
@@ -243,7 +244,7 @@ async function resolveNext(
       const key = `${current}→${outEdges[0].to}`;
       edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
     }
-    safeObserve(observer, { type: "route", from: current, to: outEdges[0].to, reason: "only path" });
+    safeObserve(observer, { type: "route", from: current, to: outEdges[0].to, reason: "only path" }, logger);
     return outEdges[0].to;
   }
 
@@ -283,12 +284,16 @@ async function resolveNext(
     edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
   }
 
-  safeObserve(observer, {
-    type: "route",
-    from: current,
-    to: resolved,
-    reason: choices.find((c) => c.id === resolved)?.description ?? "default",
-  });
+  safeObserve(
+    observer,
+    {
+      type: "route",
+      from: current,
+      to: resolved,
+      reason: choices.find((c) => c.id === resolved)?.description ?? "default",
+    },
+    logger,
+  );
 
   return resolved;
 }


### PR DESCRIPTION
## Summary

`resolveNext` — the internal edge-routing function inside `packages/core/src/executor.ts` — never received the caller-provided `logger`. Its two `safeObserve` calls (emitting `"route"` events) always fell back to `consoleLogger`, silently bypassing any structured or silent logger configured by the workflow caller.

## Root Cause

In `execute()`, the resolved logger is correctly threaded into every `safeObserve` call for state-lifecycle events (`enter`, `exit`, `complete`, `error`). However, `resolveNext` was never given a `logger` parameter, so routing events were always logged to the console regardless of what the caller provided — breaking structured logging setups and making test output noisy.

## Changes

- **`resolveNext` signature** — added `logger?: Logger` as the final (8th) parameter
- **Call site in `execute()`** — forwards `logger` as the 8th argument to `resolveNext`
- **Two `safeObserve` calls inside `resolveNext`** — pass `logger` as the third argument

Zero runtime behaviour change when no custom logger is provided (the existing `consoleLogger` fallback inside `safeObserve` is unchanged).

## Testing

- [ ] Tested locally
- [ ] No breaking changes — purely additive parameter threading; all existing call sites unaffected

## Related Issues

Fixes #127