### PR TITLE
fix(core): defend workflowToFlow against partial/undefined fields

### DIFF
--- a/packages/core/src/__tests__/studio.test.ts
+++ b/packages/core/src/__tests__/studio.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { workflowToFlow, flowToWorkflow, applyExecutionEvent, exportAsTypescript, getSkillCatalog } from "../studio.js";
-import type { Workflow, ExecutionEvent, NodeResult } from "../types.js";
+import type { Workflow, ExecutionEvent, NodeResult, Skill } from "../types.js";
 import type { SkillNodeData } from "../studio.js";
 
 const testWorkflow: Workflow = {
@@ -74,6 +74,88 @@ describe("workflowToFlow", () => {
     for (const node of nodes) {
       expect(node.data.exec.status).toBe("pending");
     }
+  });
+
+  // Defensive behavior: streaming LLM YAML (and user-authored
+  // workflows) routinely arrive with fields omitted. The viewer
+  // must not crash on these — it should render an empty state for
+  // the missing pieces.
+  describe("defensive handling of partial workflows", () => {
+    it("treats a node with undefined skills as having no skills", () => {
+      const partial = {
+        id: "partial",
+        name: "Partial",
+        description: "",
+        entry: "a",
+        nodes: {
+          // Cast to unknown→Node: we're deliberately simulating
+          // what a partial YAML parse produces at runtime.
+          a: { name: "A", instruction: "Do A" } as unknown as Workflow["nodes"][string],
+        },
+        edges: [],
+      } satisfies Workflow;
+
+      expect(() => workflowToFlow(partial)).not.toThrow();
+      const { nodes } = workflowToFlow(partial);
+      expect(nodes[0].data.skills).toEqual([]);
+    });
+
+    it("treats a workflow with undefined edges as having no edges", () => {
+      const partial = {
+        id: "partial",
+        name: "Partial",
+        description: "",
+        entry: "a",
+        nodes: {
+          a: { name: "A", instruction: "Do A", skills: [] },
+        },
+      } as unknown as Workflow;
+
+      expect(() => workflowToFlow(partial)).not.toThrow();
+      const { nodes, edges } = workflowToFlow(partial);
+      expect(edges).toEqual([]);
+      // The sole node is still terminal because there are no outgoing edges.
+      expect(nodes[0].data.isTerminal).toBe(true);
+    });
+
+    it("treats a workflow with undefined nodes as having no nodes", () => {
+      const partial = {
+        id: "partial",
+        name: "Partial",
+        description: "",
+        entry: "a",
+        edges: [],
+      } as unknown as Workflow;
+
+      expect(() => workflowToFlow(partial)).not.toThrow();
+      const { nodes, edges } = workflowToFlow(partial);
+      expect(nodes).toEqual([]);
+      expect(edges).toEqual([]);
+    });
+
+    it("treats a skill catalog entry with missing tools as toolCount=0", () => {
+      const brokenSkill = {
+        id: "broken",
+        name: "Broken",
+        description: "No tools array",
+        category: "general" as const,
+        config: {},
+        // tools omitted on purpose
+      } as unknown as Skill;
+
+      const wf: Workflow = {
+        id: "t",
+        name: "T",
+        description: "",
+        entry: "a",
+        nodes: { a: { name: "A", instruction: "Do A", skills: ["broken"] } },
+        edges: [],
+      };
+
+      expect(() => workflowToFlow(wf, [brokenSkill])).not.toThrow();
+      const { nodes } = workflowToFlow(wf, [brokenSkill]);
+      expect(nodes[0].data.skills[0].toolCount).toBe(0);
+    });
   });
 });
 

--- a/packages/core/src/studio.ts
+++ b/packages/core/src/studio.ts
@@ -92,7 +92,16 @@ export function workflowToFlow(
   const skillMap = new Map(skillCatalog.map((s) => [s.id, s]));
   const terminalIds = findTerminals(workflow);
 
-  const nodes: FlowNode[] = Object.entries(workflow.nodes).map(([id, node]) => ({
+  // Defensive: streaming LLM YAML (or user-authored partial workflows)
+  // can produce nodes with missing `skills` / workflows with missing
+  // `edges`. The types say these are required, but runtime data from
+  // untrusted sources frequently violates that. Rather than crash the
+  // viewer with "Cannot read properties of undefined (reading 'map')",
+  // treat them as empty and let the caller decide what to render.
+  const workflowNodes = workflow.nodes ?? {};
+  const workflowEdges = workflow.edges ?? [];
+
+  const nodes: FlowNode[] = Object.entries(workflowNodes).map(([id, node]) => ({
     id,
     type: "skillNode" as const,
     position: { x: 0, y: 0 }, // ELK will compute real positions
@@ -101,19 +110,19 @@ export function workflowToFlow(
       node,
       isEntry: id === workflow.entry,
       isTerminal: terminalIds.has(id),
-      skills: node.skills.map((sid) => {
+      skills: (node.skills ?? []).map((sid) => {
         const skill = skillMap.get(sid);
         return {
           id: sid,
           name: skill?.name ?? sid,
-          toolCount: skill?.tools.length ?? 0,
+          toolCount: skill?.tools?.length ?? 0,
         };
       }),
       exec: { status: "pending" },
     },
   }));
 
-  const edges: FlowEdge[] = workflow.edges.map((edge) => ({
+  const edges: FlowEdge[] = workflowEdges.map((edge) => ({
     id: `${edge.from}--${edge.to}`,
     source: edge.from,
     target: edge.to,
@@ -198,8 +207,8 @@ export function flowToWorkflow(
 // ─── Helpers ─────────────────────────────────────────────────────
 
 function findTerminals(workflow: Workflow): Set<string> {
-  const hasOutgoing = new Set(workflow.edges.map((e) => e.from));
-  return new Set(Object.keys(workflow.nodes).filter((id) => !hasOutgoing.has(id)));
+  const hasOutgoing = new Set((workflow.edges ?? []).map((e) => e.from));
+  return new Set(Object.keys(workflow.nodes ?? {}).filter((id) => !hasOutgoing.has(id)));
 }
 
 /**


### PR DESCRIPTION
## Summary

`workflowToFlow` crashed with `Cannot read properties of undefined (reading 'map')` when given a workflow whose `node.skills`, `workflow.edges`, or `workflow.nodes` fields were missing. The TypeScript types mark these as required, but runtime data from streaming LLM YAML (and user-authored workflows mid-edit) routinely violates that.

This hit the [marketplace.sweny.ai](https://marketplace.sweny.ai) site during live workflow generation — the viewer blew up and rendered a jarring inline-styled light-theme error panel on top of the dark UI. The marketplace wrapped the viewer in an error boundary and added a normalization step as a workaround, but the upstream library should not hand consumers a viewer that explodes on partial data.

## Changes

- `workflow.nodes ?? {}` in `Object.entries` and `findTerminals`
- `workflow.edges ?? []` in the edge map and `findTerminals`
- `node.skills ?? []` in the per-node skill map
- `skill?.tools?.length ?? 0` in case skill catalog entries are sparse
- 4 tests covering each defensive path

## Test plan

- [x] `npm test` in `packages/core` — 945 passed, 5 skipped (unchanged), 4 new tests added
- [x] `npm run build` in `packages/core` — clean
- [x] `npm run build:lib` in `packages/studio` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)