### PR TITLE
fix(core): add node.verify post-conditions; close Linear silent-success gap

### DIFF
--- a/.changeset/verify-issue-creation.md
+++ b/.changeset/verify-issue-creation.md
@@ -1,0 +1,9 @@
+---
+"@sweny-ai/core": minor
+---
+
+Add node-level `verify` post-conditions and close Linear silent-success gap
+
+- **Schema / executor**: Nodes may now declare a `verify` block (e.g. `any_tool_called: [...]`) that the executor checks after the LLM returns. If the declared tools were never successfully invoked, the node is marked `failed` and downstream nodes do not run with hallucinated output. Keeps the executor generic — the workflow YAML declares what must hold.
+- **Linear skill**: `linear_create_issue` and `linear_update_issue` now throw when Linear returns `success: false` or omits the `identifier`. Prevents agents from proceeding with a synthesized identifier when the GraphQL mutation silently failed.
+- **Triage workflow**: `create_issue` node now (a) declares `verify.any_tool_called: [linear_create_issue, github_create_issue]`, (b) requires `issueIdentifier` to match the Linear/Jira-style `^[A-Z][A-Z0-9]*-\d+$` pattern, and (c) explicitly forbids fabricating an identifier from a Sentry short-ID, commit SHA, or alert payload. `implement` picks up a precondition gate that STOPs if the identifier is malformed, preventing branch names like `off-sentry-7348174237-...` that fail downstream CI branch-naming rules.

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -567,4 +567,103 @@ describe("executor", () => {
     // Should still complete — falls back to first valid edge target
     expect(results.size).toBe(2);
   });
+
+  describe("node.verify", () => {
+    // Context: a create_issue node can satisfy its output schema (issueIdentifier
+    // present) while never actually calling the Linear/GitHub create-issue tool.
+    // The verify block catches this by requiring a real, successful tool call.
+    const verifyWorkflow: Workflow = {
+      id: "verify-create-issue",
+      name: "Verify Create Issue",
+      description: "Single node that must call linear_create_issue",
+      entry: "create",
+      nodes: {
+        create: {
+          name: "Create",
+          instruction: "Create an issue",
+          skills: [],
+          verify: { any_tool_called: ["linear_create_issue", "github_create_issue"] },
+        },
+      },
+      edges: [],
+    };
+
+    it("marks node failed when required tool was never called", async () => {
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: { issueIdentifier: "OFF-9999", issueTitle: "hallucinated", issueUrl: "https://" },
+            toolCalls: [{ tool: "linear_search_issues", input: {}, output: [] }],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      const { results } = await execute(verifyWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("create")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/verify\.any_tool_called failed/);
+      expect(r.data.error).toMatch(/linear_create_issue/);
+    });
+
+    it("marks node failed when required tool erred (output.error set)", async () => {
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: { issueIdentifier: "OFF-9999" },
+            toolCalls: [{ tool: "linear_create_issue", input: {}, output: { error: "Linear API 403" } }],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      const { results } = await execute(verifyWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
+      expect(results.get("create")!.status).toBe("failed");
+    });
+
+    it("passes when a required tool was invoked successfully", async () => {
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: { issueIdentifier: "OFF-1234" },
+            toolCalls: [
+              {
+                tool: "linear_create_issue",
+                input: { title: "t" },
+                output: { issueCreate: { success: true, issue: { identifier: "OFF-1234" } } },
+              },
+            ],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      const { results } = await execute(verifyWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
+      expect(results.get("create")!.status).toBe("success");
+    });
+
+    it("leaves already-failed nodes alone (does not overwrite Claude errors)", async () => {
+      const claude: any = {
+        async run() {
+          return { status: "failed", data: { error: "max_turns" }, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      const { results } = await execute(verifyWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
+      expect(results.get("create")!.status).toBe("failed");
+      expect(results.get("create")!.data.error).toBe("max_turns");
+    });
+  });
 });

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -63,6 +63,23 @@ describe("Zod schemas", () => {
       });
       expect(result.output).toBeDefined();
     });
+
+    it("accepts a verify block with any_tool_called", () => {
+      const result = nodeZ.parse({
+        name: "S",
+        instruction: "I",
+        verify: { any_tool_called: ["linear_create_issue", "github_create_issue"] },
+      });
+      expect(result.verify?.any_tool_called).toEqual(["linear_create_issue", "github_create_issue"]);
+    });
+
+    it("rejects verify with no check declared", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", verify: {} })).toThrow();
+    });
+
+    it("rejects verify with empty any_tool_called", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", verify: { any_tool_called: [] } })).toThrow();
+    });
   });
 
   describe("edgeZ", () => {

--- a/packages/core/src/__tests__/skills.test.ts
+++ b/packages/core/src/__tests__/skills.test.ts
@@ -117,7 +117,16 @@ describe("linear skill", () => {
   const ctx = () => mockCtx({ LINEAR_API_KEY: "lin_test" });
 
   it("create_issue sends correct GraphQL mutation", async () => {
-    fetchMock.mockResolvedValueOnce(mockResponse({ data: { issueCreate: { success: true, issue: { id: "1" } } } }));
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        data: {
+          issueCreate: {
+            success: true,
+            issue: { id: "1", identifier: "TEST-1", url: "https://linear.app/test/issue/TEST-1", title: "Bug" },
+          },
+        },
+      }),
+    );
     const tool = findTool(linear.tools, "linear_create_issue");
     await tool.handler({ teamId: "team1", title: "Bug" }, ctx());
 
@@ -126,6 +135,22 @@ describe("linear skill", () => {
     expect(opts.headers.Authorization).toBe("lin_test");
     const body = JSON.parse(opts.body);
     expect(body.query).toContain("issueCreate");
+  });
+
+  it("throws when issueCreate returns no identifier (silent failure guard)", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ data: { issueCreate: { success: true, issue: { id: "1" } } } }));
+    const tool = findTool(linear.tools, "linear_create_issue");
+    await expect(tool.handler({ teamId: "team1", title: "Bug" }, ctx())).rejects.toThrow(
+      /linear_create_issue returned no identifier/,
+    );
+  });
+
+  it("throws when issueCreate returns success: false", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ data: { issueCreate: { success: false } } }));
+    const tool = findTool(linear.tools, "linear_create_issue");
+    await expect(tool.handler({ teamId: "team1", title: "Bug" }, ctx())).rejects.toThrow(
+      /linear_create_issue returned no identifier/,
+    );
   });
 
   it("search_issues sends correct query", async () => {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -204,6 +204,16 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
       },
     });
 
+    // Machine-checked post-condition. Enforced AFTER the LLM finishes so that
+    // a model claiming success cannot bypass side-effect requirements (e.g.
+    // reporting "issue created" when no `linear_create_issue` call was made).
+    const verifyError = evaluateVerify(node.verify, result);
+    if (verifyError && result.status === "success") {
+      result.status = "failed";
+      result.data = { ...result.data, error: verifyError };
+      logger.warn(`  verify failed: ${verifyError}`, { node: currentId });
+    }
+
     results.set(currentId, result);
     trace.steps.push({ node: currentId, status: result.status, iteration });
     safeObserve(observer, { type: "node:exit", node: currentId, result }, logger);
@@ -248,6 +258,36 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
 }
 
 // ─── Internals ───────────────────────────────────────────────────
+
+/**
+ * Evaluate a node's `verify` post-condition against the executed result.
+ *
+ * Returns an error string when the check fails, or null when the node
+ * passes verification (or has no verify block).
+ *
+ * Keep this deterministic and side-effect free — the executor calls it
+ * synchronously right after the LLM finishes.
+ */
+function evaluateVerify(verify: import("./types.js").NodeVerify | undefined, result: NodeResult): string | null {
+  if (!verify) return null;
+
+  if (verify.any_tool_called && verify.any_tool_called.length > 0) {
+    const required = new Set(verify.any_tool_called);
+    const success = result.toolCalls.some(
+      (c) =>
+        required.has(c.tool) &&
+        // Treat explicit error outputs (from coreToolToSdkTool's catch branch)
+        // as failed calls so a swallowed handler throw doesn't count as success.
+        !(c.output && typeof c.output === "object" && "error" in (c.output as Record<string, unknown>)),
+    );
+    if (!success) {
+      const called = result.toolCalls.map((c) => c.tool).join(", ") || "none";
+      return `verify.any_tool_called failed — required one of [${verify.any_tool_called.join(", ")}] to succeed, but tool calls were: [${called}]`;
+    }
+  }
+
+  return null;
+}
 
 /**
  * Build the full instruction for a node.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -87,6 +87,14 @@ export const nodeSourcesZ = z.union([
   }),
 ]);
 
+export const nodeVerifyZ = z
+  .object({
+    any_tool_called: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .refine((v) => v.any_tool_called !== undefined, {
+    message: "verify must declare at least one check (e.g. any_tool_called)",
+  });
+
 export const nodeZ = z.object({
   name: z.string().min(1),
   instruction: sourceZ,
@@ -95,6 +103,7 @@ export const nodeZ = z.object({
   max_turns: z.number().int().min(1).optional(),
   rules: nodeSourcesZ.optional(),
   context: nodeSourcesZ.optional(),
+  verify: nodeVerifyZ.optional(),
 });
 
 export const edgeZ = z.object({

--- a/packages/core/src/skills/linear.ts
+++ b/packages/core/src/skills/linear.ts
@@ -49,12 +49,19 @@ export const linear: Skill = {
         },
         required: ["teamId", "title"],
       },
-      handler: async (input: any, ctx) =>
-        linearGql(
+      handler: async (input: any, ctx) => {
+        const data = await linearGql(
           `mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier url title } } }`,
           { input },
           ctx,
-        ),
+        );
+        if (!data?.issueCreate?.success || !data?.issueCreate?.issue?.identifier) {
+          throw new Error(
+            `[Linear] linear_create_issue returned no identifier — issue was not created. Raw response: ${JSON.stringify(data)}`,
+          );
+        }
+        return data;
+      },
     },
     {
       name: "linear_search_issues",
@@ -157,11 +164,15 @@ export const linear: Skill = {
       },
       handler: async (input: { issueId: string; [key: string]: any }, ctx) => {
         const { issueId, ...updates } = input;
-        return linearGql(
+        const data = await linearGql(
           `mutation($id: String!, $input: IssueUpdateInput!) { issueUpdate(id: $id, input: $input) { success issue { id identifier url title state { name } } } }`,
           { id: issueId, input: updates },
           ctx,
         );
+        if (!data?.issueUpdate?.success) {
+          throw new Error(`[Linear] linear_update_issue failed for ${issueId}. Raw response: ${JSON.stringify(data)}`);
+        }
+        return data;
       },
     },
   ],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,6 +70,27 @@ export interface Skill {
  */
 export type NodeSources = _Source[] | { only?: boolean; sources: _Source[] };
 
+/**
+ * Machine-checked post-condition for a node.
+ *
+ * Evaluated by the executor AFTER the LLM finishes. If the check fails, the
+ * node is marked `failed` even if the LLM itself returned success — this
+ * catches the common case of the model claiming success without actually
+ * invoking the side-effectful tool (e.g. reporting "issue created" when no
+ * `linear_create_issue` call was made, or the call errored).
+ *
+ * Keep the shape small and declarative. Anything richer should be a skill
+ * or a dedicated workflow node, not a verify clause.
+ */
+export interface NodeVerify {
+  /**
+   * At least one of the named tools must have been invoked successfully during
+   * this node's execution (no `output.error` recorded in `toolCalls`). The
+   * node is marked failed otherwise.
+   */
+  any_tool_called?: string[];
+}
+
 /** A node in the workflow DAG */
 export interface Node {
   /** Human-readable name */
@@ -86,6 +107,8 @@ export interface Node {
   rules?: NodeSources;
   /** Per-node background knowledge. Additive by default; set `{ only: true, sources: [...] }` to block cascade. */
   context?: NodeSources;
+  /** Machine-checked post-conditions. Enforced by the executor after the LLM finishes. */
+  verify?: NodeVerify;
 }
 
 /** An edge connecting two nodes */

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -148,13 +148,20 @@ nodes:
 
       **For each NOVEL finding** (is_duplicate = false):
 
-      1. Create a new issue with a clear, actionable title.
+      1. Create a new issue with a clear, actionable title by invoking the appropriate tool
+      (`linear_create_issue` or `github_create_issue`). You MUST actually call the tool — do NOT
+      synthesize an identifier from an alert ID, commit SHA, or your own imagination. If the
+      tool errors, stop and report the failure; do not invent a fallback identifier.
 
       2. Include: root cause, severity, affected services, reproduction steps, and recommended fix.
 
       3. Add appropriate labels (bug, severity level, affected service).
 
       4. Link to relevant commits, PRs, or existing issues.
+
+      5. Copy the identifier returned by the tool verbatim into the `issueIdentifier` output
+      field. The identifier must match `^[A-Z][A-Z0-9]*-\d+$` (e.g. `OFF-1234`) — do not
+      prefix it with anything else.
 
 
       **For each DUPLICATE finding** (is_duplicate = true):
@@ -179,20 +186,35 @@ nodes:
     skills:
       - linear
       - github
+    verify:
+      # Reject output that claims success without a real issue-creation tool call.
+      # The executor checks this after the node finishes; if none of these tools
+      # was invoked successfully, the node is marked failed and downstream nodes
+      # (implement, create_pr) never run with a hallucinated identifier.
+      any_tool_called:
+        - linear_create_issue
+        - github_create_issue
     output:
       type: object
       properties:
         issueIdentifier:
           type: string
-          description: Primary issue identifier (e.g. OFF-1234). This is the first novel issue created — used by downstream nodes for branch naming and PR linking.
+          pattern: '^[A-Z][A-Z0-9]*-\d+$'
+          description: >-
+            Primary issue identifier (e.g. OFF-1234). MUST be the identifier returned by
+            `linear_create_issue` / `github_create_issue` — do NOT invent a value from a
+            Sentry short-ID or commit SHA. Used by downstream nodes for branch naming and
+            PR linking.
         issueTitle:
           type: string
           description: Title of the primary issue created
         issueUrl:
           type: string
-          description: URL of the primary issue created
+          pattern: "^https?://"
+          description: URL of the primary issue created, as returned by the create-issue tool
         issues:
           type: array
+          minItems: 1
           description: All issues created or updated during this step
           items:
             type: object
@@ -245,10 +267,20 @@ nodes:
     instruction: |-
       Implement the fix identified during investigation. The issue created in the previous step is in your context — use its identifier for branch naming and commit messages.
 
+      0. **Precondition — verify context.create_issue.issueIdentifier is well-formed.**
+         The identifier MUST match `^[A-Z][A-Z0-9]*-\d+$` (e.g. `OFF-1234`). If it is
+         missing, empty, or matches a Sentry short-ID / slug / any other shape, STOP
+         immediately — do NOT invent a branch name from the Sentry event, commit SHA,
+         or alert payload. Return a failed status with a clear message instead; the
+         workflow will route to notify and a human will pick it up.
+
       1. Create a feature branch from the base branch (check context for baseBranch, default "main").
-         **Branch name MUST include the issue identifier** (e.g. context.create_issue.issueIdentifier).
-         Format: lowercase the identifier and use it as a prefix, e.g. `off-1234-fix-null-check`.
-         If the repository uses a different branch convention (check context.branchPattern), follow that instead.
+         **Branch name MUST include the issue identifier** exactly as provided in
+         `context.create_issue.issueIdentifier`. Format: lowercase the identifier and use
+         it as a prefix, e.g. `off-1234-fix-null-check`. If the repository uses a different
+         branch convention (check context.branchPattern or the rules/CLAUDE.md for a
+         regex), follow that — but the identifier piece MUST still come from
+         `context.create_issue.issueIdentifier`, never from a Sentry short-ID.
       2. Read the relevant source files to understand the current code.
       3. Make the necessary code changes — fix the bug, nothing more.
       4. Run any existing tests if available to verify the fix doesn't break anything.


### PR DESCRIPTION
## Summary

Triage runs were producing branch names like `off-sentry-7348174237-fix-nan-projectid` — malformed per the downstream repo's `off-{numericID}-description` CI rule — because the agent fell back to synthesizing an identifier from the Sentry short-ID when no Linear issue was actually created. The root cause: the `create_issue` node's output schema forced the LLM to return an `issueIdentifier`, but nothing verified that a real issue-creation tool had been invoked. When the Linear GraphQL mutation failed or the agent skipped the tool entirely, downstream nodes (`implement`, `create_pr`) happily ran with a hallucinated ID.

This PR closes the gap at three layers:

### 1. `node.verify` post-conditions (schema + executor)
Nodes may now declare:
```yaml
verify:
  any_tool_called:
    - linear_create_issue
    - github_create_issue
```
After the LLM returns, the executor checks the captured `toolCalls`. If none of the required tools was invoked successfully (i.e. without an `error` in the output), the node is marked `failed` and downstream nodes never run with fabricated output. The executor stays generic — the workflow YAML declares what must hold.

### 2. Linear skill — reject silent failures
`linear_create_issue` and `linear_update_issue` now throw when Linear returns `success: false` or omits the `identifier`. Previously a business-logic failure returned normally, masking the problem.

### 3. Triage workflow tightening
- `create_issue` declares the `verify` block above.
- `issueIdentifier` in the output schema is regex-constrained to `^[A-Z][A-Z0-9]*-\d+$`; `issueUrl` to `^https?://`.
- Instruction explicitly forbids synthesizing identifiers from Sentry short-IDs, commit SHAs, or alert payloads.
- `implement` node gets a precondition gate (step 0) that STOPs on a malformed identifier rather than inventing a branch name.

## Test plan
- [x] `npm test` in `packages/core` — 2156 passing / 5 skipped
- [x] `npm run typecheck` — clean across all workspaces
- [x] New tests: 4 executor tests for `verify` (missing tool, erroring tool, success path, already-failed passthrough); 3 schema tests (accepts `any_tool_called`, rejects empty verify, rejects empty array); 2 Linear tests (throws on missing identifier, throws on `success: false`)
- [ ] Verify on a real triage run that a forced Linear-unauthorized failure now marks `create_issue` failed and routes to `notify` instead of `implement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)