### PR TITLE
fix: default observability provider to 'none' instead of 'datadog'

### DIFF
--- a/packages/core/src/cli/config.test.ts
+++ b/packages/core/src/cli/config.test.ts
@@ -125,6 +125,31 @@ describe("validateInputs — notification provider", () => {
   });
 });
 
+describe("validateInputs — observability provider", () => {
+  it("accepts 'none' without requiring any credentials", () => {
+    const errors = validateInputs(baseConfig({ observabilityProvider: "none", observabilityCredentials: {} }));
+    expect(errors.filter((e) => e.includes("DD_") || e.includes("observability"))).toEqual([]);
+  });
+
+  it("requires DD keys when explicitly set to datadog", () => {
+    const errors = validateInputs(baseConfig({ observabilityProvider: "datadog", observabilityCredentials: {} }));
+    expect(errors.some((e) => e.includes("DD_API_KEY"))).toBe(true);
+    expect(errors.some((e) => e.includes("DD_APP_KEY"))).toBe(true);
+  });
+});
+
+describe("parseCliInputs — observability provider default", () => {
+  it("defaults to 'none' when no provider is configured", () => {
+    const config = parseCliInputs({}, {});
+    expect(config.observabilityProvider).toBe("none");
+  });
+
+  it("respects explicit datadog provider", () => {
+    const config = parseCliInputs({ observabilityProvider: "datadog" }, {});
+    expect(config.observabilityProvider).toBe("datadog");
+  });
+});
+
 describe("fetch.auth + offline parsing", () => {
   it("parses offline flag", () => {
     const config = parseCliInputs({ offline: true }, {});

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -117,7 +117,7 @@ export function registerTriageCommand(program: Command): Command {
     .description("Run the SWEny triage workflow")
     .option("--agent <provider>", "Coding agent: claude (default), codex, gemini")
     .option("--coding-agent-provider <provider>", "Coding agent provider (alias for --agent)")
-    .option("--observability-provider <provider>", "Observability provider (default: datadog)")
+    .option("--observability-provider <provider>", "Observability provider (default: none)")
     .option("--issue-tracker-provider <provider>", "Issue tracker provider (default: github-issues)")
     .option("--source-control-provider <provider>", "Source control provider (default: github)")
     .option(
@@ -208,7 +208,7 @@ export function parseCliInputs(options: Record<string, unknown>, fileConfig: Fil
     return [];
   };
 
-  const obsProvider = (options.observabilityProvider as string) || f("observability-provider") || "datadog";
+  const obsProvider = (options.observabilityProvider as string) || f("observability-provider") || "none";
 
   return {
     codingAgentProvider:
@@ -378,6 +378,8 @@ export function validateInputs(config: CliConfig): string[] {
 
   // Observability credentials by provider
   switch (config.observabilityProvider) {
+    case "none":
+      break; // No observability provider configured — nothing to validate
     case "datadog":
       if (!config.observabilityCredentials.apiKey)
         errors.push("Missing: DD_API_KEY — find API keys at https://app.datadoghq.com/organization-settings/api-keys");
@@ -495,7 +497,7 @@ export function validateInputs(config: CliConfig): string[] {
       break;
     default:
       errors.push(
-        `Unknown --observability-provider "${config.observabilityProvider}". Valid values: datadog, sentry, cloudwatch, splunk, elastic, newrelic, loki, prometheus, pagerduty, honeycomb, heroku, opsgenie, axiom, betterstack, vercel, supabase, netlify, fly, render, file`,
+        `Unknown --observability-provider "${config.observabilityProvider}". Valid values: none, datadog, sentry, cloudwatch, splunk, elastic, newrelic, loki, prometheus, pagerduty, honeycomb, heroku, opsgenie, axiom, betterstack, vercel, supabase, netlify, fly, render, file`,
       );
   }
 


### PR DESCRIPTION
## Summary

- Default `--observability-provider` changed from `"datadog"` to `"none"`
- Added `"none"` case to `validateInputs()` switch (no credentials required)
- Updated help text and error message to include `"none"` as a valid value

## Problem

When no observability provider is explicitly configured, the default was `"datadog"`, which caused `sweny check` to fail with:

```
Missing: DD_API_KEY
Missing: DD_APP_KEY
```

This is wrong for any user running workflows that don't use observability skills (which is most workflow-only users). Observability should be opt-in, not opt-out.

## Test plan

- [x] New tests: `"none"` accepted without credentials, `"datadog"` still requires DD keys when explicit
- [x] New tests: `parseCliInputs` defaults to `"none"`, respects explicit `"datadog"`
- [x] All 53 config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)