### PR TITLE
fix(triage): address PR #154 review feedback

### DIFF
--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -86,11 +86,12 @@ nodes:
 
       - DO NOT create branches, commits, or pull requests. A downstream `implement` node handles that.
 
-      - DO NOT call `linear_create_issue`, `github_create_issue`, `github_create_pr`, or any
-      write tool besides `linear_add_comment` / `github_add_comment` (for +1 duplicate comments).
+      - DO NOT call any write tools (`linear_create_issue`, `github_create_issue`,
+      `github_create_pr`, `linear_add_comment`, `github_add_comment`, etc.).
+      Downstream nodes handle all writes — issue creation, +1 comments, and PRs.
 
-      - Your ONLY job is classification and output. If you create an issue here, the downstream
-      verify check will fail because it expects to be the one calling the create tool.
+      - Your ONLY job is read, search, classify, and output. If you create an issue
+      or add a comment here, the downstream verify check will fail or duplicate work.
     skills:
       - github
       - linear
@@ -165,9 +166,9 @@ nodes:
       (`linear_create_issue` or `github_create_issue`). You MUST actually call the tool — do NOT
       synthesize an identifier from an alert ID, commit SHA, or your own imagination. If the
       tool errors, stop and report the failure; do not invent a fallback identifier.
-      **Use the exact tool names above** — do NOT use generic alternatives like `create_issue`,
-      `create_pull_request`, or `get_issue` from ToolSearch. The verify check requires the
-      specific tool names listed here.
+      **Use the exact tool names above** — do NOT use generic alternatives like `create_issue`
+      or `create_pull_request` from ToolSearch. The verify check requires the specific tool
+      names listed here.
 
       2. Include: root cause, severity, affected services, reproduction steps, and recommended fix.
 


### PR DESCRIPTION
## Summary

Follow-up to #154 — addresses review feedback that was merged before comments landed.

- **Remove `add_comment` carve-out from investigate node**: The investigate node allowed `linear_add_comment`/`github_add_comment` for +1 duplicate comments, but `create_issue` also processes duplicates and adds +1 comments. In mixed-finding runs (some novel, some duplicate), both nodes would run and double-comment. Fix: make investigate a pure read/classify node — downstream nodes handle all writes.
- **Remove `get_issue` from forbidden tool list**: It's a read tool, not a write tool — listing it diluted the warning about actual write-tool alternatives.

## Test plan

- [ ] Mixed-finding run (novel + duplicate): verify only one +1 comment per duplicate
- [ ] Investigate node: confirm no write tool calls at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)