### PR TITLE
style(spec): apply prettier formatting to spec docs

### DIFF
--- a/spec/astro.config.mjs
+++ b/spec/astro.config.mjs
@@ -9,9 +9,7 @@ export default defineConfig({
       title: "SWEny Workflow Specification",
       description: "A declarative format for AI agent orchestration",
       favicon: "/favicon.svg",
-      head: [
-        { tag: "meta", attrs: { property: "og:type", content: "website" } },
-      ],
+      head: [{ tag: "meta", attrs: { property: "og:type", content: "website" } }],
       social: [
         { icon: "github", label: "GitHub", href: "https://github.com/swenyai/sweny" },
         { icon: "external", label: "Docs", href: "https://docs.sweny.ai" },

--- a/spec/src/content/docs/edges.mdx
+++ b/spec/src/content/docs/edges.mdx
@@ -7,12 +7,12 @@ Edges define the execution flow between [Nodes](/nodes) in a [Workflow](/workflo
 
 ## Fields
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `from` | string | REQUIRED | — | Source node ID. MUST reference a key in `nodes`. |
-| `to` | string | REQUIRED | — | Target node ID. MUST reference a key in `nodes`. |
-| `when` | string | OPTIONAL | — | Natural language routing condition. |
-| `max_iterations` | integer (&ge; 1) | OPTIONAL | unlimited | Maximum times this edge can be followed. |
+| Field            | Type             | Required | Default   | Description                                      |
+| ---------------- | ---------------- | -------- | --------- | ------------------------------------------------ |
+| `from`           | string           | REQUIRED | —         | Source node ID. MUST reference a key in `nodes`. |
+| `to`             | string           | REQUIRED | —         | Target node ID. MUST reference a key in `nodes`. |
+| `when`           | string           | OPTIONAL | —         | Natural language routing condition.              |
+| `max_iterations` | integer (&ge; 1) | OPTIONAL | unlimited | Maximum times this edge can be followed.         |
 
 ## Routing Algorithm
 

--- a/spec/src/content/docs/execution.mdx
+++ b/spec/src/content/docs/execution.mdx
@@ -41,18 +41,18 @@ For each node, a conforming executor MUST perform the following steps in order:
 
 The result of executing a single node.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | `"success"` \| `"skipped"` \| `"failed"` | Outcome of this node's execution. |
-| `data` | Record&lt;string, unknown&gt; | Output data. When the node has an `output` schema, this conforms to it. Available to downstream nodes via context. |
-| `toolCalls` | [ToolCall](#toolcall)[] | Record of tools invoked during execution. |
+| Field       | Type                                     | Description                                                                                                        |
+| ----------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `status`    | `"success"` \| `"skipped"` \| `"failed"` | Outcome of this node's execution.                                                                                  |
+| `data`      | Record&lt;string, unknown&gt;            | Output data. When the node has an `output` schema, this conforms to it. Available to downstream nodes via context. |
+| `toolCalls` | [ToolCall](#toolcall)[]                  | Record of tools invoked during execution.                                                                          |
 
 ### ToolCall
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `tool` | string | Tool name. |
-| `input` | unknown | Input passed to the tool. |
+| Field    | Type    | Description                                   |
+| -------- | ------- | --------------------------------------------- |
+| `tool`   | string  | Tool name.                                    |
+| `input`  | unknown | Input passed to the tool.                     |
 | `output` | unknown | Output returned by the tool. Absent on error. |
 
 ## Dry-Run Semantics
@@ -71,16 +71,16 @@ Unconditional edges are deterministic transitions (e.g., `gather` &rarr; `invest
 
 A conforming executor MUST emit the following events during execution. Events are delivered to an observer callback. If the observer throws, the executor MUST NOT crash — observer errors are silently swallowed.
 
-| Event Type | Payload | Emitted When |
-|------------|---------|--------------|
-| `workflow:start` | `{ workflow: string }` | Before the first node executes. |
-| `node:enter` | `{ node: string, instruction: string }` | Before a node begins execution. |
-| `tool:call` | `{ node: string, tool: string, input: unknown }` | Before a tool is invoked. |
-| `tool:result` | `{ node: string, tool: string, output: unknown }` | After a tool returns. |
-| `node:progress` | `{ node: string, message: string }` | During node execution (streaming status). |
-| `node:exit` | `{ node: string, result: NodeResult }` | After a node completes. |
-| `route` | `{ from: string, to: string, reason: string }` | After an edge is selected for routing. |
-| `workflow:end` | `{ results: Record<string, NodeResult> }` | After all execution is complete. |
+| Event Type       | Payload                                           | Emitted When                              |
+| ---------------- | ------------------------------------------------- | ----------------------------------------- |
+| `workflow:start` | `{ workflow: string }`                            | Before the first node executes.           |
+| `node:enter`     | `{ node: string, instruction: string }`           | Before a node begins execution.           |
+| `tool:call`      | `{ node: string, tool: string, input: unknown }`  | Before a tool is invoked.                 |
+| `tool:result`    | `{ node: string, tool: string, output: unknown }` | After a tool returns.                     |
+| `node:progress`  | `{ node: string, message: string }`               | During node execution (streaming status). |
+| `node:exit`      | `{ node: string, result: NodeResult }`            | After a node completes.                   |
+| `route`          | `{ from: string, to: string, reason: string }`    | After an edge is selected for routing.    |
+| `workflow:end`   | `{ results: Record<string, NodeResult> }`         | After all execution is complete.          |
 
 ### Event Ordering
 
@@ -99,28 +99,28 @@ A conforming executor MUST produce an `ExecutionTrace` after execution completes
 
 ### TraceStep
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `node` | string | Node ID. |
-| `status` | `"success"` \| `"failed"` \| `"skipped"` | Outcome. |
-| `iteration` | number | 1-based iteration count. `2` means this node executed a second time (via bounded cycle). |
+| Field       | Type                                     | Description                                                                              |
+| ----------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `node`      | string                                   | Node ID.                                                                                 |
+| `status`    | `"success"` \| `"failed"` \| `"skipped"` | Outcome.                                                                                 |
+| `iteration` | number                                   | 1-based iteration count. `2` means this node executed a second time (via bounded cycle). |
 
 ### TraceEdge
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `from` | string | Source node ID. |
-| `to` | string | Target node ID. |
+| Field    | Type   | Description                                                                                       |
+| -------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `from`   | string | Source node ID.                                                                                   |
+| `to`     | string | Target node ID.                                                                                   |
 | `reason` | string | Why this edge was followed — the `when` condition text, or `"only path"` for unconditional edges. |
 
 ### ExecutionResult
 
 The return value of a workflow execution.
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field     | Type                          | Description                                                                                                  |
+| --------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `results` | Map&lt;string, NodeResult&gt; | Final result per node. If a node executed multiple times (bounded cycle), this contains the **last** result. |
-| `trace` | ExecutionTrace | Ordered record of all steps and routing decisions. |
+| `trace`   | ExecutionTrace                | Ordered record of all steps and routing decisions.                                                           |
 
 ## Error Handling
 

--- a/spec/src/content/docs/index.mdx
+++ b/spec/src/content/docs/index.mdx
@@ -26,13 +26,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Specification
 
-| Section | Description |
-|---------|-------------|
-| [Workflow](/workflow) | Top-level document structure: `id`, `name`, `nodes`, `edges`, `entry`. |
-| [Nodes](/nodes) | The Node object: `instruction`, `skills`, `output` schema. |
-| [Edges & Routing](/edges) | The Edge object: `when` conditions, `max_iterations`, routing algorithm. |
-| [Skills & Tools](/skills) | Skill and Tool interfaces: config resolution, tool invocation contract. |
-| [Execution Model](/execution) | Context accumulation, node execution, events, trace, dry-run semantics. |
+| Section                       | Description                                                              |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| [Workflow](/workflow)         | Top-level document structure: `id`, `name`, `nodes`, `edges`, `entry`.   |
+| [Nodes](/nodes)               | The Node object: `instruction`, `skills`, `output` schema.               |
+| [Edges & Routing](/edges)     | The Edge object: `when` conditions, `max_iterations`, routing algorithm. |
+| [Skills & Tools](/skills)     | Skill and Tool interfaces: config resolution, tool invocation contract.  |
+| [Execution Model](/execution) | Context accumulation, node execution, events, trace, dry-run semantics.  |
 
 ## Machine-Readable Schemas
 

--- a/spec/src/content/docs/nodes.mdx
+++ b/spec/src/content/docs/nodes.mdx
@@ -7,12 +7,12 @@ A Node represents a single step in a [Workflow](/workflow). Each node contains a
 
 ## Fields
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `name` | string | REQUIRED | — | Display name for this node. MUST be non-empty. |
-| `instruction` | string | REQUIRED | — | Natural language instruction for the AI model. MUST be non-empty. |
-| `skills` | string[] | OPTIONAL | `[]` | Skill IDs this node has access to. |
-| `output` | JSON Schema object | OPTIONAL | — | Structured output schema for this node's result. |
+| Field         | Type               | Required | Default | Description                                                       |
+| ------------- | ------------------ | -------- | ------- | ----------------------------------------------------------------- |
+| `name`        | string             | REQUIRED | —       | Display name for this node. MUST be non-empty.                    |
+| `instruction` | string             | REQUIRED | —       | Natural language instruction for the AI model. MUST be non-empty. |
+| `skills`      | string[]           | OPTIONAL | `[]`    | Skill IDs this node has access to.                                |
+| `output`      | JSON Schema object | OPTIONAL | —       | Structured output schema for this node's result.                  |
 
 ## Instruction Semantics
 

--- a/spec/src/content/docs/skills.mdx
+++ b/spec/src/content/docs/skills.mdx
@@ -7,36 +7,36 @@ A Skill is a composable bundle of tools that provides capabilities to [Nodes](/n
 
 ## Skill Object
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | REQUIRED | Unique identifier. Referenced by node `skills` arrays. MUST be non-empty. |
-| `name` | string | REQUIRED | Human-readable name. |
-| `description` | string | REQUIRED | What this skill provides. |
-| `category` | [SkillCategory](#skill-categories) | REQUIRED | Functional category. |
-| `config` | Record&lt;string, [ConfigField](#config-field-object)&gt; | REQUIRED | Configuration fields required by this skill. |
-| `tools` | [Tool](#tool-object)[] | REQUIRED | Tools this skill provides to nodes. |
+| Field         | Type                                                      | Required | Description                                                               |
+| ------------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `id`          | string                                                    | REQUIRED | Unique identifier. Referenced by node `skills` arrays. MUST be non-empty. |
+| `name`        | string                                                    | REQUIRED | Human-readable name.                                                      |
+| `description` | string                                                    | REQUIRED | What this skill provides.                                                 |
+| `category`    | [SkillCategory](#skill-categories)                        | REQUIRED | Functional category.                                                      |
+| `config`      | Record&lt;string, [ConfigField](#config-field-object)&gt; | REQUIRED | Configuration fields required by this skill.                              |
+| `tools`       | [Tool](#tool-object)[]                                    | REQUIRED | Tools this skill provides to nodes.                                       |
 
 ## Skill Categories
 
 The `category` field classifies a skill's function. Valid values:
 
-| Category | Description |
-|----------|-------------|
-| `git` | Source control operations (commits, PRs, code search). |
-| `observability` | Error tracking, logs, metrics, incident management. |
-| `tasks` | Issue tracking and project management. |
-| `notification` | Messaging and alerting. |
-| `general` | Catch-all for skills that don't fit other categories. |
+| Category        | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `git`           | Source control operations (commits, PRs, code search). |
+| `observability` | Error tracking, logs, metrics, incident management.    |
+| `tasks`         | Issue tracking and project management.                 |
+| `notification`  | Messaging and alerting.                                |
+| `general`       | Catch-all for skills that don't fit other categories.  |
 
 ## Config Field Object
 
 Each entry in a skill's `config` map declares a configuration value the skill needs.
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `description` | string | REQUIRED | — | Human-readable description of this config field. |
-| `required` | boolean | OPTIONAL | `false` | Whether this field must be provided for the skill to function. |
-| `env` | string | OPTIONAL | — | Default environment variable name to read this value from. |
+| Field         | Type    | Required | Default | Description                                                    |
+| ------------- | ------- | -------- | ------- | -------------------------------------------------------------- |
+| `description` | string  | REQUIRED | —       | Human-readable description of this config field.               |
+| `required`    | boolean | OPTIONAL | `false` | Whether this field must be provided for the skill to function. |
+| `env`         | string  | OPTIONAL | —       | Default environment variable name to read this value from.     |
 
 ### Config Resolution
 
@@ -49,12 +49,12 @@ If a required config field cannot be resolved from either source, the skill MUST
 
 ## Tool Object
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | REQUIRED | Tool name. MUST be unique within the skill. |
-| `description` | string | REQUIRED | What this tool does. Provided to the AI model for tool selection. |
-| `input_schema` | JSON Schema object | REQUIRED | JSON Schema defining the tool's input parameters. |
-| `handler` | function | REQUIRED (runtime) | Implementation-defined. Receives validated input and a context object. Not serialized. |
+| Field          | Type               | Required           | Description                                                                            |
+| -------------- | ------------------ | ------------------ | -------------------------------------------------------------------------------------- |
+| `name`         | string             | REQUIRED           | Tool name. MUST be unique within the skill.                                            |
+| `description`  | string             | REQUIRED           | What this tool does. Provided to the AI model for tool selection.                      |
+| `input_schema` | JSON Schema object | REQUIRED           | JSON Schema defining the tool's input parameters.                                      |
+| `handler`      | function           | REQUIRED (runtime) | Implementation-defined. Receives validated input and a context object. Not serialized. |
 
 ### Tool Invocation Contract
 
@@ -69,16 +69,16 @@ A conforming executor:
 
 The specification defines the following well-known skill IDs. Implementations SHOULD support these when the required config is available. Implementations MAY support additional skills beyond this registry.
 
-| ID | Category | Required Config | Description |
-|----|----------|-----------------|-------------|
-| `github` | git | `GITHUB_TOKEN` | GitHub code search, issues, pull requests. |
-| `linear` | tasks | `LINEAR_API_KEY` | Linear issue tracking. |
-| `slack` | notification | `SLACK_WEBHOOK_URL` | Slack messaging. |
-| `sentry` | observability | `SENTRY_AUTH_TOKEN` | Sentry error tracking. |
-| `datadog` | observability | `DD_API_KEY`, `DD_APP_KEY` | Datadog logs and metrics. |
-| `betterstack` | observability | `BETTERSTACK_API_TOKEN` | BetterStack incident management. |
-| `notification` | notification | varies | Multi-channel notifications. |
-| `supabase` | general | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | Supabase database operations. |
+| ID             | Category      | Required Config                             | Description                                |
+| -------------- | ------------- | ------------------------------------------- | ------------------------------------------ |
+| `github`       | git           | `GITHUB_TOKEN`                              | GitHub code search, issues, pull requests. |
+| `linear`       | tasks         | `LINEAR_API_KEY`                            | Linear issue tracking.                     |
+| `slack`        | notification  | `SLACK_WEBHOOK_URL`                         | Slack messaging.                           |
+| `sentry`       | observability | `SENTRY_AUTH_TOKEN`                         | Sentry error tracking.                     |
+| `datadog`      | observability | `DD_API_KEY`, `DD_APP_KEY`                  | Datadog logs and metrics.                  |
+| `betterstack`  | observability | `BETTERSTACK_API_TOKEN`                     | BetterStack incident management.           |
+| `notification` | notification  | varies                                      | Multi-channel notifications.               |
+| `supabase`     | general       | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | Supabase database operations.              |
 
 ## Example
 

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -7,14 +7,14 @@ A Workflow is the top-level document. It defines a directed graph of [Nodes](/no
 
 ## Fields
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `id` | string | REQUIRED | — | Unique identifier for this workflow. MUST be non-empty. |
-| `name` | string | REQUIRED | — | Human-readable name. MUST be non-empty. |
-| `description` | string | OPTIONAL | `""` | Purpose of the workflow. |
-| `entry` | string | REQUIRED | — | Node ID where execution begins. MUST reference a key in `nodes`. |
-| `nodes` | Record&lt;string, [Node](/nodes)&gt; | REQUIRED | — | Map of node ID to Node definition. Keys are referenced by `entry` and edge `from`/`to` fields. |
-| `edges` | [Edge](/edges)[] | REQUIRED | — | Directed edges defining execution flow and routing conditions. |
+| Field         | Type                                 | Required | Default | Description                                                                                    |
+| ------------- | ------------------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `id`          | string                               | REQUIRED | —       | Unique identifier for this workflow. MUST be non-empty.                                        |
+| `name`        | string                               | REQUIRED | —       | Human-readable name. MUST be non-empty.                                                        |
+| `description` | string                               | OPTIONAL | `""`    | Purpose of the workflow.                                                                       |
+| `entry`       | string                               | REQUIRED | —       | Node ID where execution begins. MUST reference a key in `nodes`.                               |
+| `nodes`       | Record&lt;string, [Node](/nodes)&gt; | REQUIRED | —       | Map of node ID to Node definition. Keys are referenced by `entry` and edge `from`/`to` fields. |
+| `edges`       | [Edge](/edges)[]                     | REQUIRED | —       | Directed edges defining execution flow and routing conditions.                                 |
 
 ## Structural Validation
 
@@ -29,15 +29,15 @@ A conforming validator MUST enforce the following rules:
 
 ## Error Codes
 
-| Code | Description |
-|------|-------------|
-| `MISSING_ENTRY` | `entry` does not reference an existing node. |
+| Code                  | Description                                    |
+| --------------------- | ---------------------------------------------- |
+| `MISSING_ENTRY`       | `entry` does not reference an existing node.   |
 | `UNKNOWN_EDGE_SOURCE` | An edge `from` references a non-existent node. |
-| `UNKNOWN_EDGE_TARGET` | An edge `to` references a non-existent node. |
-| `UNREACHABLE_NODE` | A node is not reachable from `entry`. |
-| `SELF_LOOP` | A self-loop edge lacks `max_iterations`. |
-| `UNBOUNDED_CYCLE` | A cycle exists with no `max_iterations` guard. |
-| `UNKNOWN_SKILL` | A node references a skill not in the registry. |
+| `UNKNOWN_EDGE_TARGET` | An edge `to` references a non-existent node.   |
+| `UNREACHABLE_NODE`    | A node is not reachable from `entry`.          |
+| `SELF_LOOP`           | A self-loop edge lacks `max_iterations`.       |
+| `UNBOUNDED_CYCLE`     | A cycle exists with no `max_iterations` guard. |
+| `UNKNOWN_SKILL`       | A node references a skill not in the registry. |
 
 ## Minimal Example
 


### PR DESCRIPTION
CI format:check was failing because the spec/ Astro docs site
was added without prettier formatting, causing the CI badge to
show red on the README.

https://claude.ai/code/session_01GFG563BXAU5ebmmGZXDm5j