### PR TITLE
fix: skill config parsing, validation, and credential derivation

### DIFF
--- a/packages/core/src/__tests__/custom-loader.test.ts
+++ b/packages/core/src/__tests__/custom-loader.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReaddirSync = vi.mocked(readdirSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+// Import after mocking
+const { discoverSkills } = await import("../skills/custom-loader.js");
+
+describe("custom-loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("config parsing from SKILL.md frontmatter", () => {
+    it("parses config fields from frontmatter", () => {
+      const skillMd = `---
+name: tax-tool
+description: Processes tax filings
+config:
+  MY_TAX_API_KEY:
+    description: API key for the tax service
+    required: true
+  MY_TAX_REGION:
+    description: Tax region code
+    required: false
+---
+Do tax stuff.
+`;
+
+      mockedExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        return s.endsWith(".sweny/skills") || s.endsWith("tax-tool/SKILL.md");
+      });
+      mockedReaddirSync.mockReturnValue([{ name: "tax-tool", isDirectory: () => true } as any]);
+      mockedReadFileSync.mockReturnValue(skillMd);
+
+      const skills = discoverSkills("/fake");
+      expect(skills).toHaveLength(1);
+      const skill = skills[0];
+
+      expect(skill.id).toBe("tax-tool");
+      expect(skill.config).toEqual({
+        MY_TAX_API_KEY: {
+          description: "API key for the tax service",
+          required: true,
+          env: "MY_TAX_API_KEY",
+        },
+        MY_TAX_REGION: {
+          description: "Tax region code",
+          required: false,
+          env: "MY_TAX_REGION",
+        },
+      });
+    });
+
+    it("produces config: {} when no config block in frontmatter", () => {
+      const skillMd = `---
+name: simple-skill
+description: A simple skill
+---
+Instructions here.
+`;
+
+      mockedExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        return s.endsWith(".sweny/skills") || s.endsWith("simple-skill/SKILL.md");
+      });
+      mockedReaddirSync.mockReturnValue([{ name: "simple-skill", isDirectory: () => true } as any]);
+      mockedReadFileSync.mockReturnValue(skillMd);
+
+      const skills = discoverSkills("/fake");
+      expect(skills).toHaveLength(1);
+      expect(skills[0].config).toEqual({});
+    });
+
+    it("sets env field to the key name automatically", () => {
+      const skillMd = `---
+name: my-api
+description: API skill
+config:
+  CUSTOM_API_TOKEN:
+    description: Token for the API
+    required: true
+---
+Use the API.
+`;
+
+      mockedExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        return s.endsWith(".sweny/skills") || s.endsWith("my-api/SKILL.md");
+      });
+      mockedReaddirSync.mockReturnValue([{ name: "my-api", isDirectory: () => true } as any]);
+      mockedReadFileSync.mockReturnValue(skillMd);
+
+      const skills = discoverSkills("/fake");
+      expect(skills[0].config.CUSTOM_API_TOKEN.env).toBe("CUSTOM_API_TOKEN");
+    });
+
+    it("handles config entries with missing description gracefully", () => {
+      const skillMd = `---
+name: sparse-config
+description: Sparse config skill
+config:
+  SOME_KEY:
+    required: true
+---
+Body.
+`;
+
+      mockedExistsSync.mockImplementation((p) => {
+        const s = String(p);
+        return s.endsWith(".sweny/skills") || s.endsWith("sparse-config/SKILL.md");
+      });
+      mockedReaddirSync.mockReturnValue([{ name: "sparse-config", isDirectory: () => true } as any]);
+      mockedReadFileSync.mockReturnValue(skillMd);
+
+      const skills = discoverSkills("/fake");
+      expect(skills).toHaveLength(1);
+      // Falls back to key name as description
+      expect(skills[0].config.SOME_KEY.description).toBe("SOME_KEY");
+      expect(skills[0].config.SOME_KEY.required).toBe(true);
+      expect(skills[0].config.SOME_KEY.env).toBe("SOME_KEY");
+    });
+  });
+});

--- a/packages/core/src/__tests__/publish.test.ts
+++ b/packages/core/src/__tests__/publish.test.ts
@@ -62,6 +62,48 @@ edges: []
     expect(result.valid).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
   });
+
+  it("rejects a workflow with unknown skill references", () => {
+    const file = path.join(tmpDir, "unknown-skill.yml");
+    fs.writeFileSync(
+      file,
+      `id: unknown-skill-test
+name: Unknown Skill Test
+description: Test
+entry: start
+nodes:
+  start:
+    name: Start
+    instruction: Do something.
+    skills: [unicorn]
+edges: []
+`,
+    );
+    const result = validateWorkflowFile(file);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unicorn"))).toBe(true);
+  });
+
+  it("returns config warnings for skills with required env vars", () => {
+    const file = path.join(tmpDir, "with-github.yml");
+    fs.writeFileSync(
+      file,
+      `id: github-test
+name: GitHub Test
+description: Test
+entry: start
+nodes:
+  start:
+    name: Start
+    instruction: Do something.
+    skills: [github]
+edges: []
+`,
+    );
+    const result = validateWorkflowFile(file);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("GITHUB_TOKEN"))).toBe(true);
+  });
 });
 
 describe("validateSkillDir", () => {

--- a/packages/core/src/__tests__/skill-config-integration.test.ts
+++ b/packages/core/src/__tests__/skill-config-integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Integration tests validating the skill config system end-to-end:
+ * - Every builtin skill has a non-empty config
+ * - Config fields have correct structure (description, required, env)
+ * - deriveWorkflowVariables produces correct output for real skills
+ * - collectCredentialsForSkills works with real builtins
+ * - Custom skill config merge works correctly
+ * - publish validation catches real problems
+ */
+import { describe, it, expect } from "vitest";
+import { builtinSkills } from "../skills/index.js";
+import { deriveWorkflowVariables } from "../workflow-builder.js";
+import { collectCredentialsForSkills } from "../cli/new.js";
+import type { Workflow, ConfigField, Skill } from "../types.js";
+
+// ── Builtin skill config completeness ────────────────────────────────
+
+describe("builtin skill config completeness", () => {
+  const SKILLS_WITH_CONFIG = [
+    "github",
+    "linear",
+    "slack",
+    "sentry",
+    "datadog",
+    "betterstack",
+    "notification",
+    "supabase",
+  ];
+
+  it("all expected skills exist in builtinSkills", () => {
+    const ids = builtinSkills.map((s) => s.id);
+    for (const expected of SKILLS_WITH_CONFIG) {
+      expect(ids, `missing builtin skill: ${expected}`).toContain(expected);
+    }
+  });
+
+  it("every builtin skill has at least one config field", () => {
+    for (const skill of builtinSkills) {
+      if (!SKILLS_WITH_CONFIG.includes(skill.id)) continue;
+      expect(Object.keys(skill.config).length, `${skill.id} should have config fields`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every config field has description, required boolean, and env string", () => {
+    for (const skill of builtinSkills) {
+      for (const [key, field] of Object.entries(skill.config)) {
+        expect(typeof field.description, `${skill.id}.${key}.description`).toBe("string");
+        expect(field.description.length, `${skill.id}.${key}.description is empty`).toBeGreaterThan(0);
+        expect(typeof field.required, `${skill.id}.${key}.required`).toBe("boolean");
+        expect(typeof field.env, `${skill.id}.${key}.env`).toBe("string");
+        expect(field.env, `${skill.id}.${key}.env should match key`).toBe(key);
+      }
+    }
+  });
+
+  it("github has GITHUB_TOKEN as required", () => {
+    const github = builtinSkills.find((s) => s.id === "github")!;
+    expect(github.config.GITHUB_TOKEN).toBeDefined();
+    expect(github.config.GITHUB_TOKEN.required).toBe(true);
+  });
+
+  it("sentry has SENTRY_AUTH_TOKEN, SENTRY_ORG (required) and SENTRY_BASE_URL (optional)", () => {
+    const sentry = builtinSkills.find((s) => s.id === "sentry")!;
+    expect(sentry.config.SENTRY_AUTH_TOKEN.required).toBe(true);
+    expect(sentry.config.SENTRY_ORG.required).toBe(true);
+    expect(sentry.config.SENTRY_BASE_URL.required).toBe(false);
+  });
+
+  it("datadog has DD_API_KEY, DD_APP_KEY (required) and DD_SITE (optional)", () => {
+    const dd = builtinSkills.find((s) => s.id === "datadog")!;
+    expect(dd.config.DD_API_KEY.required).toBe(true);
+    expect(dd.config.DD_APP_KEY.required).toBe(true);
+    expect(dd.config.DD_SITE.required).toBe(false);
+  });
+
+  it("betterstack has 4 required config fields", () => {
+    const bs = builtinSkills.find((s) => s.id === "betterstack")!;
+    expect(Object.keys(bs.config)).toHaveLength(4);
+    expect(bs.config.BETTERSTACK_API_TOKEN.required).toBe(true);
+    expect(bs.config.BETTERSTACK_QUERY_ENDPOINT.required).toBe(true);
+    expect(bs.config.BETTERSTACK_QUERY_USERNAME.required).toBe(true);
+    expect(bs.config.BETTERSTACK_QUERY_PASSWORD.required).toBe(true);
+  });
+
+  it("notification has all optional config fields", () => {
+    const notif = builtinSkills.find((s) => s.id === "notification")!;
+    for (const field of Object.values(notif.config)) {
+      expect(field.required).toBe(false);
+    }
+  });
+});
+
+// ── deriveWorkflowVariables integration ──────────────────────────────
+
+describe("deriveWorkflowVariables with real builtins", () => {
+  const makeWorkflow = (skills: string[]): Workflow => ({
+    id: "test",
+    name: "test",
+    description: "test",
+    entry: "step1",
+    nodes: { step1: { name: "Step 1", instruction: "do it", skills } },
+    edges: [],
+  });
+
+  it("produces ANTHROPIC_API_KEY + all github config fields", () => {
+    const vars = deriveWorkflowVariables(makeWorkflow(["github"]), builtinSkills);
+    const names = vars.map((v) => v.name);
+    expect(names[0]).toBe("ANTHROPIC_API_KEY");
+    expect(names).toContain("GITHUB_TOKEN");
+  });
+
+  it("handles multi-skill workflow correctly", () => {
+    const vars = deriveWorkflowVariables(makeWorkflow(["github", "sentry", "slack"]), builtinSkills);
+    const names = vars.map((v) => v.name);
+    expect(names).toContain("GITHUB_TOKEN");
+    expect(names).toContain("SENTRY_AUTH_TOKEN");
+    expect(names).toContain("SENTRY_ORG");
+    expect(names).toContain("SENTRY_BASE_URL");
+    expect(names).toContain("SLACK_WEBHOOK_URL");
+    expect(names).toContain("SLACK_BOT_TOKEN");
+  });
+
+  it("deduplicates when same skill appears in multiple nodes", () => {
+    const workflow: Workflow = {
+      id: "test",
+      name: "test",
+      description: "test",
+      entry: "a",
+      nodes: {
+        a: { name: "A", instruction: "a", skills: ["github"] },
+        b: { name: "B", instruction: "b", skills: ["github"] },
+      },
+      edges: [{ from: "a", to: "b" }],
+    };
+    const vars = deriveWorkflowVariables(workflow, builtinSkills);
+    const tokenVars = vars.filter((v) => v.name === "GITHUB_TOKEN");
+    expect(tokenVars).toHaveLength(1);
+  });
+
+  it("tracks skill attribution correctly", () => {
+    const vars = deriveWorkflowVariables(makeWorkflow(["github", "sentry"]), builtinSkills);
+    expect(vars.find((v) => v.name === "GITHUB_TOKEN")?.skill).toBe("github");
+    expect(vars.find((v) => v.name === "SENTRY_AUTH_TOKEN")?.skill).toBe("sentry");
+  });
+
+  it("marks required/optional correctly", () => {
+    const vars = deriveWorkflowVariables(makeWorkflow(["sentry"]), builtinSkills);
+    expect(vars.find((v) => v.name === "SENTRY_AUTH_TOKEN")?.required).toBe(true);
+    expect(vars.find((v) => v.name === "SENTRY_BASE_URL")?.required).toBe(false);
+  });
+});
+
+// ── collectCredentialsForSkills integration ──────────────────────────
+
+describe("collectCredentialsForSkills with real builtins", () => {
+  it("always includes ANTHROPIC_API_KEY first", () => {
+    const creds = collectCredentialsForSkills(["github"], builtinSkills);
+    expect(creds[0].key).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("derives credentials from skill.config when availableSkills provided", () => {
+    const creds = collectCredentialsForSkills(["github"], builtinSkills);
+    expect(creds.some((c) => c.key === "GITHUB_TOKEN")).toBe(true);
+  });
+
+  it("includes all betterstack credentials", () => {
+    const creds = collectCredentialsForSkills(["betterstack"], builtinSkills);
+    const keys = creds.map((c) => c.key);
+    expect(keys).toContain("BETTERSTACK_API_TOKEN");
+    expect(keys).toContain("BETTERSTACK_QUERY_ENDPOINT");
+    expect(keys).toContain("BETTERSTACK_QUERY_USERNAME");
+    expect(keys).toContain("BETTERSTACK_QUERY_PASSWORD");
+  });
+
+  it("deduplicates across multiple skills", () => {
+    const creds = collectCredentialsForSkills(["github", "github"], builtinSkills);
+    const tokenCreds = creds.filter((c) => c.key === "GITHUB_TOKEN");
+    expect(tokenCreds).toHaveLength(1);
+  });
+
+  it("falls back to SKILL_CREDENTIALS for unknown skills", () => {
+    // "gitlab" isn't in builtinSkills but is in SKILL_CREDENTIALS
+    const creds = collectCredentialsForSkills(["gitlab"], builtinSkills);
+    expect(creds.some((c) => c.key === "GITLAB_TOKEN")).toBe(true);
+  });
+});
+
+// ── Custom skill config merge ────────────────────────────────────────
+
+describe("custom skill config merge", () => {
+  it("custom skill config fields are preserved in deriveWorkflowVariables", () => {
+    const customSkill: Skill = {
+      id: "my-tax-tool",
+      name: "Tax Tool",
+      description: "Tax processing",
+      category: "general",
+      config: {
+        TAX_API_KEY: { description: "Tax service API key", required: true, env: "TAX_API_KEY" },
+      },
+      tools: [],
+    };
+
+    const workflow: Workflow = {
+      id: "test",
+      name: "test",
+      description: "test",
+      entry: "start",
+      nodes: { start: { name: "Start", instruction: "process", skills: ["my-tax-tool"] } },
+      edges: [],
+    };
+
+    const vars = deriveWorkflowVariables(workflow, [customSkill]);
+    expect(vars.find((v) => v.name === "TAX_API_KEY")).toBeDefined();
+    expect(vars.find((v) => v.name === "TAX_API_KEY")?.skill).toBe("my-tax-tool");
+    expect(vars.find((v) => v.name === "TAX_API_KEY")?.required).toBe(true);
+  });
+
+  it("collectCredentialsForSkills works with custom skills", () => {
+    const customSkill: Skill = {
+      id: "my-db",
+      name: "DB",
+      description: "Database",
+      category: "general",
+      config: {
+        DB_URL: { description: "Database URL", required: true, env: "DB_URL" },
+      },
+      tools: [],
+    };
+
+    const creds = collectCredentialsForSkills(["my-db"], [customSkill]);
+    expect(creds.some((c) => c.key === "DB_URL")).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/workflow-builder.test.ts
+++ b/packages/core/src/__tests__/workflow-builder.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt, deriveWorkflowVariables } from "../workflow-builder.js";
+import type { Skill, Workflow } from "../types.js";
+
+const fakeSkill = (id: string, config: Skill["config"] = {}): Skill => ({
+  id,
+  name: id,
+  description: `${id} skill`,
+  category: "general",
+  config,
+  tools: [],
+});
+
+describe("buildSystemPrompt", () => {
+  it("includes config fields in the skill list", () => {
+    const skills = [
+      fakeSkill("github", {
+        GITHUB_TOKEN: { description: "GitHub token", required: true, env: "GITHUB_TOKEN" },
+      }),
+    ];
+    const prompt = buildSystemPrompt(skills);
+    expect(prompt).toContain("- github: github skill");
+    expect(prompt).toContain("Config: GITHUB_TOKEN (required)");
+  });
+
+  it("shows optional config fields", () => {
+    const skills = [
+      fakeSkill("slack", {
+        SLACK_WEBHOOK_URL: { description: "Webhook URL", required: false, env: "SLACK_WEBHOOK_URL" },
+        SLACK_BOT_TOKEN: { description: "Bot token", required: false, env: "SLACK_BOT_TOKEN" },
+      }),
+    ];
+    const prompt = buildSystemPrompt(skills);
+    expect(prompt).toContain("SLACK_WEBHOOK_URL (optional)");
+    expect(prompt).toContain("SLACK_BOT_TOKEN (optional)");
+  });
+
+  it("omits Config line for skills with no config", () => {
+    const skills = [fakeSkill("simple")];
+    const prompt = buildSystemPrompt(skills);
+    expect(prompt).toContain("- simple: simple skill");
+    expect(prompt).not.toContain("Config:");
+  });
+});
+
+describe("deriveWorkflowVariables", () => {
+  const workflow: Workflow = {
+    name: "test",
+    version: "1.0.0",
+    description: "test workflow",
+    entry: "gather",
+    nodes: {
+      gather: {
+        name: "Gather",
+        instruction: "gather data",
+        skills: ["github", "slack"],
+        edges: [],
+      },
+    },
+    edges: [],
+  };
+
+  it("always includes ANTHROPIC_API_KEY first", () => {
+    const vars = deriveWorkflowVariables(workflow, []);
+    expect(vars[0].name).toBe("ANTHROPIC_API_KEY");
+    expect(vars[0].required).toBe(true);
+  });
+
+  it("derives variables from referenced skills", () => {
+    const skills = [
+      fakeSkill("github", {
+        GITHUB_TOKEN: { description: "GitHub token", required: true, env: "GITHUB_TOKEN" },
+      }),
+      fakeSkill("slack", {
+        SLACK_WEBHOOK_URL: { description: "Webhook URL", required: false, env: "SLACK_WEBHOOK_URL" },
+      }),
+    ];
+    const vars = deriveWorkflowVariables(workflow, skills);
+    const names = vars.map((v) => v.name);
+    expect(names).toContain("GITHUB_TOKEN");
+    expect(names).toContain("SLACK_WEBHOOK_URL");
+  });
+
+  it("deduplicates env vars across skills", () => {
+    const multiNodeWorkflow: Workflow = {
+      ...workflow,
+      nodes: {
+        a: { name: "A", instruction: "a", skills: ["github"], edges: [] },
+        b: { name: "B", instruction: "b", skills: ["github"], edges: [] },
+      },
+    };
+    const skills = [
+      fakeSkill("github", {
+        GITHUB_TOKEN: { description: "GitHub token", required: true, env: "GITHUB_TOKEN" },
+      }),
+    ];
+    const vars = deriveWorkflowVariables(multiNodeWorkflow, skills);
+    const tokenCount = vars.filter((v) => v.name === "GITHUB_TOKEN").length;
+    expect(tokenCount).toBe(1);
+  });
+
+  it("skips skills not in the available list", () => {
+    const vars = deriveWorkflowVariables(workflow, []);
+    // Only ANTHROPIC_API_KEY
+    expect(vars).toHaveLength(1);
+  });
+
+  it("includes custom skills with config", () => {
+    const customWorkflow: Workflow = {
+      ...workflow,
+      nodes: { tax: { name: "Tax", instruction: "do taxes", skills: ["my-tax-tool"], edges: [] } },
+    };
+    const skills = [
+      fakeSkill("my-tax-tool", {
+        MY_TAX_KEY: { description: "Tax API key", required: true, env: "MY_TAX_KEY" },
+      }),
+    ];
+    const vars = deriveWorkflowVariables(customWorkflow, skills);
+    expect(vars.find((v) => v.name === "MY_TAX_KEY")).toBeDefined();
+    expect(vars.find((v) => v.name === "MY_TAX_KEY")?.skill).toBe("my-tax-tool");
+  });
+});

--- a/packages/core/src/__tests__/workflow-builder.test.ts
+++ b/packages/core/src/__tests__/workflow-builder.test.ts
@@ -45,8 +45,8 @@ describe("buildSystemPrompt", () => {
 
 describe("deriveWorkflowVariables", () => {
   const workflow: Workflow = {
+    id: "test",
     name: "test",
-    version: "1.0.0",
     description: "test workflow",
     entry: "gather",
     nodes: {
@@ -54,7 +54,6 @@ describe("deriveWorkflowVariables", () => {
         name: "Gather",
         instruction: "gather data",
         skills: ["github", "slack"],
-        edges: [],
       },
     },
     edges: [],
@@ -85,8 +84,8 @@ describe("deriveWorkflowVariables", () => {
     const multiNodeWorkflow: Workflow = {
       ...workflow,
       nodes: {
-        a: { name: "A", instruction: "a", skills: ["github"], edges: [] },
-        b: { name: "B", instruction: "b", skills: ["github"], edges: [] },
+        a: { name: "A", instruction: "a", skills: ["github"] },
+        b: { name: "B", instruction: "b", skills: ["github"] },
       },
     };
     const skills = [
@@ -108,7 +107,7 @@ describe("deriveWorkflowVariables", () => {
   it("includes custom skills with config", () => {
     const customWorkflow: Workflow = {
       ...workflow,
-      nodes: { tax: { name: "Tax", instruction: "do taxes", skills: ["my-tax-tool"], edges: [] } },
+      nodes: { tax: { name: "Tax", instruction: "do taxes", skills: ["my-tax-tool"] } },
     };
     const skills = [
       fakeSkill("my-tax-tool", {

--- a/packages/core/src/cli/new.test.ts
+++ b/packages/core/src/cli/new.test.ts
@@ -774,6 +774,45 @@ describe("collectCredentialsForSkills", () => {
     const creds = collectCredentialsForSkills(["datadog", "github"]);
     expect(creds[0].key).toBe("ANTHROPIC_API_KEY");
   });
+
+  it("derives credentials from skill.config when availableSkills provided", () => {
+    const fakeSkill = {
+      id: "my-tax-tool",
+      name: "my-tax-tool",
+      description: "Tax tool",
+      category: "general" as const,
+      config: {
+        MY_TAX_KEY: { description: "Tax API key", required: true, env: "MY_TAX_KEY" },
+        MY_TAX_REGION: { description: "Region code", required: false, env: "MY_TAX_REGION" },
+      },
+      tools: [],
+    };
+    const creds = collectCredentialsForSkills(["my-tax-tool"], [fakeSkill]);
+    const keys = creds.map((c) => c.key);
+    expect(keys).toContain("ANTHROPIC_API_KEY");
+    expect(keys).toContain("MY_TAX_KEY");
+    expect(keys).toContain("MY_TAX_REGION");
+  });
+
+  it("falls back to SKILL_CREDENTIALS when skill not in availableSkills", () => {
+    const creds = collectCredentialsForSkills(["github"], []);
+    const keys = creds.map((c) => c.key);
+    expect(keys).toContain("GITHUB_TOKEN");
+  });
+
+  it("uses SKILL_EXTRAS for url/hint when deriving from config", () => {
+    const githubSkill = {
+      id: "github",
+      name: "github",
+      description: "GitHub",
+      category: "git" as const,
+      config: { GITHUB_TOKEN: { description: "GitHub token", required: true, env: "GITHUB_TOKEN" } },
+      tools: [],
+    };
+    const creds = collectCredentialsForSkills(["github"], [githubSkill]);
+    const token = creds.find((c) => c.key === "GITHUB_TOKEN");
+    expect(token?.url).toBe("https://github.com/settings/tokens");
+  });
 });
 
 // ── extractSkillsFromYaml: block-style arrays + malformed input ───────

--- a/packages/core/src/cli/new.ts
+++ b/packages/core/src/cli/new.ts
@@ -78,8 +78,9 @@ export const SKILL_EXTRAS: Record<string, { url?: string; hint?: string; default
 };
 
 /**
- * @deprecated Use collectCredentialsForSkills with availableSkills param instead.
- * Kept for backward compatibility.
+ * Static fallback credential map, used when skill objects are unavailable.
+ * When availableSkills is provided, collectCredentialsForSkills derives
+ * credentials from skill.config instead.
  */
 export const SKILL_CREDENTIALS: Record<string, Credential[]> = {
   github: [{ key: "GITHUB_TOKEN", url: "https://github.com/settings/tokens", hint: "repo + issues scopes" }],

--- a/packages/core/src/cli/new.ts
+++ b/packages/core/src/cli/new.ts
@@ -16,8 +16,9 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { WORKFLOW_TEMPLATES, type WorkflowTemplate } from "./templates.js";
 import { buildWorkflow, refineWorkflow } from "../workflow-builder.js";
 import { ClaudeClient } from "../claude.js";
-import { consoleLogger } from "../types.js";
+import { consoleLogger, type Skill } from "../types.js";
 import { configuredSkills } from "../skills/custom-loader.js";
+import { builtinSkills } from "../skills/index.js";
 import { DagRenderer } from "./renderer.js";
 import { runE2eInit } from "./e2e.js";
 
@@ -44,26 +45,46 @@ export interface GitRemoteInfo {
   remote: string;
 }
 
-// ── Skill → Credential mapping ────────────────────────────────────────
+// ── Skill → Credential extras ─────────────────────────────────────────
 
 /**
- * Maps skill IDs (as used in workflow nodes) to the credentials they require.
- * When a workflow uses a skill, we collect only those credentials.
+ * Supplementary metadata (URLs, hints, defaults) for env vars.
+ * skill.config has description/required but not setup URLs or default values.
+ */
+export const SKILL_EXTRAS: Record<string, { url?: string; hint?: string; default?: string }> = {
+  GITHUB_TOKEN: { url: "https://github.com/settings/tokens", hint: "repo + issues scopes" },
+  GITLAB_TOKEN: { url: "https://gitlab.com/-/profile/personal_access_tokens", hint: "api scope" },
+  GITLAB_URL: { hint: "e.g. https://gitlab.com", default: "https://gitlab.com" },
+  DD_API_KEY: { url: "https://app.datadoghq.com/organization-settings", hint: "Organization Settings > API Keys" },
+  DD_APP_KEY: { hint: "Organization Settings > Application Keys" },
+  DD_SITE: { hint: "datadoghq.com, datadoghq.eu, etc.", default: "datadoghq.com" },
+  SENTRY_AUTH_TOKEN: { url: "https://sentry.io/settings/auth-tokens/" },
+  SENTRY_ORG: { hint: "sentry.io/organizations/slug/" },
+  BETTERSTACK_API_TOKEN: { url: "https://betterstack.com/docs/logs/api" },
+  NR_API_KEY: { url: "https://one.newrelic.com/api-keys" },
+  LINEAR_API_KEY: { url: "https://linear.app/settings/api" },
+  LINEAR_TEAM_ID: { hint: "Settings > Teams > copy ID from URL" },
+  JIRA_BASE_URL: { hint: "e.g. https://your-org.atlassian.net" },
+  JIRA_EMAIL: { hint: "your Atlassian account email" },
+  JIRA_API_TOKEN: { url: "https://id.atlassian.com/manage-profile/security/api-tokens" },
+  SLACK_BOT_TOKEN: { url: "https://api.slack.com/apps" },
+  SLACK_WEBHOOK_URL: { hint: "Incoming webhook URL" },
+  DISCORD_WEBHOOK_URL: { hint: "Server Settings > Integrations > Webhooks" },
+  NOTIFICATION_WEBHOOK_URL: { hint: "Your webhook endpoint URL" },
+  TEAMS_WEBHOOK_URL: { hint: "Channel > Connectors > Incoming Webhook" },
+  SUPABASE_URL: { hint: "Supabase project URL" },
+  SUPABASE_SERVICE_ROLE_KEY: { hint: "Settings > API > service_role key" },
+  BETTERSTACK_QUERY_ENDPOINT: { hint: "ClickHouse HTTP endpoint" },
+};
+
+/**
+ * @deprecated Use collectCredentialsForSkills with availableSkills param instead.
+ * Kept for backward compatibility.
  */
 export const SKILL_CREDENTIALS: Record<string, Credential[]> = {
-  github: [
-    {
-      key: "GITHUB_TOKEN",
-      url: "https://github.com/settings/tokens",
-      hint: "repo + issues scopes",
-    },
-  ],
+  github: [{ key: "GITHUB_TOKEN", url: "https://github.com/settings/tokens", hint: "repo + issues scopes" }],
   gitlab: [
-    {
-      key: "GITLAB_TOKEN",
-      hint: "api scope",
-      url: "https://gitlab.com/-/profile/personal_access_tokens",
-    },
+    { key: "GITLAB_TOKEN", hint: "api scope", url: "https://gitlab.com/-/profile/personal_access_tokens" },
     { key: "GITLAB_URL", hint: "e.g. https://gitlab.com", default: "https://gitlab.com" },
   ],
   datadog: [
@@ -76,36 +97,19 @@ export const SKILL_CREDENTIALS: Record<string, Credential[]> = {
     { key: "DD_SITE", hint: "datadoghq.com, datadoghq.eu, etc.", default: "datadoghq.com" },
   ],
   sentry: [
-    {
-      key: "SENTRY_AUTH_TOKEN",
-      url: "https://sentry.io/settings/auth-tokens/",
-    },
+    { key: "SENTRY_AUTH_TOKEN", url: "https://sentry.io/settings/auth-tokens/" },
     { key: "SENTRY_ORG", hint: "sentry.io/organizations/slug/" },
   ],
-  betterstack: [
-    {
-      key: "BETTERSTACK_API_TOKEN",
-      url: "https://betterstack.com/docs/logs/api",
-    },
-  ],
+  betterstack: [{ key: "BETTERSTACK_API_TOKEN", url: "https://betterstack.com/docs/logs/api" }],
   newrelic: [{ key: "NR_API_KEY", url: "https://one.newrelic.com/api-keys" }],
   linear: [
-    {
-      key: "LINEAR_API_KEY",
-      url: "https://linear.app/settings/api",
-    },
-    {
-      key: "LINEAR_TEAM_ID",
-      hint: "Settings > Teams > copy ID from URL",
-    },
+    { key: "LINEAR_API_KEY", url: "https://linear.app/settings/api" },
+    { key: "LINEAR_TEAM_ID", hint: "Settings > Teams > copy ID from URL" },
   ],
   jira: [
     { key: "JIRA_BASE_URL", hint: "e.g. https://your-org.atlassian.net" },
     { key: "JIRA_EMAIL", hint: "your Atlassian account email" },
-    {
-      key: "JIRA_API_TOKEN",
-      url: "https://id.atlassian.com/manage-profile/security/api-tokens",
-    },
+    { key: "JIRA_API_TOKEN", url: "https://id.atlassian.com/manage-profile/security/api-tokens" },
   ],
   slack: [{ key: "SLACK_BOT_TOKEN", url: "https://api.slack.com/apps" }],
   discord: [{ key: "DISCORD_WEBHOOK_URL", hint: "Server Settings > Integrations > Webhooks" }],
@@ -181,20 +185,46 @@ export function extractSkillsFromYaml(yaml: string): string[] {
 /**
  * Gather credentials required for a set of skills.
  * Always includes ANTHROPIC_API_KEY. Deduplicates by key name.
+ *
+ * When `availableSkills` is provided, derives credentials from each skill's
+ * `.config` fields (works for both builtins and custom skills from Task 01).
+ * Falls back to `SKILL_CREDENTIALS` for skills not found in the available set.
  */
-export function collectCredentialsForSkills(skills: string[]): Credential[] {
+export function collectCredentialsForSkills(skillIds: string[], availableSkills?: Skill[]): Credential[] {
   const seen = new Map<string, Credential>();
 
   for (const cred of ALWAYS_CREDENTIALS) {
     seen.set(cred.key, cred);
   }
 
-  for (const skill of skills) {
-    const creds = SKILL_CREDENTIALS[skill];
-    if (!creds) continue;
-    for (const cred of creds) {
-      if (!seen.has(cred.key)) {
-        seen.set(cred.key, cred);
+  const skillMap = new Map<string, Skill>();
+  if (availableSkills) {
+    for (const s of availableSkills) skillMap.set(s.id, s);
+  }
+
+  for (const id of skillIds) {
+    const skill = skillMap.get(id);
+    if (skill && Object.keys(skill.config).length > 0) {
+      // Derive from skill.config
+      for (const [envKey, field] of Object.entries(skill.config)) {
+        const key = field.env ?? envKey;
+        if (seen.has(key)) continue;
+        const extras = SKILL_EXTRAS[key];
+        seen.set(key, {
+          key,
+          hint: extras?.hint ?? field.description,
+          url: extras?.url,
+          default: extras?.default,
+        });
+      }
+    } else {
+      // Fallback to SKILL_CREDENTIALS for unknown skills or skills without config
+      const creds = SKILL_CREDENTIALS[id];
+      if (!creds) continue;
+      for (const cred of creds) {
+        if (!seen.has(cred.key)) {
+          seen.set(cred.key, cred);
+        }
       }
     }
   }
@@ -500,7 +530,7 @@ export async function runNew(): Promise<void> {
   const observability = inferObservability(workflowSkills);
 
   // Collect credentials for the workflow's skills (+ always ANTHROPIC_API_KEY)
-  const credentials = collectCredentialsForSkills(workflowSkills);
+  const credentials = collectCredentialsForSkills(workflowSkills, builtinSkills);
 
   // ── Step 3: Summary + confirm ───────────────────────────────────────
   const files: string[] = [];

--- a/packages/core/src/cli/new.ts
+++ b/packages/core/src/cli/new.ts
@@ -488,6 +488,13 @@ export async function runNew(): Promise<void> {
     p.log.info(`Detected: ${chalk.cyan(gitInfo.remote)} (${gitInfo.provider})`);
   }
 
+  // ── Discover all skills (builtins + custom) ────────────────────────
+  const allSkills = configuredSkills(process.env, cwd);
+  const customSkills = allSkills.filter((s) => !builtinSkills.some((b) => b.id === s.id));
+  if (customSkills.length > 0) {
+    p.log.info(`Found ${customSkills.length} custom skill(s): ${chalk.cyan(customSkills.map((s) => s.id).join(", "))}`);
+  }
+
   // ── Step 1: Pick a workflow ─────────────────────────────────────────
   const templateChoice = await p.select({
     message: "What do you want to do?",
@@ -514,7 +521,7 @@ export async function runNew(): Promise<void> {
   let template: WorkflowTemplate | undefined;
 
   if (templateChoice === "__custom") {
-    template = (await runCustomWorkflowBuilder()) ?? undefined;
+    template = (await runCustomWorkflowBuilder(allSkills)) ?? undefined;
     if (!template) {
       p.cancel("Setup cancelled.");
       process.exit(0);
@@ -530,7 +537,7 @@ export async function runNew(): Promise<void> {
   const observability = inferObservability(workflowSkills);
 
   // Collect credentials for the workflow's skills (+ always ANTHROPIC_API_KEY)
-  const credentials = collectCredentialsForSkills(workflowSkills, builtinSkills);
+  const credentials = collectCredentialsForSkills(workflowSkills, allSkills);
 
   // ── Step 3: Summary + confirm ───────────────────────────────────────
   const files: string[] = [];
@@ -695,7 +702,7 @@ export async function runNew(): Promise<void> {
  *
  * Consumed by the `__custom` branch of `runNew`'s picker.
  */
-async function runCustomWorkflowBuilder(): Promise<WorkflowTemplate | null> {
+async function runCustomWorkflowBuilder(skills: Skill[]): Promise<WorkflowTemplate | null> {
   const description = await p.text({
     message: "Describe the workflow you want",
     placeholder: "e.g. Review Python PRs for security issues and post a comment",
@@ -706,8 +713,6 @@ async function runCustomWorkflowBuilder(): Promise<WorkflowTemplate | null> {
     },
   });
   if (p.isCancel(description)) return null;
-
-  const skills = configuredSkills();
   const claude = new ClaudeClient({
     maxTurns: 3,
     cwd: process.cwd(),

--- a/packages/core/src/cli/publish.ts
+++ b/packages/core/src/cli/publish.ts
@@ -15,6 +15,8 @@ import chalk from "chalk";
 import { parse as parseYaml } from "yaml";
 import type { Command } from "commander";
 import { parseWorkflow, validateWorkflow } from "../schema.js";
+import { builtinSkills } from "../skills/index.js";
+import { discoverSkills } from "../skills/custom-loader.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -39,11 +41,13 @@ export function validateWorkflowFile(filePath: string): {
   nodeCount?: number;
   edgeCount?: number;
   errors: string[];
+  warnings: string[];
 } {
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   if (!fs.existsSync(filePath)) {
-    return { valid: false, errors: ["File not found"] };
+    return { valid: false, errors: ["File not found"], warnings };
   }
 
   const raw = fs.readFileSync(filePath, "utf-8");
@@ -51,20 +55,56 @@ export function validateWorkflowFile(filePath: string): {
   try {
     parsed = parseYaml(raw);
   } catch (e) {
-    return { valid: false, errors: [`Invalid YAML: ${e instanceof Error ? e.message : e}`] };
+    return { valid: false, errors: [`Invalid YAML: ${e instanceof Error ? e.message : e}`], warnings };
   }
 
   try {
     const workflow = parseWorkflow(parsed);
-    const schemaErrors = validateWorkflow(workflow);
+
+    // Build known skill IDs from builtins + custom + inline workflow skills
+    const customSkills = discoverSkills();
+    const allSkillIds = new Set([...builtinSkills.map((s) => s.id), ...customSkills.map((s) => s.id)]);
+
+    // Inline skills defined in the workflow's skills block are also valid
+    if (parsed && typeof parsed === "object" && "skills" in (parsed as Record<string, unknown>)) {
+      const inlineSkills = (parsed as Record<string, unknown>).skills;
+      if (Array.isArray(inlineSkills)) {
+        for (const s of inlineSkills) {
+          if (typeof s === "object" && s && "id" in s) allSkillIds.add((s as { id: string }).id);
+          if (typeof s === "string") allSkillIds.add(s);
+        }
+      }
+    }
+
+    const schemaErrors = validateWorkflow(workflow, allSkillIds);
     if (schemaErrors.length > 0) {
       return {
         valid: false,
         id: workflow.id,
         name: workflow.name,
         errors: schemaErrors.map((e) => e.message),
+        warnings,
       };
     }
+
+    // Config completeness warnings
+    const allSkills = [...builtinSkills, ...customSkills];
+    const skillMap = new Map(allSkills.map((s) => [s.id, s]));
+    const referencedSkillIds = new Set<string>();
+    for (const node of Object.values(workflow.nodes)) {
+      for (const id of node.skills) referencedSkillIds.add(id);
+    }
+    for (const id of referencedSkillIds) {
+      const skill = skillMap.get(id);
+      if (!skill) continue;
+      const requiredEnvs = Object.entries(skill.config)
+        .filter(([, f]) => f.required && f.env)
+        .map(([, f]) => f.env!);
+      if (requiredEnvs.length > 0) {
+        warnings.push(`Skill "${id}" requires: ${requiredEnvs.join(", ")}`);
+      }
+    }
+
     return {
       valid: true,
       id: workflow.id,
@@ -72,9 +112,10 @@ export function validateWorkflowFile(filePath: string): {
       nodeCount: Object.keys(workflow.nodes).length,
       edgeCount: workflow.edges.length,
       errors: [],
+      warnings,
     };
   } catch (e) {
-    return { valid: false, errors: [`Schema error: ${e instanceof Error ? e.message : e}`] };
+    return { valid: false, errors: [`Schema error: ${e instanceof Error ? e.message : e}`], warnings };
   }
 }
 
@@ -217,6 +258,12 @@ async function publishWorkflow(): Promise<PublishResult | null> {
   p.log.success(
     `Validated: ${chalk.cyan(validation.name)} — ${validation.nodeCount} nodes, ${validation.edgeCount} edges`,
   );
+
+  if (validation.warnings.length > 0) {
+    for (const warn of validation.warnings) {
+      p.log.warn(warn);
+    }
+  }
 
   // Step 3: Metadata
   const raw = parseYaml(fs.readFileSync(absPath, "utf-8")) as Record<string, unknown>;

--- a/packages/core/src/cli/publish.ts
+++ b/packages/core/src/cli/publish.ts
@@ -65,14 +65,10 @@ export function validateWorkflowFile(filePath: string): {
     const customSkills = discoverSkills();
     const allSkillIds = new Set([...builtinSkills.map((s) => s.id), ...customSkills.map((s) => s.id)]);
 
-    // Inline skills defined in the workflow's skills block are also valid
-    if (parsed && typeof parsed === "object" && "skills" in (parsed as Record<string, unknown>)) {
-      const inlineSkills = (parsed as Record<string, unknown>).skills;
-      if (Array.isArray(inlineSkills)) {
-        for (const s of inlineSkills) {
-          if (typeof s === "object" && s && "id" in s) allSkillIds.add((s as { id: string }).id);
-          if (typeof s === "string") allSkillIds.add(s);
-        }
+    // Inline skills defined in the workflow's skills block (a Record<id, def>) are also valid
+    if (workflow.skills) {
+      for (const skillId of Object.keys(workflow.skills)) {
+        allSkillIds.add(skillId);
       }
     }
 

--- a/packages/core/src/skills/custom-loader.ts
+++ b/packages/core/src/skills/custom-loader.ts
@@ -162,9 +162,10 @@ export function configuredSkills(env: Record<string, string | undefined> = proce
   for (const skill of custom) {
     const existing = configuredMap.get(skill.id);
     if (existing) {
-      // Merge: built-in tools + custom instruction/mcp
+      // Merge: built-in tools + config, custom instruction/mcp + extra config
       configuredMap.set(skill.id, {
         ...existing,
+        config: { ...existing.config, ...skill.config },
         instruction: skill.instruction ?? existing.instruction,
         mcp: skill.mcp ?? existing.mcp,
       });

--- a/packages/core/src/skills/custom-loader.ts
+++ b/packages/core/src/skills/custom-loader.ts
@@ -13,7 +13,7 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";
 
-import type { Skill, SkillCategory, McpServerConfig } from "../types.js";
+import type { Skill, SkillCategory, McpServerConfig, ConfigField } from "../types.js";
 import { builtinSkills, isSkillConfigured } from "./index.js";
 
 /** Directories to scan, in ascending priority order. Last match wins. */
@@ -68,7 +68,12 @@ function parseSkillMd(content: string): Skill | null {
   if (!raw?.name) return null;
 
   // Narrow the loosely-typed YAML output into the fields we expect
-  const fm = raw as { name: string; description?: string; mcp?: Record<string, unknown> };
+  const fm = raw as {
+    name: string;
+    description?: string;
+    config?: Record<string, unknown>;
+    mcp?: Record<string, unknown>;
+  };
 
   const id = String(fm.name);
   if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) return null;
@@ -90,12 +95,27 @@ function parseSkillMd(content: string): Skill | null {
     }
   }
 
+  // Parse config fields from frontmatter
+  const config: Record<string, ConfigField> = {};
+  if (fm.config && typeof fm.config === "object") {
+    for (const [key, value] of Object.entries(fm.config)) {
+      if (value && typeof value === "object") {
+        const v = value as Record<string, unknown>;
+        config[key] = {
+          description: typeof v.description === "string" ? v.description : key,
+          required: v.required === true,
+          env: key,
+        };
+      }
+    }
+  }
+
   return {
     id,
     name: id,
     description: typeof fm.description === "string" ? fm.description : `Custom skill: ${id}`,
     category: "general" as SkillCategory,
-    config: {},
+    config,
     tools: [],
     instruction: instruction || undefined,
     mcp,

--- a/packages/core/src/workflow-builder.ts
+++ b/packages/core/src/workflow-builder.ts
@@ -45,7 +45,16 @@ Good: "Query Sentry for unresolved errors from the last 24 hours. Group by issue
  * guidance, rules, and optionally an existing workflow to refine.
  */
 export function buildSystemPrompt(skills: Skill[], existingWorkflow?: Workflow): string {
-  const skillList = skills.map((s) => `- ${s.id}: ${s.description}`).join("\n");
+  const skillList = skills
+    .map((s) => {
+      const configEntries = Object.entries(s.config)
+        .filter(([, f]) => f.env)
+        .map(([, f]) => `${f.env} (${f.required ? "required" : "optional"})`)
+        .join(", ");
+      const configLine = configEntries ? `\n  Config: ${configEntries}` : "";
+      return `- ${s.id}: ${s.description}${configLine}`;
+    })
+    .join("\n");
 
   const parts = [
     "You generate SWEny workflow definitions as JSON.",
@@ -96,6 +105,50 @@ export function extractWorkflow(data: Record<string, unknown>): Workflow {
   }
 
   return parsed;
+}
+
+/**
+ * Derive the required environment variables for a workflow from its skills.
+ * Deterministic — doesn't depend on Claude generating a variables block.
+ */
+export interface DerivedVariable {
+  name: string;
+  description: string;
+  required: boolean;
+  skill: string;
+}
+
+export function deriveWorkflowVariables(workflow: Workflow, skills: Skill[]): DerivedVariable[] {
+  const vars: DerivedVariable[] = [
+    { name: "ANTHROPIC_API_KEY", description: "Claude API key", required: true, skill: "core" },
+  ];
+  const seen = new Set<string>(["ANTHROPIC_API_KEY"]);
+
+  const skillMap = new Map(skills.map((s) => [s.id, s]));
+
+  // Collect all skill IDs referenced by workflow nodes
+  const referencedSkills = new Set<string>();
+  for (const node of Object.values(workflow.nodes)) {
+    for (const id of node.skills) referencedSkills.add(id);
+  }
+
+  for (const id of referencedSkills) {
+    const skill = skillMap.get(id);
+    if (!skill) continue;
+    for (const [envKey, field] of Object.entries(skill.config)) {
+      const name = field.env ?? envKey;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      vars.push({
+        name,
+        description: field.description,
+        required: field.required ?? false,
+        skill: id,
+      });
+    }
+  }
+
+  return vars;
 }
 
 // ─── Public API ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Custom skill config**: Parse `config:` from SKILL.md frontmatter instead of hardcoding `config: {}`
- **Credential derivation**: `collectCredentialsForSkills()` now derives from `skill.config` (builtins + custom), falls back to `SKILL_CREDENTIALS` for unknown skills
- **Workflow builder**: System prompt includes per-skill config fields; new `deriveWorkflowVariables()` function
- **Publish validation**: `sweny publish` checks skill references against builtins + custom + inline skills, warns about missing config
- **Custom skill discovery**: `sweny new` wizard shows custom skills alongside builtins
- **Config merge**: When a custom SKILL.md overrides a builtin, config fields are properly merged

## Test plan

- [x] 1788 core tests passing (20 new integration tests)
- [x] Custom SKILL.md config parsing: 4 tests
- [x] Publish validation: 7 tests
- [x] Workflow builder: 8 tests
- [x] Skill config integration: 20 tests (builtin completeness, real skill derivation, credential collection)
- [x] Pre-commit hooks pass (ESLint + Prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)