### PR TITLE
fix(triage): prevent investigate from creating issues; add verify to create_pr

### DIFF
--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -78,6 +78,19 @@ nodes:
 
 
       Downstream nodes will act ONLY on novel findings. Duplicates will be +1'd automatically.
+
+
+      **IMPORTANT — scope boundaries for this node:**
+
+      - DO NOT create issues (Linear, GitHub, or any tracker). A downstream `create_issue` node handles that.
+
+      - DO NOT create branches, commits, or pull requests. A downstream `implement` node handles that.
+
+      - DO NOT call `linear_create_issue`, `github_create_issue`, `github_create_pr`, or any
+      write tool besides `linear_add_comment` / `github_add_comment` (for +1 duplicate comments).
+
+      - Your ONLY job is classification and output. If you create an issue here, the downstream
+      verify check will fail because it expects to be the one calling the create tool.
     skills:
       - github
       - linear
@@ -152,6 +165,9 @@ nodes:
       (`linear_create_issue` or `github_create_issue`). You MUST actually call the tool — do NOT
       synthesize an identifier from an alert ID, commit SHA, or your own imagination. If the
       tool errors, stop and report the failure; do not invent a fallback identifier.
+      **Use the exact tool names above** — do NOT use generic alternatives like `create_issue`,
+      `create_pull_request`, or `get_issue` from ToolSearch. The verify check requires the
+      specific tool names listed here.
 
       2. Include: root cause, severity, affected services, reproduction steps, and recommended fix.
 
@@ -300,14 +316,18 @@ nodes:
 
       1. Push the branch to the remote.
 
-      2. Create a PR with a title that starts with the issue identifier in brackets.
+      2. Create the PR using the `github_create_pr` tool. **Use this exact tool name** — do NOT
+      use `create_pull_request` or any other variant from ToolSearch. The verify check requires
+      `github_create_pr` specifically.
+
+      3. PR title MUST start with the issue identifier in brackets.
       Format: `[{context.create_issue.issueIdentifier}] fix: {short description}`.
 
-      3. In the PR body, include: summary of the bug, what the fix does, and a link to the issue
+      4. In the PR body, include: summary of the bug, what the fix does, and a link to the issue
       (context.create_issue.issueUrl). If the investigation found a Sentry issue, include "Fixes {sentryShortId}"
       in the PR body so Sentry auto-resolves on merge.
 
-      4. Add appropriate labels if available.
+      5. Add appropriate labels if available.
 
 
       If context.prTemplate is provided, use it as the format for the PR body. Otherwise use a clear structure with:
@@ -321,6 +341,9 @@ nodes:
       Return the PR URL and number.
     skills:
       - github
+    verify:
+      any_tool_called:
+        - github_create_pr
   notify:
     name: Notify Team
     instruction: |-


### PR DESCRIPTION
## Summary

- **investigate node**: Add explicit scope boundaries prohibiting issue/PR/branch creation. The investigate node had access to `linear_create_issue` via the `linear` skill and was preemptively creating Linear issues, causing the downstream `create_issue` verify check to fail.
- **create_issue node**: Strengthen tool naming guidance to prevent Claude Code from using its own deferred tools (`create_pull_request`, `get_issue`) instead of the SWEny MCP tools (`linear_create_issue`, `github_create_issue`).
- **create_pr node**: Add `verify.any_tool_called` check for `github_create_pr`. Previously had no verify block — node could report success even when the PR wasn't created (Claude Code used a hallucinated `create_pull_request` tool).

## Root Cause

When SWEny runs headless Claude Code, Claude sees both:
1. SWEny skill tools via MCP (`linear_create_issue`, `github_create_pr`)  
2. Claude Code's own deferred tools (`create_pull_request`, `get_issue`, etc.)

Claude sometimes picks the native tools over the MCP ones. The verify checks look for the MCP tool names, so this causes false failures. In the investigate node, Claude was using the MCP tools but in the wrong phase — creating issues during investigation instead of during the create_issue step.

## Test plan

- [ ] E2E: fire a Sentry alert → verify create_issue node creates the Linear issue (not investigate)
- [ ] E2E: verify create_pr node opens an actual PR and passes the new verify check
- [ ] Verify investigate node outputs classification without any write side-effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)