### PR TITLE
feat(core): extend verify with all/none/output checks + spec docs

### DIFF
--- a/docs/superpowers/plans/2026-04-18-verify-v2.md
+++ b/docs/superpowers/plans/2026-04-18-verify-v2.md
@@ -1,0 +1,1530 @@
+# Verify v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `verify` from a single check (`any_tool_called`) into a small declarative set covering tool-call shape variants (`all_tools_called`, `no_tool_called`) and structured-output assertions (`output_required`, `output_matches`), with explicit `all:`/`any:` wildcard semantics and aggregated failure reporting. Document the feature end-to-end in the public spec.
+
+**Architecture:** Extract verify evaluation from `executor.ts` into a new `verify.ts` module with three concerns: a tiny path resolver (dotted + `[*]` wildcard), per-check evaluators (`any/all/no_tool_called`, `output_required`, `output_matches`), and a top-level orchestrator that runs every declared check and concatenates failures into one error string. `NodeResult` shape is unchanged — failures land in `result.data.error` exactly as today.
+
+**Tech Stack:** TypeScript, Zod 4, Vitest 4, ESM. No new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-verify-v2-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `packages/core/src/verify.ts` — path resolver + check evaluators + `evaluateVerify` orchestrator. The verify logic is currently 17 lines inline in `executor.ts`; with five check types and a path grammar it grows to ~150 lines and earns its own module.
+- `packages/core/src/__tests__/verify.test.ts` — focused unit tests for the path resolver and each check evaluator, against plain JS objects (no zod, no executor).
+
+**Modified files:**
+- `packages/core/src/types.ts` — extend `NodeVerify` interface, add `OutputMatch` interface.
+- `packages/core/src/schema.ts` — extend `nodeVerifyZ`, add `outputMatchZ`.
+- `packages/core/src/executor.ts` — delete inline `evaluateVerify`, import from `./verify.js`.
+- `packages/core/src/__tests__/schema.test.ts` — add tests for new fields and the broader refine.
+- `packages/core/src/__tests__/executor.test.ts` — add executor-level integration tests for the new check types.
+- `spec/src/content/docs/nodes.mdx` — add a top-level Verify section.
+
+**Untouched:** cloud worker, studio, MCP, web docs. `triage.yml` works as-is (any_tool_called is unchanged).
+
+---
+
+## Task 1: Add `OutputMatch` type and extend `NodeVerify`
+
+**Files:**
+- Modify: `packages/core/src/types.ts:85-92`
+
+This is a pure type-declaration change. No tests — TS compiles types away. Tests come in later tasks once there's behavior to test.
+
+- [ ] **Step 1: Replace the `NodeVerify` interface with the extended shape**
+
+In `packages/core/src/types.ts`, replace the existing `NodeVerify` interface (lines 85-92) with:
+
+```ts
+/**
+ * Machine-checked post-condition for a node.
+ *
+ * Evaluated by the executor AFTER the LLM finishes. If any declared check
+ * fails, the node is marked `failed` even if the LLM itself returned success.
+ *
+ * All declared checks are AND-ed. The executor runs every check (no fast-fail)
+ * and concatenates failures into a single error string on `result.data.error`.
+ *
+ * Keep the shape small and declarative. Anything richer should be a skill or
+ * a dedicated workflow node, not a verify clause.
+ */
+export interface NodeVerify {
+  /** At least one of these tools was called and succeeded during this node. */
+  any_tool_called?: string[];
+  /** Every named tool was called and succeeded at least once during this node. */
+  all_tools_called?: string[];
+  /** None of these tools may have been invoked during this node. */
+  no_tool_called?: string[];
+  /** Listed paths must be present and non-null in `result.data` (see Path resolution in the spec). */
+  output_required?: string[];
+  /** Each assertion must hold against `result.data`. */
+  output_matches?: OutputMatch[];
+}
+
+/**
+ * A single output assertion. Exactly one of `equals | in | matches` must be set.
+ *
+ * `path` is a dotted path that may include `[*]` wildcard segments and may be
+ * prefixed with `all:` or `any:` to set wildcard semantics (default `all:`).
+ *
+ * Examples: `prUrl`, `findings[*].severity`, `any:checks[*].conclusion`.
+ */
+export interface OutputMatch {
+  path: string;
+  equals?: unknown;
+  in?: unknown[];
+  /** Regex source (no surrounding slashes, no flags). Value is coerced to string. */
+  matches?: string;
+}
+```
+
+- [ ] **Step 2: Verify the package still compiles**
+
+Run: `cd packages/core && npm run build`
+Expected: build succeeds (the new fields are all optional, so no existing call site breaks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/src/types.ts
+git commit -m "feat(core): extend NodeVerify with new check types"
+```
+
+---
+
+## Task 2: Path resolver — TDD
+
+**Files:**
+- Create: `packages/core/src/verify.ts`
+- Create: `packages/core/src/__tests__/verify.test.ts`
+
+The path resolver is the foundation for `output_required` and `output_matches`. Build it first, in isolation, with full test coverage of the grammar and edge cases. The resolver returns either an expanded list of values or a structured failure with the missing segment named.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/src/__tests__/verify.test.ts` with the following content:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { resolvePath } from "../verify.js";
+
+describe("resolvePath", () => {
+  describe("simple dotted paths", () => {
+    it("resolves a top-level key", () => {
+      expect(resolvePath({ a: 1 }, "a")).toEqual({ ok: true, mode: "all", values: [1] });
+    });
+
+    it("resolves a nested key", () => {
+      expect(resolvePath({ a: { b: { c: "x" } } }, "a.b.c")).toEqual({
+        ok: true,
+        mode: "all",
+        values: ["x"],
+      });
+    });
+
+    it("returns the literal null value (does not treat null as missing)", () => {
+      expect(resolvePath({ a: null }, "a")).toEqual({ ok: true, mode: "all", values: [null] });
+    });
+
+    it("fails when a top-level segment is missing", () => {
+      const r = resolvePath({}, "a");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'a'/);
+    });
+
+    it("fails when an intermediate segment is missing", () => {
+      const r = resolvePath({ a: {} }, "a.b.c");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'b'/);
+    });
+
+    it("fails when an intermediate segment is null", () => {
+      const r = resolvePath({ a: null }, "a.b");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/null/);
+    });
+  });
+
+  describe("wildcard expansion", () => {
+    it("expands [*] over an array of primitives", () => {
+      expect(resolvePath({ xs: [1, 2, 3] }, "xs[*]")).toEqual({
+        ok: true,
+        mode: "all",
+        values: [1, 2, 3],
+      });
+    });
+
+    it("expands [*] then walks into each element", () => {
+      const data = { findings: [{ severity: "critical" }, { severity: "low" }] };
+      expect(resolvePath(data, "findings[*].severity")).toEqual({
+        ok: true,
+        mode: "all",
+        values: ["critical", "low"],
+      });
+    });
+
+    it("returns an empty values array when the array is empty", () => {
+      expect(resolvePath({ xs: [] }, "xs[*]")).toEqual({ ok: true, mode: "all", values: [] });
+    });
+
+    it("returns an empty values array when expanding deeper into an empty array", () => {
+      expect(resolvePath({ findings: [] }, "findings[*].severity")).toEqual({
+        ok: true,
+        mode: "all",
+        values: [],
+      });
+    });
+
+    it("fails when [*] is applied to a non-array", () => {
+      const r = resolvePath({ xs: { not: "array" } }, "xs[*]");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/expected array at 'xs'/);
+    });
+
+    it("fails when an element under [*] is missing the next segment", () => {
+      const data = { findings: [{ severity: "critical" }, { title: "x" }] };
+      const r = resolvePath(data, "findings[*].severity");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'severity'/);
+    });
+  });
+
+  describe("mode prefixes", () => {
+    it("parses `all:` prefix", () => {
+      const r = resolvePath({ xs: [1, 2] }, "all:xs[*]");
+      expect(r).toEqual({ ok: true, mode: "all", values: [1, 2] });
+    });
+
+    it("parses `any:` prefix", () => {
+      const r = resolvePath({ xs: [1, 2] }, "any:xs[*]");
+      expect(r).toEqual({ ok: true, mode: "any", values: [1, 2] });
+    });
+
+    it("defaults to `all` when no prefix", () => {
+      const r = resolvePath({ xs: [1] }, "xs[*]");
+      expect(r).toEqual({ ok: true, mode: "all", values: [1] });
+    });
+
+    it("rejects an unknown prefix", () => {
+      const r = resolvePath({ xs: [1] }, "every:xs[*]");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/unknown prefix 'every'/);
+    });
+  });
+
+  describe("grammar errors", () => {
+    it("rejects an empty path", () => {
+      const r = resolvePath({}, "");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/empty path/);
+    });
+
+    it("rejects a malformed segment", () => {
+      const r = resolvePath({}, "a..b");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/malformed/);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: FAIL — `Cannot find module '../verify.js'` or similar.
+
+- [ ] **Step 3: Implement the path resolver**
+
+Create `packages/core/src/verify.ts` with:
+
+```ts
+// ─── Verify: path resolver + check evaluators ───────────────────────
+//
+// Evaluates `node.verify` post-conditions after the LLM finishes.
+// All checks are AND-ed; failures are aggregated into one error string.
+
+export type Resolution =
+  | { ok: true; mode: "all" | "any"; values: unknown[] }
+  | { ok: false; reason: string };
+
+interface Segment {
+  name: string;
+  wildcard: boolean;
+}
+
+const SEGMENT_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)(\[\*\])?$/;
+
+function parsePath(path: string): { mode: "all" | "any"; segments: Segment[] } | string {
+  if (path.length === 0) return "empty path";
+
+  let mode: "all" | "any" = "all";
+  let body = path;
+  const colon = path.indexOf(":");
+  if (colon !== -1 && /^[a-z]+$/.test(path.slice(0, colon))) {
+    const prefix = path.slice(0, colon);
+    if (prefix === "all" || prefix === "any") {
+      mode = prefix;
+      body = path.slice(colon + 1);
+    } else {
+      return `unknown prefix '${prefix}' (expected 'all' or 'any')`;
+    }
+    if (body.length === 0) return "empty path after prefix";
+  }
+
+  const parts = body.split(".");
+  const segments: Segment[] = [];
+  for (const part of parts) {
+    const m = SEGMENT_RE.exec(part);
+    if (!m) return `malformed segment '${part}'`;
+    segments.push({ name: m[1], wildcard: m[2] === "[*]" });
+  }
+  return { mode, segments };
+}
+
+export function resolvePath(data: unknown, path: string): Resolution {
+  const parsed = parsePath(path);
+  if (typeof parsed === "string") return { ok: false, reason: parsed };
+
+  // Walking model: maintain an array of "current values" being expanded.
+  // Start with [data]. Every non-wildcard segment maps each current to its
+  // child. Every wildcard segment requires the child to be an array and
+  // flattens its elements into the current set.
+  let current: unknown[] = [data];
+
+  for (let i = 0; i < parsed.segments.length; i++) {
+    const seg = parsed.segments[i]!;
+    const next: unknown[] = [];
+    for (const v of current) {
+      if (v === null) return { ok: false, reason: `null encountered before segment '${seg.name}'` };
+      if (typeof v !== "object") {
+        return { ok: false, reason: `expected object before segment '${seg.name}', got ${typeof v}` };
+      }
+      const obj = v as Record<string, unknown>;
+      if (!(seg.name in obj)) {
+        return { ok: false, reason: `missing segment '${seg.name}'` };
+      }
+      const child = obj[seg.name];
+      if (seg.wildcard) {
+        if (!Array.isArray(child)) {
+          return { ok: false, reason: `expected array at '${seg.name}', got ${child === null ? "null" : typeof child}` };
+        }
+        for (const el of child) next.push(el);
+      } else {
+        next.push(child);
+      }
+    }
+    current = next;
+    if (current.length === 0) {
+      // All remaining segments are vacuous over an empty wildcard expansion.
+      // Fast-exit with empty values; subsequent segments would never see input.
+      return { ok: true, mode: parsed.mode, values: [] };
+    }
+  }
+
+  return { ok: true, mode: parsed.mode, values: current };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: PASS — all 17 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/verify.ts packages/core/src/__tests__/verify.test.ts
+git commit -m "feat(core): add verify path resolver"
+```
+
+---
+
+## Task 3: Tool-call check evaluators — TDD
+
+**Files:**
+- Modify: `packages/core/src/verify.ts`
+- Modify: `packages/core/src/__tests__/verify.test.ts`
+
+Three checks: `any_tool_called`, `all_tools_called`, `no_tool_called`. Each takes a list of tool names and the executed `result.toolCalls`, and returns `null` (pass) or an error string.
+
+A tool "succeeded" if it appears in `result.toolCalls` with no `error` key in `output`. For `no_tool_called`, *any* appearance counts as a violation (success or failure).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/__tests__/verify.test.ts`:
+
+```ts
+import { checkAnyToolCalled, checkAllToolsCalled, checkNoToolCalled } from "../verify.js";
+import type { ToolCall } from "../types.js";
+
+const tc = (tool: string, output?: unknown): ToolCall => ({ tool, input: {}, output });
+const errOut = { error: "boom" };
+
+describe("checkAnyToolCalled", () => {
+  it("passes when one of the named tools succeeded", () => {
+    expect(checkAnyToolCalled(["a", "b"], [tc("a", { ok: true })])).toBeNull();
+  });
+
+  it("passes when one succeeded among others", () => {
+    expect(checkAnyToolCalled(["a"], [tc("x"), tc("a", { ok: true }), tc("y")])).toBeNull();
+  });
+
+  it("fails when only an unrelated tool was called", () => {
+    const err = checkAnyToolCalled(["a", "b"], [tc("x")]);
+    expect(err).toMatch(/any_tool_called.*required one of \[a, b\].*called.*x/);
+  });
+
+  it("fails when the required tool errored", () => {
+    const err = checkAnyToolCalled(["a"], [tc("a", errOut)]);
+    expect(err).toMatch(/any_tool_called/);
+  });
+
+  it("reports 'none' when no tools were called", () => {
+    const err = checkAnyToolCalled(["a"], []);
+    expect(err).toMatch(/called: \[none\]/);
+  });
+});
+
+describe("checkAllToolsCalled", () => {
+  it("passes when every named tool succeeded", () => {
+    expect(checkAllToolsCalled(["a", "b"], [tc("a", { ok: true }), tc("b", { ok: true })])).toBeNull();
+  });
+
+  it("passes when extras were also called", () => {
+    expect(
+      checkAllToolsCalled(["a"], [tc("a", { ok: true }), tc("x"), tc("y")]),
+    ).toBeNull();
+  });
+
+  it("fails when a required tool was never called", () => {
+    const err = checkAllToolsCalled(["a", "b"], [tc("a", { ok: true })]);
+    expect(err).toMatch(/all_tools_called.*missing.*\[b\]/);
+  });
+
+  it("fails when a required tool only errored", () => {
+    const err = checkAllToolsCalled(["a", "b"], [tc("a", { ok: true }), tc("b", errOut)]);
+    expect(err).toMatch(/all_tools_called.*missing.*\[b\]/);
+  });
+});
+
+describe("checkNoToolCalled", () => {
+  it("passes when none of the named tools were called", () => {
+    expect(checkNoToolCalled(["a", "b"], [tc("x"), tc("y")])).toBeNull();
+  });
+
+  it("passes when toolCalls is empty", () => {
+    expect(checkNoToolCalled(["a"], [])).toBeNull();
+  });
+
+  it("fails when a forbidden tool was called successfully", () => {
+    const err = checkNoToolCalled(["force_push"], [tc("force_push", { ok: true })]);
+    expect(err).toMatch(/no_tool_called.*forbidden.*\[force_push\]/);
+  });
+
+  it("fails when a forbidden tool was called even with error", () => {
+    const err = checkNoToolCalled(["force_push"], [tc("force_push", errOut)]);
+    expect(err).toMatch(/no_tool_called/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: FAIL — `checkAnyToolCalled is not a function` or import error.
+
+- [ ] **Step 3: Implement the three check functions**
+
+Add to `packages/core/src/verify.ts` (below `resolvePath`):
+
+```ts
+import type { ToolCall } from "./types.js";
+
+function isErrorOutput(output: unknown): boolean {
+  return !!(output && typeof output === "object" && "error" in (output as Record<string, unknown>));
+}
+
+function succeededTools(toolCalls: ToolCall[]): Set<string> {
+  const names = new Set<string>();
+  for (const c of toolCalls) {
+    if (!isErrorOutput(c.output)) names.add(c.tool);
+  }
+  return names;
+}
+
+export function checkAnyToolCalled(required: string[], toolCalls: ToolCall[]): string | null {
+  const succeeded = succeededTools(toolCalls);
+  if (required.some((t) => succeeded.has(t))) return null;
+  const called = toolCalls.map((c) => c.tool).join(", ") || "none";
+  return `any_tool_called: required one of [${required.join(", ")}] to succeed, called: [${called}]`;
+}
+
+export function checkAllToolsCalled(required: string[], toolCalls: ToolCall[]): string | null {
+  const succeeded = succeededTools(toolCalls);
+  const missing = required.filter((t) => !succeeded.has(t));
+  if (missing.length === 0) return null;
+  return `all_tools_called: missing successful calls to [${missing.join(", ")}]`;
+}
+
+export function checkNoToolCalled(forbidden: string[], toolCalls: ToolCall[]): string | null {
+  const calledNames = new Set(toolCalls.map((c) => c.tool));
+  const violated = forbidden.filter((t) => calledNames.has(t));
+  if (violated.length === 0) return null;
+  return `no_tool_called: forbidden tools were invoked: [${violated.join(", ")}]`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: PASS — all tool-call check tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/verify.ts packages/core/src/__tests__/verify.test.ts
+git commit -m "feat(core): add tool-call verify checks (any/all/none)"
+```
+
+---
+
+## Task 4: Output check evaluators — TDD
+
+**Files:**
+- Modify: `packages/core/src/verify.ts`
+- Modify: `packages/core/src/__tests__/verify.test.ts`
+
+Two checks: `output_required` (paths must resolve to non-null values) and `output_matches` (each entry asserts an operator against resolved values). Both honor wildcard `all:`/`any:` semantics from the resolver.
+
+For `output_matches`:
+- `equals` — strict deep equality (compare via `JSON.stringify` for our use cases — values come from JSON-shaped agent output, no Dates/Maps/etc).
+- `in` — value is deep-equal to one element of the array.
+- `matches` — value coerced to string and tested against `new RegExp(source)`.
+
+Exactly one operator per entry — enforced upstream by zod, but also defensively here.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/__tests__/verify.test.ts`:
+
+```ts
+import { checkOutputRequired, checkOutputMatches } from "../verify.js";
+
+describe("checkOutputRequired", () => {
+  it("passes when all paths resolve to non-null values", () => {
+    expect(checkOutputRequired(["a", "b.c"], { a: 1, b: { c: "x" } })).toBeNull();
+  });
+
+  it("fails when a path is missing", () => {
+    const err = checkOutputRequired(["a", "missing"], { a: 1 });
+    expect(err).toMatch(/output_required.*'missing'.*missing segment/);
+  });
+
+  it("fails when a path resolves to null", () => {
+    const err = checkOutputRequired(["a"], { a: null });
+    // Resolution succeeds with [null]; required check rejects null values.
+    expect(err).toMatch(/output_required.*'a'.*null/);
+  });
+
+  it("with default (all) wildcard, requires every element to have non-null path", () => {
+    const data = { findings: [{ severity: "critical" }, { severity: null }] };
+    const err = checkOutputRequired(["findings[*].severity"], data);
+    expect(err).toMatch(/output_required/);
+  });
+
+  it("with default (all) wildcard, passes when every element has non-null path", () => {
+    const data = { findings: [{ severity: "critical" }, { severity: "low" }] };
+    expect(checkOutputRequired(["findings[*].severity"], data)).toBeNull();
+  });
+
+  it("with default (all) wildcard over empty array, vacuously passes", () => {
+    expect(checkOutputRequired(["findings[*].severity"], { findings: [] })).toBeNull();
+  });
+
+  it("with `any` wildcard, passes when at least one element has non-null path", () => {
+    const data = { findings: [{ severity: null }, { severity: "low" }] };
+    expect(checkOutputRequired(["any:findings[*].severity"], data)).toBeNull();
+  });
+
+  it("with `any` wildcard over empty array, fails", () => {
+    const err = checkOutputRequired(["any:findings[*].severity"], { findings: [] });
+    expect(err).toMatch(/output_required.*no elements/);
+  });
+
+  it("aggregates multiple required-path failures into one message", () => {
+    const err = checkOutputRequired(["a", "b"], {});
+    expect(err).toMatch(/'a'/);
+    expect(err).toMatch(/'b'/);
+  });
+});
+
+describe("checkOutputMatches", () => {
+  it("passes equals on a single value", () => {
+    expect(checkOutputMatches([{ path: "a", equals: 1 }], { a: 1 })).toBeNull();
+  });
+
+  it("fails equals on a mismatched value", () => {
+    const err = checkOutputMatches([{ path: "a", equals: 1 }], { a: 2 });
+    expect(err).toMatch(/output_matches.*'a'.*equals.*1.*got.*2/);
+  });
+
+  it("passes `in` when the value is in the set", () => {
+    expect(checkOutputMatches([{ path: "sev", in: ["high", "low"] }], { sev: "low" })).toBeNull();
+  });
+
+  it("fails `in` when the value is not in the set", () => {
+    const err = checkOutputMatches([{ path: "sev", in: ["high", "low"] }], { sev: "urgent" });
+    expect(err).toMatch(/output_matches.*'sev'.*in.*\[high, low\].*got.*urgent/);
+  });
+
+  it("passes `matches` when the regex matches the coerced string", () => {
+    expect(
+      checkOutputMatches([{ path: "url", matches: "^https://" }], { url: "https://x" }),
+    ).toBeNull();
+  });
+
+  it("fails `matches` when the regex does not match", () => {
+    const err = checkOutputMatches([{ path: "url", matches: "^https://" }], { url: "ftp://x" });
+    expect(err).toMatch(/output_matches.*'url'.*matches.*ftp/);
+  });
+
+  it("with default (all) wildcard, requires every element to satisfy operator", () => {
+    const data = { sevs: [{ s: "high" }, { s: "urgent" }] };
+    const err = checkOutputMatches([{ path: "sevs[*].s", in: ["high", "low"] }], data);
+    expect(err).toMatch(/output_matches/);
+  });
+
+  it("with default (all) wildcard, passes when every element satisfies operator", () => {
+    const data = { sevs: [{ s: "high" }, { s: "low" }] };
+    expect(
+      checkOutputMatches([{ path: "sevs[*].s", in: ["high", "low"] }], data),
+    ).toBeNull();
+  });
+
+  it("with default (all) wildcard over empty array, vacuously passes", () => {
+    expect(
+      checkOutputMatches([{ path: "sevs[*].s", in: ["high"] }], { sevs: [] }),
+    ).toBeNull();
+  });
+
+  it("with `any` wildcard, passes when at least one element satisfies operator", () => {
+    const data = { sevs: [{ s: "low" }, { s: "critical" }] };
+    expect(
+      checkOutputMatches([{ path: "any:sevs[*].s", equals: "critical" }], data),
+    ).toBeNull();
+  });
+
+  it("with `any` wildcard, fails when no element satisfies operator", () => {
+    const data = { sevs: [{ s: "low" }, { s: "high" }] };
+    const err = checkOutputMatches(
+      [{ path: "any:sevs[*].s", equals: "critical" }],
+      data,
+    );
+    expect(err).toMatch(/output_matches.*no element.*satisfied/);
+  });
+
+  it("with `any` wildcard over empty array, fails", () => {
+    const err = checkOutputMatches([{ path: "any:sevs[*].s", equals: "x" }], { sevs: [] });
+    expect(err).toMatch(/output_matches/);
+  });
+
+  it("fails when the path itself does not resolve", () => {
+    const err = checkOutputMatches([{ path: "missing", equals: 1 }], {});
+    expect(err).toMatch(/output_matches.*'missing'.*missing segment/);
+  });
+
+  it("aggregates multiple match failures into one message", () => {
+    const err = checkOutputMatches(
+      [
+        { path: "a", equals: 1 },
+        { path: "b", equals: 2 },
+      ],
+      { a: 999, b: 999 },
+    );
+    expect(err).toMatch(/'a'/);
+    expect(err).toMatch(/'b'/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: FAIL — `checkOutputRequired is not a function` / `checkOutputMatches is not a function`.
+
+- [ ] **Step 3: Implement the output check functions**
+
+Add to `packages/core/src/verify.ts` (below the tool-call checks):
+
+```ts
+import type { OutputMatch } from "./types.js";
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function formatValue(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "string") return v;
+  return JSON.stringify(v);
+}
+
+export function checkOutputRequired(paths: string[], data: unknown): string | null {
+  const failures: string[] = [];
+  for (const path of paths) {
+    const r = resolvePath(data, path);
+    if (!r.ok) {
+      failures.push(`'${path}' ${r.reason}`);
+      continue;
+    }
+    const allNonNull = r.values.every((v) => v !== null && v !== undefined);
+    const anyNonNull = r.values.some((v) => v !== null && v !== undefined);
+    if (r.mode === "all") {
+      // Vacuously true on empty values.
+      if (r.values.length > 0 && !allNonNull) {
+        failures.push(`'${path}' resolved to null/undefined value(s)`);
+      }
+    } else {
+      // any
+      if (r.values.length === 0) {
+        failures.push(`'${path}' (any:) resolved to no elements`);
+      } else if (!anyNonNull) {
+        failures.push(`'${path}' (any:) all resolved values are null/undefined`);
+      }
+    }
+  }
+  if (failures.length === 0) return null;
+  return `output_required: ${failures.join("; ")}`;
+}
+
+function applyOperator(m: OutputMatch, value: unknown): { ok: true } | { ok: false; reason: string } {
+  if (m.equals !== undefined) {
+    if (deepEqual(value, m.equals)) return { ok: true };
+    return { ok: false, reason: `equals ${formatValue(m.equals)}, got ${formatValue(value)}` };
+  }
+  if (m.in !== undefined) {
+    if (m.in.some((x) => deepEqual(value, x))) return { ok: true };
+    return {
+      ok: false,
+      reason: `in [${m.in.map(formatValue).join(", ")}], got ${formatValue(value)}`,
+    };
+  }
+  if (m.matches !== undefined) {
+    const re = new RegExp(m.matches);
+    const s = typeof value === "string" ? value : JSON.stringify(value);
+    if (re.test(s)) return { ok: true };
+    return { ok: false, reason: `matches /${m.matches}/, got ${formatValue(value)}` };
+  }
+  return { ok: false, reason: "no operator declared (zod should have caught this)" };
+}
+
+export function checkOutputMatches(matches: OutputMatch[], data: unknown): string | null {
+  const failures: string[] = [];
+  for (const m of matches) {
+    const r = resolvePath(data, m.path);
+    if (!r.ok) {
+      failures.push(`'${m.path}' ${r.reason}`);
+      continue;
+    }
+    if (r.mode === "all") {
+      if (r.values.length === 0) continue; // vacuously true
+      const firstFailure = r.values
+        .map((v) => applyOperator(m, v))
+        .find((res): res is { ok: false; reason: string } => !res.ok);
+      if (firstFailure) failures.push(`'${m.path}' ${firstFailure.reason}`);
+    } else {
+      // any
+      if (r.values.length === 0) {
+        failures.push(`'${m.path}' (any:) resolved to no elements`);
+        continue;
+      }
+      const anyOk = r.values.some((v) => applyOperator(m, v).ok);
+      if (!anyOk) {
+        failures.push(`'${m.path}' (any:) no element satisfied operator`);
+      }
+    }
+  }
+  if (failures.length === 0) return null;
+  return `output_matches: ${failures.join("; ")}`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: PASS — all output check tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/verify.ts packages/core/src/__tests__/verify.test.ts
+git commit -m "feat(core): add output_required and output_matches checks"
+```
+
+---
+
+## Task 5: Top-level `evaluateVerify` orchestrator — TDD
+
+**Files:**
+- Modify: `packages/core/src/verify.ts`
+- Modify: `packages/core/src/__tests__/verify.test.ts`
+
+The orchestrator runs every declared check (no fast-fail), concatenates non-null returns into a single multi-line error string, and returns `null` if everything passed (or if `verify` is undefined).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/src/__tests__/verify.test.ts`:
+
+```ts
+import { evaluateVerify } from "../verify.js";
+import type { NodeResult } from "../types.js";
+
+const result = (data: Record<string, unknown>, toolCalls: ToolCall[] = []): NodeResult => ({
+  status: "success",
+  data,
+  toolCalls,
+});
+
+describe("evaluateVerify", () => {
+  it("returns null when verify is undefined", () => {
+    expect(evaluateVerify(undefined, result({}))).toBeNull();
+  });
+
+  it("returns null when every declared check passes", () => {
+    const v = {
+      any_tool_called: ["a"],
+      output_required: ["x"],
+      output_matches: [{ path: "x", equals: 1 }],
+    };
+    const r = result({ x: 1 }, [tc("a", { ok: true })]);
+    expect(evaluateVerify(v, r)).toBeNull();
+  });
+
+  it("aggregates failures from multiple checks into one error string", () => {
+    const v = {
+      any_tool_called: ["create_pr"],
+      no_tool_called: ["force_push"],
+      output_required: ["prUrl"],
+      output_matches: [{ path: "branch", matches: "^sweny/" }],
+    };
+    const r = result({ branch: "main" }, [tc("force_push", { ok: true })]);
+    const err = evaluateVerify(v, r);
+    expect(err).not.toBeNull();
+    expect(err!).toMatch(/^verify failed:/);
+    expect(err!).toMatch(/any_tool_called/);
+    expect(err!).toMatch(/no_tool_called/);
+    expect(err!).toMatch(/output_required/);
+    expect(err!).toMatch(/output_matches/);
+  });
+
+  it("formats failures as a bulleted list", () => {
+    const v = { any_tool_called: ["a"], no_tool_called: ["b"] };
+    const r = result({}, [tc("b")]);
+    const err = evaluateVerify(v, r);
+    expect(err).toMatch(/\n {2}- /);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: FAIL — `evaluateVerify is not a function`.
+
+- [ ] **Step 3: Implement the orchestrator**
+
+Add to `packages/core/src/verify.ts` (at the bottom):
+
+```ts
+import type { NodeResult, NodeVerify } from "./types.js";
+
+/**
+ * Evaluate every declared check and return a concatenated error string,
+ * or null when the node passes verification (or has no verify block).
+ *
+ * Deterministic and side-effect free — the executor calls this synchronously
+ * after the LLM finishes.
+ */
+export function evaluateVerify(verify: NodeVerify | undefined, result: NodeResult): string | null {
+  if (!verify) return null;
+
+  const failures: string[] = [];
+
+  if (verify.any_tool_called && verify.any_tool_called.length > 0) {
+    const e = checkAnyToolCalled(verify.any_tool_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.all_tools_called && verify.all_tools_called.length > 0) {
+    const e = checkAllToolsCalled(verify.all_tools_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.no_tool_called && verify.no_tool_called.length > 0) {
+    const e = checkNoToolCalled(verify.no_tool_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.output_required && verify.output_required.length > 0) {
+    const e = checkOutputRequired(verify.output_required, result.data);
+    if (e) failures.push(e);
+  }
+  if (verify.output_matches && verify.output_matches.length > 0) {
+    const e = checkOutputMatches(verify.output_matches, result.data);
+    if (e) failures.push(e);
+  }
+
+  if (failures.length === 0) return null;
+  return `verify failed:\n  - ${failures.join("\n  - ")}`;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/verify.test.ts`
+Expected: PASS — all verify tests green (resolver + tool checks + output checks + orchestrator).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/verify.ts packages/core/src/__tests__/verify.test.ts
+git commit -m "feat(core): add evaluateVerify orchestrator"
+```
+
+---
+
+## Task 6: Wire executor.ts to the new verify module
+
+**Files:**
+- Modify: `packages/core/src/executor.ts:260-290`
+
+Delete the inline `evaluateVerify` and import from `./verify.js`. The existing executor test at `executor.test.ts:585-610` validates that `verify.any_tool_called` failures still mark the node failed and produce an error string. That test asserts `error` matches `/verify\.any_tool_called failed/` — the new error format is different, so that assertion needs updating. Update it to match the new format `/verify failed:.*any_tool_called/`.
+
+- [ ] **Step 1: Replace the inline `evaluateVerify` with an import**
+
+In `packages/core/src/executor.ts`, replace lines 260-290 (the `// ─── Internals ───` comment block and the entire `evaluateVerify` function definition) with:
+
+```ts
+// ─── Internals ───────────────────────────────────────────────────
+
+import { evaluateVerify } from "./verify.js";
+```
+
+Move the `import { evaluateVerify } from "./verify.js";` line up to the existing import block at the top of the file (next to other type/module imports). The `// ─── Internals ───` comment can stay if there are other internal helpers below it; check the surrounding code before deleting.
+
+- [ ] **Step 2: Update the existing executor verify test to match the new error format**
+
+In `packages/core/src/__tests__/executor.test.ts`, find the assertion at line 608:
+
+```ts
+expect(r.data.error).toMatch(/verify\.any_tool_called failed/);
+```
+
+Replace with:
+
+```ts
+expect(r.data.error).toMatch(/verify failed:.*any_tool_called/s);
+```
+
+Find any sibling tests below it in the same `describe("node.verify")` block (lines 612+) that assert against the old format and update them similarly. Search the file for `verify\\.any_tool_called` — every occurrence needs updating to the new pattern.
+
+- [ ] **Step 3: Run the executor test suite to verify backwards compatibility**
+
+Run: `cd packages/core && npx vitest run src/__tests__/executor.test.ts`
+Expected: PASS — all existing tests, including the `node.verify` describe block, green.
+
+- [ ] **Step 4: Run the full core test suite**
+
+Run: `cd packages/core && npm test`
+Expected: PASS — every test in the package green. The verify refactor should not affect anything outside the verify and executor tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/executor.ts packages/core/src/__tests__/executor.test.ts
+git commit -m "refactor(core): route executor verify through verify.ts module"
+```
+
+---
+
+## Task 7: Extend the zod schema for new verify fields
+
+**Files:**
+- Modify: `packages/core/src/schema.ts:90-96`
+- Modify: `packages/core/src/__tests__/schema.test.ts`
+
+Add `outputMatchZ` and extend `nodeVerifyZ` so workflow authors can declare the new fields. The refine ("must declare ≥1 check") expands to "≥1 of any of these fields".
+
+- [ ] **Step 1: Write the failing schema tests**
+
+In `packages/core/src/__tests__/schema.test.ts`, find the existing `describe` block for `node.verify` (search for `accepts a verify block with any_tool_called` — it's around line 67-82). Append these tests inside the same describe block:
+
+```ts
+it("accepts all_tools_called", () => {
+  const v = nodeVerifyZ.parse({ all_tools_called: ["a", "b"] });
+  expect(v.all_tools_called).toEqual(["a", "b"]);
+});
+
+it("accepts no_tool_called", () => {
+  const v = nodeVerifyZ.parse({ no_tool_called: ["force_push"] });
+  expect(v.no_tool_called).toEqual(["force_push"]);
+});
+
+it("accepts output_required", () => {
+  const v = nodeVerifyZ.parse({ output_required: ["prUrl", "branch"] });
+  expect(v.output_required).toEqual(["prUrl", "branch"]);
+});
+
+it("accepts output_matches with each operator", () => {
+  const v = nodeVerifyZ.parse({
+    output_matches: [
+      { path: "a", equals: 1 },
+      { path: "b", in: ["x", "y"] },
+      { path: "c", matches: "^foo" },
+    ],
+  });
+  expect(v.output_matches).toHaveLength(3);
+});
+
+it("accepts a combination of multiple checks", () => {
+  const v = nodeVerifyZ.parse({
+    any_tool_called: ["a"],
+    output_required: ["x"],
+    output_matches: [{ path: "x", equals: 1 }],
+  });
+  expect(v.any_tool_called).toBeDefined();
+  expect(v.output_required).toBeDefined();
+  expect(v.output_matches).toBeDefined();
+});
+
+it("rejects an output_matches entry with zero operators", () => {
+  expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a" }] })).toThrow();
+});
+
+it("rejects an output_matches entry with two operators", () => {
+  expect(() =>
+    nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: 1, in: [1, 2] }] }),
+  ).toThrow();
+});
+
+it("rejects an output_matches entry with empty path", () => {
+  expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "", equals: 1 }] })).toThrow();
+});
+
+it("rejects empty output_required", () => {
+  expect(() => nodeVerifyZ.parse({ output_required: [] })).toThrow();
+});
+
+it("rejects empty all_tools_called", () => {
+  expect(() => nodeVerifyZ.parse({ all_tools_called: [] })).toThrow();
+});
+
+it("rejects empty no_tool_called", () => {
+  expect(() => nodeVerifyZ.parse({ no_tool_called: [] })).toThrow();
+});
+
+it("rejects empty output_matches array", () => {
+  expect(() => nodeVerifyZ.parse({ output_matches: [] })).toThrow();
+});
+```
+
+- [ ] **Step 2: Run the schema tests to verify they fail**
+
+Run: `cd packages/core && npx vitest run src/__tests__/schema.test.ts`
+Expected: FAIL — the existing zod schema doesn't know about the new fields.
+
+- [ ] **Step 3: Extend the zod schema**
+
+In `packages/core/src/schema.ts`, replace the existing `nodeVerifyZ` (lines 90-96) with:
+
+```ts
+export const outputMatchZ = z
+  .object({
+    path: z.string().min(1),
+    equals: z.unknown().optional(),
+    in: z.array(z.unknown()).optional(),
+    matches: z.string().min(1).optional(),
+  })
+  .refine(
+    (m) => {
+      const operators = [m.equals !== undefined, m.in !== undefined, m.matches !== undefined];
+      return operators.filter(Boolean).length === 1;
+    },
+    { message: "output_matches entry must declare exactly one of: equals, in, matches" },
+  );
+
+export const nodeVerifyZ = z
+  .object({
+    any_tool_called: z.array(z.string().min(1)).min(1).optional(),
+    all_tools_called: z.array(z.string().min(1)).min(1).optional(),
+    no_tool_called: z.array(z.string().min(1)).min(1).optional(),
+    output_required: z.array(z.string().min(1)).min(1).optional(),
+    output_matches: z.array(outputMatchZ).min(1).optional(),
+  })
+  .refine(
+    (v) =>
+      v.any_tool_called !== undefined ||
+      v.all_tools_called !== undefined ||
+      v.no_tool_called !== undefined ||
+      v.output_required !== undefined ||
+      v.output_matches !== undefined,
+    {
+      message:
+        "verify must declare at least one check (any_tool_called, all_tools_called, no_tool_called, output_required, or output_matches)",
+    },
+  );
+```
+
+- [ ] **Step 4: Run the schema tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/schema.test.ts`
+Expected: PASS — all new and pre-existing schema tests green.
+
+- [ ] **Step 5: Run the full core test suite to confirm nothing else broke**
+
+Run: `cd packages/core && npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/schema.ts packages/core/src/__tests__/schema.test.ts
+git commit -m "feat(core): zod schema for new verify fields"
+```
+
+---
+
+## Task 8: Executor integration tests for new check types
+
+**Files:**
+- Modify: `packages/core/src/__tests__/executor.test.ts`
+
+The unit tests in `verify.test.ts` cover the check evaluators in isolation. These integration tests confirm the executor wiring works end-to-end: a workflow declaring a new check actually marks the node failed when the check fails, with the error visible on `result.data.error`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Find the `describe("node.verify", ...)` block in `packages/core/src/__tests__/executor.test.ts` (around line 571). Append the following tests inside it:
+
+```ts
+it("marks node failed when all_tools_called missing a required tool", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: { all_tools_called: ["a", "b"] },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return { status: "success", data: {}, toolCalls: [{ tool: "a", input: {}, output: { ok: true } }] };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("failed");
+  expect(r.data.error).toMatch(/verify failed.*all_tools_called.*\[b\]/s);
+});
+
+it("marks node failed when no_tool_called was violated", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: { no_tool_called: ["force_push"] },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return {
+        status: "success",
+        data: {},
+        toolCalls: [{ tool: "force_push", input: {}, output: { ok: true } }],
+      };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("failed");
+  expect(r.data.error).toMatch(/verify failed.*no_tool_called.*force_push/s);
+});
+
+it("marks node failed when output_required is missing", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: { output_required: ["prUrl"] },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return { status: "success", data: { branch: "main" }, toolCalls: [] };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("failed");
+  expect(r.data.error).toMatch(/verify failed.*output_required.*'prUrl'/s);
+});
+
+it("marks node failed when output_matches assertion fails", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: { output_matches: [{ path: "branch", matches: "^sweny/" }] },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return { status: "success", data: { branch: "main" }, toolCalls: [] };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("failed");
+  expect(r.data.error).toMatch(/verify failed.*output_matches.*'branch'/s);
+});
+
+it("aggregates multiple verify failures into one error string", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: {
+          all_tools_called: ["create_pr"],
+          output_required: ["prUrl"],
+        },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return { status: "success", data: {}, toolCalls: [] };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("failed");
+  expect(r.data.error).toMatch(/all_tools_called/);
+  expect(r.data.error).toMatch(/output_required/);
+});
+
+it("passes a node when every declared check passes", async () => {
+  const wf: Workflow = {
+    id: "wf",
+    name: "wf",
+    description: "",
+    entry: "n",
+    nodes: {
+      n: {
+        name: "N",
+        instruction: "Do",
+        skills: [],
+        verify: {
+          all_tools_called: ["create_pr"],
+          no_tool_called: ["force_push"],
+          output_required: ["prUrl"],
+          output_matches: [{ path: "prUrl", matches: "^https://" }],
+        },
+      },
+    },
+    edges: [],
+  };
+  const claude: any = {
+    async run() {
+      return {
+        status: "success",
+        data: { prUrl: "https://github.com/x/y/pull/1" },
+        toolCalls: [{ tool: "create_pr", input: {}, output: { ok: true } }],
+      };
+    },
+    async evaluate(opts: any) {
+      return opts.choices[0]?.id;
+    },
+  };
+  const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+  const r = results.get("n")!;
+  expect(r.status).toBe("success");
+  expect(r.data.error).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the executor tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run src/__tests__/executor.test.ts`
+Expected: PASS — including the new tests for each check type.
+
+- [ ] **Step 3: Run the full core test suite**
+
+Run: `cd packages/core && npm test`
+Expected: PASS — every test in the package green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/__tests__/executor.test.ts
+git commit -m "test(core): integration tests for new verify checks"
+```
+
+---
+
+## Task 9: Document the Verify feature in the public spec
+
+**Files:**
+- Modify: `spec/src/content/docs/nodes.mdx`
+
+Add a top-level **Verify** section. The spec site is built with Astro Starlight (mdx). Existing sections in `nodes.mdx` use `##` for top-level section headings; mirror that style.
+
+- [ ] **Step 1: Read the current `nodes.mdx` and find a sensible insertion point**
+
+Read `/Users/nate/src/swenyai/sweny/spec/src/content/docs/nodes.mdx` end-to-end. Note the heading pattern (`##` for top-level sections), where the file ends, and any existing references to `verify` (there should be none).
+
+The Verify section should sit *after* `output` (machine-checked post-conditions are conceptually a sibling of output schemas) and *before* `max_turns` / any execution-control fields. If there's no clear place, append it at the end of the file before any final reference table.
+
+- [ ] **Step 2: Insert the Verify section**
+
+Add a new section to `spec/src/content/docs/nodes.mdx`:
+
+````mdx
+## Verify
+
+The optional `verify` block defines machine-checked post-conditions evaluated by the executor *after* the LLM finishes. If any declared check fails, the node is marked `failed` even if the model itself returned success — this catches the common case of a model claiming success without actually invoking the side-effectful tool (or producing the required output shape).
+
+Verify is a *post-condition*: it runs once, after the node's LLM turns complete, against the resulting tool-call log and structured output. It does not modify the node's behavior.
+
+All declared checks are AND-ed. The executor runs every check (no fast-fail) and concatenates failures into a single error string on `result.data.error`.
+
+### Tool-call checks
+
+Three checks operate on the node's tool-call log. A tool "succeeded" if it appears in the log without an `error` field on its output.
+
+```yaml
+verify:
+  any_tool_called: [linear_create_issue, github_create_issue]
+  all_tools_called: [github_create_pr]
+  no_tool_called:   [github_force_push]
+```
+
+| Field | Passes when |
+|-------|-------------|
+| `any_tool_called`  | At least one of the named tools was called and succeeded. |
+| `all_tools_called` | Every named tool was called and succeeded at least once. |
+| `no_tool_called`   | None of the named tools were invoked (success or failure). |
+
+Each list must contain at least one tool name.
+
+### Output checks
+
+Two checks operate on the node's structured output (`result.data`).
+
+```yaml
+verify:
+  output_required: [prUrl, branchName]
+  output_matches:
+    - { path: prUrl,                    matches: "^https://github.com/" }
+    - { path: branchName,               matches: "^sweny/" }
+    - { path: any:checks[*].conclusion, equals:  "success" }
+```
+
+`output_required` takes a list of paths, each of which must resolve to a present, non-null value.
+
+`output_matches` takes a list of assertions. Each assertion declares a `path` and *exactly one* operator:
+
+| Operator | Meaning |
+|----------|---------|
+| `equals: x`     | Value is deep-equal to `x`. |
+| `in: [x, y, z]` | Value is deep-equal to one element of the array. |
+| `matches: "re"` | Value (coerced to string) matches the regex (no flags, no surrounding slashes). |
+
+### Path grammar
+
+A path is a `.`-separated sequence of segments. A segment is either:
+
+- An identifier matching `[a-zA-Z_][a-zA-Z0-9_]*` — object property access, OR
+- An identifier followed by `[*]` — wildcard expansion over an array.
+
+Examples: `issueIdentifier`, `findings[*].severity`, `issues[*].metadata.url`.
+
+A path may be prefixed with `all:` or `any:` to set wildcard semantics. The default when no prefix is given is `all:`.
+
+#### Path resolution
+
+A path resolves against `result.data` by walking segments left-to-right:
+
+- A non-wildcard segment that doesn't exist on the parent object → resolution **fails**. Both `output_required` and `output_matches` treat a failed resolution as a failed check, with the missing segment named in the error.
+- A `[*]` segment requires the parent to be an array. If the parent isn't an array → resolution fails. If the parent is an array (even empty), expansion succeeds.
+- A `null` encountered mid-path → resolution fails.
+
+#### Wildcard semantics
+
+When a path contains `[*]` and resolution succeeds, the mode prefix decides how the operator is combined across the resolved values:
+
+- `all:` (default) — every resolved value must satisfy the operator. Empty array → vacuously true.
+- `any:` — at least one resolved value must satisfy. Empty array → false.
+
+`output_required` follows the same rule: `output_required: ["findings[*].severity"]` means the `findings` array exists and every finding has a non-null `severity`. `output_required: ["any:findings[*].severity"]` means the array exists and at least one element does.
+
+### Failure reporting
+
+Failed checks are concatenated into a single error string on `result.data.error`:
+
+```
+verify failed:
+  - any_tool_called: required one of [linear_create_issue, github_create_issue] to succeed, called: [linear_search_issues]
+  - output_required: 'issueUrl' missing segment 'issueUrl'
+  - output_matches: 'findings[*].severity' in [critical, high, medium, low], got urgent
+```
+
+The node's `status` is set to `failed`. `NodeResult` has no separate `verifyFailures` field — everything you need is in the error string.
+
+### Worked example
+
+```yaml
+nodes:
+  open-pr:
+    name: Open PR
+    instruction: Create a PR for the fix branch.
+    skills: [github]
+    output:
+      type: object
+      properties:
+        prUrl: { type: string }
+        branchName: { type: string }
+    verify:
+      all_tools_called: [github_create_pr]
+      no_tool_called:   [github_force_push]
+      output_required:  [prUrl, branchName]
+      output_matches:
+        - { path: prUrl,      matches: "^https://github.com/" }
+        - { path: branchName, matches: "^sweny/" }
+```
+
+### When to use verify
+
+Use verify when the model has a plausible way to fake success — typically when a node's job is to invoke a side-effectful tool (create an issue, open a PR, send a notification). The check costs nothing at runtime and turns a class of silent failures into loud, debuggable ones.
+
+Don't reach for verify to express logic that belongs in a follow-on workflow node (e.g. "if the PR is large, request review from senior eng"). Conditional edges and additional nodes are the right tools for that.
+````
+
+- [ ] **Step 3: Build the spec site to confirm it renders**
+
+Run: `cd spec && npm run build`
+Expected: Astro build succeeds with no errors. mdx will fail loudly on bad syntax.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/src/content/docs/nodes.mdx
+git commit -m "docs(spec): document the verify block on nodes"
+```
+
+---
+
+## Task 10: Final pass — run all tests and confirm green
+
+- [ ] **Step 1: Run the full core test suite**
+
+Run: `cd packages/core && npm test`
+Expected: PASS — every test in the package green, no skips.
+
+- [ ] **Step 2: Run the spec-conformance test**
+
+Run: `cd packages/core && npx vitest run src/__tests__/spec-conformance.test.ts`
+Expected: PASS. (If this test references a list of supported `verify` fields, it may need updating — check the file before assuming pass.)
+
+- [ ] **Step 3: Build the entire monorepo**
+
+Run: `cd /Users/nate/src/swenyai/sweny && npm run build`
+Expected: PASS — every package builds cleanly.
+
+- [ ] **Step 4: Final commit if anything was touched**
+
+If steps 2 or 3 surfaced anything that needed a fix, commit that fix here:
+
+```bash
+git add -A
+git commit -m "chore: final verify v2 cleanup"
+```
+
+If nothing else changed, skip this step.
+
+---
+
+## Self-review checklist
+
+Run this after the plan is written.
+
+**Spec coverage:**
+- [x] Tool-call checks `any_tool_called`, `all_tools_called`, `no_tool_called` — Tasks 3, 7, 8
+- [x] Output checks `output_required`, `output_matches` with operators `equals | in | matches` — Tasks 4, 7, 8
+- [x] Path grammar (dotted + `[*]`) — Task 2
+- [x] `all:`/`any:` wildcard prefixes with `all:` default — Task 2
+- [x] Failure reporting (run all, concat into one string) — Task 5, 6, 8
+- [x] `NodeResult` shape unchanged — verified by Task 6 (executor tests still assert on `r.data.error`)
+- [x] Backwards compat for `any_tool_called` — verified by Task 6 (existing test still passes after format update)
+- [x] Spec doc updates — Task 9
+
+**Placeholder scan:** no TBDs, no "implement later", every code step shows the actual code.
+
+**Type consistency:** `evaluateVerify`, `resolvePath`, `checkAnyToolCalled`, `checkAllToolsCalled`, `checkNoToolCalled`, `checkOutputRequired`, `checkOutputMatches`, `OutputMatch`, `Resolution` — all spelled identically across tasks.
+
+**Commit cadence:** one commit per task (Tasks 1–9), final cleanup commit (Task 10) only if needed.

--- a/docs/superpowers/specs/2026-04-18-verify-v2-design.md
+++ b/docs/superpowers/specs/2026-04-18-verify-v2-design.md
@@ -1,0 +1,183 @@
+# Verify v2 — Extensible Node Post-Conditions
+
+**Status:** Draft
+**Date:** 2026-04-18
+**Owner:** nate
+
+## Context
+
+The workflow node spec already supports a `verify` block — a machine-checked post-condition the executor evaluates after the LLM finishes. Today it offers exactly one check, `any_tool_called`, which asserts that at least one of a named set of tools was invoked successfully during the node's execution. The check exists in `packages/core/src/{types.ts,schema.ts,executor.ts}` and is used by `packages/core/src/workflows/triage.yml` to catch the common "model claims success without doing the work" failure mode.
+
+Two problems:
+
+1. **One check isn't enough.** Real workflows want to assert "every named tool ran" (not just any), "this tool *didn't* run", and assertions against the node's structured output (e.g. "every finding has a valid severity"). Today the only escape is to add an entire workflow node, which is overkill.
+2. **The current check isn't documented in the public spec.** The Astro spec site at `spec/src/content/docs/nodes.mdx` has no `verify` section. The schema, executor, and a real workflow all reference `any_tool_called`, but a workflow author reading the spec wouldn't know it exists.
+
+This spec extends `verify` with a small, declarative set of additional checks and formalises the entire feature in the public spec.
+
+## Goals
+
+- Keep `verify` *declarative*. No mini-DSL, no expression language, no JS-in-YAML.
+- Cover the obvious tool-call shape variants (`all`, `none`, in addition to `any`).
+- Cover assertions against the node's structured output (`result.data`).
+- Stay backwards-compatible — `any_tool_called` keeps its current shape and meaning.
+- Document the feature end-to-end in `spec/src/content/docs/nodes.mdx`.
+
+## Non-goals
+
+- JSONPath / JMESPath / CEL / arbitrary expressions. Deferred.
+- Conditional checks (`when:` on a verify entry) — overlaps with conditional edges.
+- Cross-node verify (assert against an upstream node's result). Revisit if real demand emerges.
+- Assertions on tool *inputs* ("`github_create_pr` was called with title matching X"). Adds a query layer; revisit later.
+- `min_tool_calls`, `output_equals` — covered by other checks.
+- Structured `verifyFailures: []` field on `NodeResult`. Deferred until Studio or cloud has a UI panel that would render it specially.
+
+## Design
+
+### Schema
+
+```ts
+export interface NodeVerify {
+  /** ≥1 of these tools was called and succeeded. */
+  any_tool_called?: string[];
+  /** Every named tool was called and succeeded at least once. */
+  all_tools_called?: string[];
+  /** None of these tools may have been called. */
+  no_tool_called?: string[];
+  /** Listed paths must be present and non-null (see Path resolution). */
+  output_required?: string[];
+  /** Each assertion must hold against `result.data`. */
+  output_matches?: OutputMatch[];
+}
+
+export interface OutputMatch {
+  /** Dotted path; supports `[*]` wildcard; optional `all:`/`any:` prefix. */
+  path: string;
+  equals?: unknown;
+  in?: unknown[];
+  /** Regex source (no flags). */
+  matches?: string;
+}
+```
+
+Schema constraints (Zod):
+
+- The existing refine ("verify must declare ≥1 check") expands to "≥1 of any of these fields".
+- `OutputMatch` requires *exactly one* of `equals | in | matches` per entry.
+- All string-array fields require `min(1)` length on the array (matches existing rule for `any_tool_called`).
+- `path` is non-empty.
+
+### Path grammar
+
+A path is a `.`-separated sequence of segments. A segment is either:
+
+- An identifier matching `[a-zA-Z_][a-zA-Z0-9_]*` — object property access, OR
+- An identifier followed by `[*]` — wildcard expansion over an array.
+
+Examples: `issueIdentifier`, `findings[*].severity`, `issues[*].metadata.url`.
+
+A path may be prefixed with `all:` or `any:` to set wildcard semantics. The default when no prefix is given is `all:`.
+
+The grammar is intentionally tiny so it can be parsed with ~30 lines of code, specified in one paragraph, and rendered cleanly in Studio. We can graduate to JSONPath later if real demand appears.
+
+### Operators (`output_matches`)
+
+Exactly one operator per `OutputMatch` entry. The operator runs against each value the path resolves to:
+
+| Operator        | Meaning                                                        |
+|-----------------|----------------------------------------------------------------|
+| `equals: x`     | Strict deep equality (e.g. `lodash.isEqual`).                  |
+| `in: [x, y, z]` | Value is in the array (deep equality per element).             |
+| `matches: "re"` | Value is coerced to string and tested against the JS regex.    |
+
+Future operators (`gt`, `lt`, `not_equals`, `not_in`) are deliberately out of scope for v1.
+
+### Path resolution
+
+A path is resolved by walking segments left-to-right against `result.data`:
+
+- A non-wildcard segment that doesn't exist on the parent object → **resolution fails**. `output_required` and `output_matches` both treat a failed resolution as a failed check (with a clear error message naming the missing segment).
+- A `[*]` segment requires the parent to be an array. If the parent isn't an array → resolution fails. If the parent is an array (even empty), expansion succeeds and the wildcard rule below applies.
+- A `null` encountered mid-path → resolution fails.
+
+### Wildcard semantics
+
+When a path contains `[*]` and resolution succeeds:
+
+- `all:` (default) — every resolved value satisfies the operator. Empty array → vacuously true.
+- `any:` — at least one resolved value satisfies. Empty array → false.
+
+`output_required` follows the same rule: `output_required: ["findings[*].severity"]` (default `all:`) means the `findings` array exists and every finding has a present, non-null `severity`. `output_required: ["any:findings[*].severity"]` means the `findings` array exists and at least one finding has a non-null `severity`.
+
+### Combining checks
+
+All checks declared on a node are AND-ed. Order doesn't matter. The node passes verify only if every declared check passes.
+
+### Failure reporting
+
+Executor runs all declared checks (no fast-fail). Failed checks are concatenated into a single error string set on `result.data.error`:
+
+```
+verify failed:
+  - any_tool_called: required one of [linear_create_issue, github_create_issue], called: [linear_search_issues]
+  - output_required: 'issueUrl' missing
+  - output_matches: findings[*].severity not in [critical, high, medium, low] (got: [urgent])
+```
+
+`NodeResult` shape is unchanged. No new fields, no consumer changes in cloud worker, studio, MCP, or web.
+
+### Tool-call success rule (unchanged)
+
+A tool "was called and succeeded" if it appears in `result.toolCalls` with no `output.error`. The rule is shared by all three tool-call checks (`any_tool_called`, `all_tools_called`, `no_tool_called`). For `no_tool_called`, *any* appearance in `result.toolCalls` (success or failure) counts as a violation — the intent is "this tool must not have been invoked at all".
+
+### Worked example
+
+```yaml
+verify:
+  all_tools_called: [github_create_pr]
+  no_tool_called:   [github_force_push]
+  output_required:  [prUrl, branchName]
+  output_matches:
+    - { path: prUrl,                    matches: "^https://github.com/" }
+    - { path: branchName,               matches: "^sweny/" }
+    - { path: any:checks[*].conclusion, equals:  "success" }
+```
+
+### Spec representation
+
+A new top-level **Verify** section in `spec/src/content/docs/nodes.mdx`:
+
+1. *What verify is for.* Post-condition vs pre-condition. Complements (does not replace) conditional edges.
+2. *Tool-call checks* — `any_tool_called`, `all_tools_called`, `no_tool_called` with one example each.
+3. *Output checks* — `output_required`, `output_matches`, the path grammar, wildcard semantics, operator table.
+4. *Combining checks & failure reporting.*
+5. *Worked example* (the YAML block above).
+
+## Backwards compatibility
+
+`any_tool_called` keeps its current shape and semantics. `triage.yml` works unchanged. No migration needed for existing workflows.
+
+## Implementation footprint
+
+| File                                              | Change                                                                 |
+|---------------------------------------------------|------------------------------------------------------------------------|
+| `packages/core/src/types.ts`                      | Extend `NodeVerify`, add `OutputMatch` (~10 lines).                    |
+| `packages/core/src/schema.ts`                     | Extend `nodeVerifyZ`, add `outputMatchZ`, refine logic (~40 lines).    |
+| `packages/core/src/executor.ts`                   | Rewrite `evaluateVerify` (run-all + concat). Path resolver (~80 lines).|
+| `packages/core/src/__tests__/schema.test.ts`      | Coverage per check (~80 lines).                                        |
+| `packages/core/src/__tests__/executor.test.ts`    | Coverage per check + path/wildcard edge cases (~120 lines).            |
+| `spec/src/content/docs/nodes.mdx`                 | New Verify section (~150 lines).                                       |
+| Cloud worker, studio, MCP, web                    | No changes.                                                            |
+
+## Open questions
+
+None at this time. All design questions resolved during brainstorming (see decisions log below).
+
+## Decisions log
+
+- **Scope of verify:** Tool calls + structured output. Arbitrary expressions deferred.
+- **Check inventory:** `any_tool_called`, `all_tools_called`, `no_tool_called`, `output_required`, `output_matches` (array form only).
+- **Path grammar:** Dotted with `[*]` wildcard. No JSONPath.
+- **Failure reporting:** Run all checks, concatenate into one error string. `NodeResult` shape unchanged.
+- **Wildcard semantics:** Explicit `all:`/`any:` prefix, with `all:` as the implicit default. Removes ambiguity for readers without forcing verbosity in the common case.
+- **`output_matches` operators (v1):** `equals`, `in`, `matches`. Negative and comparison operators deferred.

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -605,7 +605,7 @@ describe("executor", () => {
       const { results } = await execute(verifyWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
       const r = results.get("create")!;
       expect(r.status).toBe("failed");
-      expect(r.data.error).toMatch(/verify\.any_tool_called failed/);
+      expect(r.data.error).toMatch(/verify failed:.*any_tool_called/s);
       expect(r.data.error).toMatch(/linear_create_issue/);
     });
 

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -665,5 +665,206 @@ describe("executor", () => {
       expect(results.get("create")!.status).toBe("failed");
       expect(results.get("create")!.data.error).toBe("max_turns");
     });
+
+    it("marks node failed when all_tools_called missing a required tool", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: { all_tools_called: ["a", "b"] },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: {},
+            toolCalls: [{ tool: "a", input: {}, output: { ok: true } }],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/verify failed.*all_tools_called.*\[b\]/s);
+    });
+
+    it("marks node failed when no_tool_called was violated", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: { no_tool_called: ["force_push"] },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: {},
+            toolCalls: [{ tool: "force_push", input: {}, output: { ok: true } }],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/verify failed.*no_tool_called.*force_push/s);
+    });
+
+    it("marks node failed when output_required is missing", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: { output_required: ["prUrl"] },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return { status: "success", data: { branch: "main" }, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/verify failed.*output_required.*'prUrl'/s);
+    });
+
+    it("marks node failed when output_matches assertion fails", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: { output_matches: [{ path: "branch", matches: "^sweny/" }] },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return { status: "success", data: { branch: "main" }, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/verify failed.*output_matches.*'branch'/s);
+    });
+
+    it("aggregates multiple verify failures into one error string", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: {
+              all_tools_called: ["create_pr"],
+              output_required: ["prUrl"],
+            },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return { status: "success", data: {}, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("failed");
+      expect(r.data.error).toMatch(/all_tools_called/);
+      expect(r.data.error).toMatch(/output_required/);
+    });
+
+    it("passes a node when every declared check passes", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "n",
+        nodes: {
+          n: {
+            name: "N",
+            instruction: "Do",
+            skills: [],
+            verify: {
+              all_tools_called: ["create_pr"],
+              no_tool_called: ["force_push"],
+              output_required: ["prUrl"],
+              output_matches: [{ path: "prUrl", matches: "^https://" }],
+            },
+          },
+        },
+        edges: [],
+      };
+      const claude: any = {
+        async run() {
+          return {
+            status: "success",
+            data: { prUrl: "https://github.com/x/y/pull/1" },
+            toolCalls: [{ tool: "create_pr", input: {}, output: { ok: true } }],
+          };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+      const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+      const r = results.get("n")!;
+      expect(r.status).toBe("success");
+      expect(r.data.error).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   workflowZ,
   nodeZ,
+  nodeVerifyZ,
   edgeZ,
   skillZ,
   toolZ,
@@ -79,6 +80,71 @@ describe("Zod schemas", () => {
 
     it("rejects verify with empty any_tool_called", () => {
       expect(() => nodeZ.parse({ name: "S", instruction: "I", verify: { any_tool_called: [] } })).toThrow();
+    });
+
+    it("accepts all_tools_called", () => {
+      const v = nodeVerifyZ.parse({ all_tools_called: ["a", "b"] });
+      expect(v.all_tools_called).toEqual(["a", "b"]);
+    });
+
+    it("accepts no_tool_called", () => {
+      const v = nodeVerifyZ.parse({ no_tool_called: ["force_push"] });
+      expect(v.no_tool_called).toEqual(["force_push"]);
+    });
+
+    it("accepts output_required", () => {
+      const v = nodeVerifyZ.parse({ output_required: ["prUrl", "branch"] });
+      expect(v.output_required).toEqual(["prUrl", "branch"]);
+    });
+
+    it("accepts output_matches with each operator", () => {
+      const v = nodeVerifyZ.parse({
+        output_matches: [
+          { path: "a", equals: 1 },
+          { path: "b", in: ["x", "y"] },
+          { path: "c", matches: "^foo" },
+        ],
+      });
+      expect(v.output_matches).toHaveLength(3);
+    });
+
+    it("accepts a combination of multiple checks", () => {
+      const v = nodeVerifyZ.parse({
+        any_tool_called: ["a"],
+        output_required: ["x"],
+        output_matches: [{ path: "x", equals: 1 }],
+      });
+      expect(v.any_tool_called).toBeDefined();
+      expect(v.output_required).toBeDefined();
+      expect(v.output_matches).toBeDefined();
+    });
+
+    it("rejects an output_matches entry with zero operators", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a" }] })).toThrow();
+    });
+
+    it("rejects an output_matches entry with two operators", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: 1, in: [1, 2] }] })).toThrow();
+    });
+
+    it("rejects an output_matches entry with empty path", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "", equals: 1 }] })).toThrow();
+    });
+
+    it("rejects empty output_required", () => {
+      expect(() => nodeVerifyZ.parse({ output_required: [] })).toThrow();
+    });
+
+    it("rejects empty all_tools_called", () => {
+      expect(() => nodeVerifyZ.parse({ all_tools_called: [] })).toThrow();
+    });
+
+    it("rejects empty no_tool_called", () => {
+      expect(() => nodeVerifyZ.parse({ no_tool_called: [] })).toThrow();
+    });
+
+    it("rejects empty output_matches array", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [] })).toThrow();
     });
   });
 

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -127,6 +127,26 @@ describe("Zod schemas", () => {
       expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: 1, in: [1, 2] }] })).toThrow();
     });
 
+    it("rejects an output_matches entry with equals + matches", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: 1, matches: "^x$" }] })).toThrow();
+    });
+
+    it("rejects an output_matches entry with in + matches", () => {
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a", in: [1, 2], matches: "^x$" }] })).toThrow();
+    });
+
+    it("rejects an output_matches entry with all three operators", () => {
+      expect(() =>
+        nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: 1, in: [1], matches: "^x$" }] }),
+      ).toThrow();
+    });
+
+    it("accepts equals: null as a valid operator value", () => {
+      // null IS a valid value to assert equality against; only `undefined` means
+      // "not set". Schema must distinguish.
+      expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "a", equals: null }] })).not.toThrow();
+    });
+
     it("rejects an output_matches entry with empty path", () => {
       expect(() => nodeVerifyZ.parse({ output_matches: [{ path: "", equals: 1 }] })).toThrow();
     });

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { checkAllToolsCalled, checkAnyToolCalled, checkNoToolCalled, resolvePath } from "../verify.js";
+import {
+  checkAllToolsCalled,
+  checkAnyToolCalled,
+  checkNoToolCalled,
+  checkOutputMatches,
+  checkOutputRequired,
+  resolvePath,
+} from "../verify.js";
 import type { ToolCall } from "../types.js";
 
 const tc = (tool: string, output?: unknown): ToolCall => ({ tool, input: {}, output });
@@ -186,5 +193,129 @@ describe("checkNoToolCalled", () => {
   it("fails when a forbidden tool was called even with error", () => {
     const err = checkNoToolCalled(["force_push"], [tc("force_push", errOut)]);
     expect(err).toMatch(/no_tool_called/);
+  });
+});
+
+describe("checkOutputRequired", () => {
+  it("passes when all paths resolve to non-null values", () => {
+    expect(checkOutputRequired(["a", "b.c"], { a: 1, b: { c: "x" } })).toBeNull();
+  });
+
+  it("fails when a path is missing", () => {
+    const err = checkOutputRequired(["a", "missing"], { a: 1 });
+    expect(err).toMatch(/output_required.*'missing'.*missing segment/);
+  });
+
+  it("fails when a path resolves to null", () => {
+    const err = checkOutputRequired(["a"], { a: null });
+    expect(err).toMatch(/output_required.*'a'.*null/);
+  });
+
+  it("with default (all) wildcard, requires every element to have non-null path", () => {
+    const data = { findings: [{ severity: "critical" }, { severity: null }] };
+    const err = checkOutputRequired(["findings[*].severity"], data);
+    expect(err).toMatch(/output_required/);
+  });
+
+  it("with default (all) wildcard, passes when every element has non-null path", () => {
+    const data = { findings: [{ severity: "critical" }, { severity: "low" }] };
+    expect(checkOutputRequired(["findings[*].severity"], data)).toBeNull();
+  });
+
+  it("with default (all) wildcard over empty array, vacuously passes", () => {
+    expect(checkOutputRequired(["findings[*].severity"], { findings: [] })).toBeNull();
+  });
+
+  it("with `any` wildcard, passes when at least one element has non-null path", () => {
+    const data = { findings: [{ severity: null }, { severity: "low" }] };
+    expect(checkOutputRequired(["any:findings[*].severity"], data)).toBeNull();
+  });
+
+  it("with `any` wildcard over empty array, fails", () => {
+    const err = checkOutputRequired(["any:findings[*].severity"], { findings: [] });
+    expect(err).toMatch(/output_required.*no elements/);
+  });
+
+  it("aggregates multiple required-path failures into one message", () => {
+    const err = checkOutputRequired(["a", "b"], {});
+    expect(err).toMatch(/'a'/);
+    expect(err).toMatch(/'b'/);
+  });
+});
+
+describe("checkOutputMatches", () => {
+  it("passes equals on a single value", () => {
+    expect(checkOutputMatches([{ path: "a", equals: 1 }], { a: 1 })).toBeNull();
+  });
+
+  it("fails equals on a mismatched value", () => {
+    const err = checkOutputMatches([{ path: "a", equals: 1 }], { a: 2 });
+    expect(err).toMatch(/output_matches.*'a'.*equals.*1.*got.*2/);
+  });
+
+  it("passes `in` when the value is in the set", () => {
+    expect(checkOutputMatches([{ path: "sev", in: ["high", "low"] }], { sev: "low" })).toBeNull();
+  });
+
+  it("fails `in` when the value is not in the set", () => {
+    const err = checkOutputMatches([{ path: "sev", in: ["high", "low"] }], { sev: "urgent" });
+    expect(err).toMatch(/output_matches.*'sev'.*in.*\[high, low\].*got.*urgent/);
+  });
+
+  it("passes `matches` when the regex matches the coerced string", () => {
+    expect(checkOutputMatches([{ path: "url", matches: "^https://" }], { url: "https://x" })).toBeNull();
+  });
+
+  it("fails `matches` when the regex does not match", () => {
+    const err = checkOutputMatches([{ path: "url", matches: "^https://" }], { url: "ftp://x" });
+    expect(err).toMatch(/output_matches.*'url'.*matches.*ftp/);
+  });
+
+  it("with default (all) wildcard, requires every element to satisfy operator", () => {
+    const data = { sevs: [{ s: "high" }, { s: "urgent" }] };
+    const err = checkOutputMatches([{ path: "sevs[*].s", in: ["high", "low"] }], data);
+    expect(err).toMatch(/output_matches/);
+  });
+
+  it("with default (all) wildcard, passes when every element satisfies operator", () => {
+    const data = { sevs: [{ s: "high" }, { s: "low" }] };
+    expect(checkOutputMatches([{ path: "sevs[*].s", in: ["high", "low"] }], data)).toBeNull();
+  });
+
+  it("with default (all) wildcard over empty array, vacuously passes", () => {
+    expect(checkOutputMatches([{ path: "sevs[*].s", in: ["high"] }], { sevs: [] })).toBeNull();
+  });
+
+  it("with `any` wildcard, passes when at least one element satisfies operator", () => {
+    const data = { sevs: [{ s: "low" }, { s: "critical" }] };
+    expect(checkOutputMatches([{ path: "any:sevs[*].s", equals: "critical" }], data)).toBeNull();
+  });
+
+  it("with `any` wildcard, fails when no element satisfies operator", () => {
+    const data = { sevs: [{ s: "low" }, { s: "high" }] };
+    const err = checkOutputMatches([{ path: "any:sevs[*].s", equals: "critical" }], data);
+    expect(err).toMatch(/output_matches.*no element.*satisfied/);
+  });
+
+  it("with `any` wildcard over empty array, fails", () => {
+    const err = checkOutputMatches([{ path: "any:sevs[*].s", equals: "x" }], { sevs: [] });
+    expect(err).toMatch(/output_matches/);
+  });
+
+  it("fails when the path itself does not resolve", () => {
+    const err = checkOutputMatches([{ path: "missing", equals: 1 }], {});
+    expect(err).toMatch(/output_matches.*'missing'.*missing segment/);
+  });
+
+  it("aggregates multiple match failures into one message", () => {
+    const err = checkOutputMatches(
+      [
+        { path: "a", equals: 1 },
+        { path: "b", equals: 2 },
+      ],
+      { a: 999, b: 999 },
+    );
+    expect(err).toMatch(/'a'/);
+    expect(err).toMatch(/'b'/);
   });
 });

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { resolvePath } from "../verify.js";
+
+describe("resolvePath", () => {
+  describe("simple dotted paths", () => {
+    it("resolves a top-level key", () => {
+      expect(resolvePath({ a: 1 }, "a")).toEqual({ ok: true, mode: "all", values: [1] });
+    });
+
+    it("resolves a nested key", () => {
+      expect(resolvePath({ a: { b: { c: "x" } } }, "a.b.c")).toEqual({
+        ok: true,
+        mode: "all",
+        values: ["x"],
+      });
+    });
+
+    it("returns the literal null value (does not treat null as missing)", () => {
+      expect(resolvePath({ a: null }, "a")).toEqual({ ok: true, mode: "all", values: [null] });
+    });
+
+    it("fails when a top-level segment is missing", () => {
+      const r = resolvePath({}, "a");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'a'/);
+    });
+
+    it("fails when an intermediate segment is missing", () => {
+      const r = resolvePath({ a: {} }, "a.b.c");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'b'/);
+    });
+
+    it("fails when an intermediate segment is null", () => {
+      const r = resolvePath({ a: null }, "a.b");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/null/);
+    });
+  });
+
+  describe("wildcard expansion", () => {
+    it("expands [*] over an array of primitives", () => {
+      expect(resolvePath({ xs: [1, 2, 3] }, "xs[*]")).toEqual({
+        ok: true,
+        mode: "all",
+        values: [1, 2, 3],
+      });
+    });
+
+    it("expands [*] then walks into each element", () => {
+      const data = { findings: [{ severity: "critical" }, { severity: "low" }] };
+      expect(resolvePath(data, "findings[*].severity")).toEqual({
+        ok: true,
+        mode: "all",
+        values: ["critical", "low"],
+      });
+    });
+
+    it("returns an empty values array when the array is empty", () => {
+      expect(resolvePath({ xs: [] }, "xs[*]")).toEqual({ ok: true, mode: "all", values: [] });
+    });
+
+    it("returns an empty values array when expanding deeper into an empty array", () => {
+      expect(resolvePath({ findings: [] }, "findings[*].severity")).toEqual({
+        ok: true,
+        mode: "all",
+        values: [],
+      });
+    });
+
+    it("fails when [*] is applied to a non-array", () => {
+      const r = resolvePath({ xs: { not: "array" } }, "xs[*]");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/expected array at 'xs'/);
+    });
+
+    it("fails when an element under [*] is missing the next segment", () => {
+      const data = { findings: [{ severity: "critical" }, { title: "x" }] };
+      const r = resolvePath(data, "findings[*].severity");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/missing segment 'severity'/);
+    });
+  });
+
+  describe("mode prefixes", () => {
+    it("parses `all:` prefix", () => {
+      const r = resolvePath({ xs: [1, 2] }, "all:xs[*]");
+      expect(r).toEqual({ ok: true, mode: "all", values: [1, 2] });
+    });
+
+    it("parses `any:` prefix", () => {
+      const r = resolvePath({ xs: [1, 2] }, "any:xs[*]");
+      expect(r).toEqual({ ok: true, mode: "any", values: [1, 2] });
+    });
+
+    it("defaults to `all` when no prefix", () => {
+      const r = resolvePath({ xs: [1] }, "xs[*]");
+      expect(r).toEqual({ ok: true, mode: "all", values: [1] });
+    });
+
+    it("rejects an unknown prefix", () => {
+      const r = resolvePath({ xs: [1] }, "every:xs[*]");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/unknown prefix 'every'/);
+    });
+  });
+
+  describe("grammar errors", () => {
+    it("rejects an empty path", () => {
+      const r = resolvePath({}, "");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/empty path/);
+    });
+
+    it("rejects a malformed segment", () => {
+      const r = resolvePath({}, "a..b");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/malformed/);
+    });
+  });
+});

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolvePath } from "../verify.js";
+import { checkAllToolsCalled, checkAnyToolCalled, checkNoToolCalled, resolvePath } from "../verify.js";
+import type { ToolCall } from "../types.js";
+
+const tc = (tool: string, output?: unknown): ToolCall => ({ tool, input: {}, output });
+const errOut = { error: "boom" };
 
 describe("resolvePath", () => {
   describe("simple dotted paths", () => {
@@ -117,5 +121,70 @@ describe("resolvePath", () => {
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.reason).toMatch(/malformed/);
     });
+  });
+});
+
+describe("checkAnyToolCalled", () => {
+  it("passes when one of the named tools succeeded", () => {
+    expect(checkAnyToolCalled(["a", "b"], [tc("a", { ok: true })])).toBeNull();
+  });
+
+  it("passes when one succeeded among others", () => {
+    expect(checkAnyToolCalled(["a"], [tc("x"), tc("a", { ok: true }), tc("y")])).toBeNull();
+  });
+
+  it("fails when only an unrelated tool was called", () => {
+    const err = checkAnyToolCalled(["a", "b"], [tc("x")]);
+    expect(err).toMatch(/any_tool_called.*required one of \[a, b\].*called.*x/);
+  });
+
+  it("fails when the required tool errored", () => {
+    const err = checkAnyToolCalled(["a"], [tc("a", errOut)]);
+    expect(err).toMatch(/any_tool_called/);
+  });
+
+  it("reports 'none' when no tools were called", () => {
+    const err = checkAnyToolCalled(["a"], []);
+    expect(err).toMatch(/called: \[none\]/);
+  });
+});
+
+describe("checkAllToolsCalled", () => {
+  it("passes when every named tool succeeded", () => {
+    expect(checkAllToolsCalled(["a", "b"], [tc("a", { ok: true }), tc("b", { ok: true })])).toBeNull();
+  });
+
+  it("passes when extras were also called", () => {
+    expect(checkAllToolsCalled(["a"], [tc("a", { ok: true }), tc("x"), tc("y")])).toBeNull();
+  });
+
+  it("fails when a required tool was never called", () => {
+    const err = checkAllToolsCalled(["a", "b"], [tc("a", { ok: true })]);
+    expect(err).toMatch(/all_tools_called.*missing.*\[b\]/);
+  });
+
+  it("fails when a required tool only errored", () => {
+    const err = checkAllToolsCalled(["a", "b"], [tc("a", { ok: true }), tc("b", errOut)]);
+    expect(err).toMatch(/all_tools_called.*missing.*\[b\]/);
+  });
+});
+
+describe("checkNoToolCalled", () => {
+  it("passes when none of the named tools were called", () => {
+    expect(checkNoToolCalled(["a", "b"], [tc("x"), tc("y")])).toBeNull();
+  });
+
+  it("passes when toolCalls is empty", () => {
+    expect(checkNoToolCalled(["a"], [])).toBeNull();
+  });
+
+  it("fails when a forbidden tool was called successfully", () => {
+    const err = checkNoToolCalled(["force_push"], [tc("force_push", { ok: true })]);
+    expect(err).toMatch(/no_tool_called.*forbidden.*\[force_push\]/);
+  });
+
+  it("fails when a forbidden tool was called even with error", () => {
+    const err = checkNoToolCalled(["force_push"], [tc("force_push", errOut)]);
+    expect(err).toMatch(/no_tool_called/);
   });
 });

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -366,3 +366,214 @@ describe("evaluateVerify", () => {
     expect(err).toMatch(/\n {2}- /);
   });
 });
+
+// ─── Hardening tests added in response to PR #158 review ─────────────
+
+describe("deepEqual semantics (via output_matches equals)", () => {
+  it("treats objects with different key insertion order as equal", () => {
+    expect(checkOutputMatches([{ path: "x", equals: { a: 1, b: 2 } }], { x: { b: 2, a: 1 } })).toBeNull();
+  });
+
+  it("differentiates objects with different keys", () => {
+    expect(checkOutputMatches([{ path: "x", equals: { a: 1, b: 2 } }], { x: { a: 1, c: 2 } })).not.toBeNull();
+  });
+
+  it("handles arrays element-wise (order-sensitive)", () => {
+    expect(checkOutputMatches([{ path: "x", equals: [1, 2, 3] }], { x: [1, 2, 3] })).toBeNull();
+    expect(checkOutputMatches([{ path: "x", equals: [1, 2, 3] }], { x: [3, 2, 1] })).not.toBeNull();
+  });
+
+  it("handles nested object/array equality", () => {
+    const eq = { items: [{ id: 1 }, { id: 2 }] };
+    expect(checkOutputMatches([{ path: "x", equals: eq }], { x: { items: [{ id: 1 }, { id: 2 }] } })).toBeNull();
+    expect(checkOutputMatches([{ path: "x", equals: eq }], { x: { items: [{ id: 1 }, { id: 3 }] } })).not.toBeNull();
+  });
+
+  it("treats NaN as equal to NaN (Object.is)", () => {
+    expect(checkOutputMatches([{ path: "x", equals: NaN }], { x: NaN })).toBeNull();
+  });
+
+  it("treats null as equal to null", () => {
+    expect(checkOutputMatches([{ path: "x", equals: null }], { x: null })).toBeNull();
+    expect(checkOutputMatches([{ path: "x", equals: null }], { x: 0 })).not.toBeNull();
+  });
+
+  it("differentiates {a: undefined} from {} (presence of key matters)", () => {
+    expect(checkOutputMatches([{ path: "x", equals: { a: undefined } }], { x: { a: undefined } })).toBeNull();
+    expect(checkOutputMatches([{ path: "x", equals: { a: undefined } }], { x: {} })).not.toBeNull();
+  });
+
+  it("differentiates an array from an object even when both have same length-ish shape", () => {
+    expect(
+      checkOutputMatches([{ path: "x", equals: { 0: "a", 1: "b", length: 2 } }], { x: ["a", "b"] }),
+    ).not.toBeNull();
+  });
+});
+
+describe("regex / matches edge cases", () => {
+  it("respects regex special characters when matching strings", () => {
+    expect(checkOutputMatches([{ path: "v", matches: "^foo\\.bar$" }], { v: "foo.bar" })).toBeNull();
+    // Unescaped `.` is regex any-char — `foo_bar` would still match `foo.bar`,
+    // but `foo.baz` should not match `^foo\.bar$`.
+    expect(checkOutputMatches([{ path: "v", matches: "^foo\\.bar$" }], { v: "foo.baz" })).not.toBeNull();
+  });
+
+  it("coerces numbers to their JSON string form for matching", () => {
+    expect(checkOutputMatches([{ path: "v", matches: "^123$" }], { v: 123 })).toBeNull();
+  });
+
+  it("coerces objects to their JSON string form for matching", () => {
+    expect(checkOutputMatches([{ path: "v", matches: '"x":"abc"' }], { v: { x: "abc" } })).toBeNull();
+  });
+
+  it("reports a clear failure when the regex source is invalid", () => {
+    const err = checkOutputMatches([{ path: "v", matches: "(unclosed" }], { v: "x" });
+    expect(err).toMatch(/output_matches.*invalid regex/);
+  });
+});
+
+describe("nested wildcard chains", () => {
+  it("expands a[*].b[*].c", () => {
+    const data = {
+      a: [{ b: [{ c: 1 }, { c: 2 }] }, { b: [{ c: 3 }] }],
+    };
+    const r = resolvePath(data, "a[*].b[*].c");
+    expect(r).toEqual({ ok: true, mode: "all", values: [1, 2, 3] });
+  });
+
+  it("fails when an inner array is missing", () => {
+    const data = { a: [{ b: [{ c: 1 }] }, { b: { c: 2 } }] };
+    const r = resolvePath(data, "a[*].b[*].c");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("malformed paths", () => {
+  it("rejects [*] at the start (no identifier)", () => {
+    const r = resolvePath({ a: [1] }, "[*].x");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/malformed segment/);
+  });
+
+  it("rejects double brackets a[*][*]", () => {
+    const r = resolvePath({ a: [[1]] }, "a[*][*]");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/malformed segment/);
+  });
+
+  it("rejects a path with only a prefix", () => {
+    const r = resolvePath({ a: 1 }, "all:");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/empty path after prefix/);
+  });
+});
+
+describe("non-object node data", () => {
+  it("checkOutputRequired against null data fails cleanly", () => {
+    const err = checkOutputRequired(["x"], null);
+    expect(err).toMatch(/output_required.*'x'/);
+  });
+
+  it("checkOutputMatches against null data fails cleanly", () => {
+    const err = checkOutputMatches([{ path: "x", equals: 1 }], null);
+    expect(err).toMatch(/output_matches.*'x'/);
+  });
+
+  it("checkOutputRequired against a primitive fails cleanly", () => {
+    const err = checkOutputRequired(["x"], "string");
+    expect(err).toMatch(/output_required.*'x'/);
+  });
+});
+
+describe("isErrorOutput tolerance for null/false sentinels", () => {
+  it("treats {error: null} as success", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", { ok: true, error: null })]);
+    expect(err).toBeNull();
+  });
+
+  it("treats {error: false} as success", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", { ok: true, error: false })]);
+    expect(err).toBeNull();
+  });
+
+  it("treats {error: undefined} as success", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", { ok: true, error: undefined })]);
+    expect(err).toBeNull();
+  });
+
+  it("treats {error: 0} as success (zero is not an error)", () => {
+    // Defensive: only truthy/non-null/non-false `error` values should fail.
+    // `error: 0` is unusual but the contract is "presence of an error value".
+    const err = checkAnyToolCalled(["save"], [tc("save", { ok: true, error: 0 })]);
+    // We DO treat `0` as an error because it's neither null, undefined, nor false.
+    // Pin this so future readers see it's intentional.
+    expect(err).not.toBeNull();
+  });
+
+  it("treats {error: 'boom'} as failure", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", { error: "boom" })]);
+    expect(err).not.toBeNull();
+  });
+});
+
+describe("output_matches all-mode aggregation", () => {
+  it("reports every offending value, not just the first", () => {
+    const data = { sevs: [{ s: "urgent" }, { s: "high" }, { s: "yikes" }] };
+    const err = checkOutputMatches([{ path: "sevs[*].s", in: ["high", "low"] }], data);
+    expect(err).toMatch(/"urgent"/);
+    expect(err).toMatch(/"yikes"/);
+    // "high" satisfies the operator and must NOT appear as an offender
+    // (verify by absence-of-substring within the offenders bracket section).
+    const m = err!.match(/got \[(.*)\]$/);
+    expect(m).not.toBeNull();
+    expect(m![1]).not.toContain('"high"');
+  });
+});
+
+describe("path-resolution failures inside output_matches", () => {
+  it("missing path produces a clean message naming the missing segment", () => {
+    const err = checkOutputMatches([{ path: "missing.x", equals: 1 }], { other: 1 });
+    expect(err).toMatch(/output_matches.*'missing\.x'.*missing segment 'missing'/);
+  });
+
+  it("[*] against a non-array fails cleanly", () => {
+    const err = checkOutputMatches([{ path: "x[*].y", equals: 1 }], { x: { not: "an array" } });
+    expect(err).toMatch(/output_matches.*expected array at 'x'/);
+  });
+});
+
+describe("tool-call message parity", () => {
+  it("checkAllToolsCalled includes the called: tail", () => {
+    const err = checkAllToolsCalled(["save", "send"], [tc("save", { ok: true }), tc("log")]);
+    expect(err).toMatch(/missing successful calls to \[send\]/);
+    expect(err).toMatch(/called: \[save, log\]/);
+  });
+
+  it("checkNoToolCalled includes the called: tail", () => {
+    const err = checkNoToolCalled(["force_push"], [tc("force_push"), tc("log")]);
+    expect(err).toMatch(/forbidden tools were invoked: \[force_push\]/);
+    expect(err).toMatch(/called: \[force_push, log\]/);
+  });
+});
+
+describe("evaluateVerify exact failure-string format (public contract)", () => {
+  it("produces the exact bulleted format", () => {
+    const v = {
+      any_tool_called: ["save"],
+      output_required: ["url"],
+    };
+    const r: NodeResult = {
+      status: "success",
+      data: {},
+      toolCalls: [tc("read")],
+    };
+    const err = evaluateVerify(v, r);
+    expect(err).toBe(
+      [
+        "verify failed:",
+        "  - any_tool_called: required one of [save] to succeed, called: [read]",
+        "  - output_required: 'url' missing segment 'url'",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -260,7 +260,7 @@ describe("checkOutputMatches", () => {
 
   it("fails `in` when the value is not in the set", () => {
     const err = checkOutputMatches([{ path: "sev", in: ["high", "low"] }], { sev: "urgent" });
-    expect(err).toMatch(/output_matches.*'sev'.*in.*\[high, low\].*got.*urgent/);
+    expect(err).toMatch(/output_matches.*'sev'.*in \["high", "low"\].*got \["urgent"\]/);
   });
 
   it("passes `matches` when the regex matches the coerced string", () => {
@@ -295,7 +295,7 @@ describe("checkOutputMatches", () => {
   it("with `any` wildcard, fails when no element satisfies operator", () => {
     const data = { sevs: [{ s: "low" }, { s: "high" }] };
     const err = checkOutputMatches([{ path: "any:sevs[*].s", equals: "critical" }], data);
-    expect(err).toMatch(/output_matches.*no element.*satisfied/);
+    expect(err).toMatch(/output_matches.*no element satisfies/);
   });
 
   it("with `any` wildcard over empty array, fails", () => {

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -5,9 +5,10 @@ import {
   checkNoToolCalled,
   checkOutputMatches,
   checkOutputRequired,
+  evaluateVerify,
   resolvePath,
 } from "../verify.js";
-import type { ToolCall } from "../types.js";
+import type { NodeResult, ToolCall } from "../types.js";
 
 const tc = (tool: string, output?: unknown): ToolCall => ({ tool, input: {}, output });
 const errOut = { error: "boom" };
@@ -317,5 +318,51 @@ describe("checkOutputMatches", () => {
     );
     expect(err).toMatch(/'a'/);
     expect(err).toMatch(/'b'/);
+  });
+});
+
+const result = (data: Record<string, unknown>, toolCalls: ToolCall[] = []): NodeResult => ({
+  status: "success",
+  data,
+  toolCalls,
+});
+
+describe("evaluateVerify", () => {
+  it("returns null when verify is undefined", () => {
+    expect(evaluateVerify(undefined, result({}))).toBeNull();
+  });
+
+  it("returns null when every declared check passes", () => {
+    const v = {
+      any_tool_called: ["a"],
+      output_required: ["x"],
+      output_matches: [{ path: "x", equals: 1 }],
+    };
+    const r = result({ x: 1 }, [tc("a", { ok: true })]);
+    expect(evaluateVerify(v, r)).toBeNull();
+  });
+
+  it("aggregates failures from multiple checks into one error string", () => {
+    const v = {
+      any_tool_called: ["create_pr"],
+      no_tool_called: ["force_push"],
+      output_required: ["prUrl"],
+      output_matches: [{ path: "branch", matches: "^sweny/" }],
+    };
+    const r = result({ branch: "main" }, [tc("force_push", { ok: true })]);
+    const err = evaluateVerify(v, r);
+    expect(err).not.toBeNull();
+    expect(err!).toMatch(/^verify failed:/);
+    expect(err!).toMatch(/any_tool_called/);
+    expect(err!).toMatch(/no_tool_called/);
+    expect(err!).toMatch(/output_required/);
+    expect(err!).toMatch(/output_matches/);
+  });
+
+  it("formats failures as a bulleted list", () => {
+    const v = { any_tool_called: ["a"], no_tool_called: ["b"] };
+    const r = result({}, [tc("b")]);
+    const err = evaluateVerify(v, r);
+    expect(err).toMatch(/\n {2}- /);
   });
 });

--- a/packages/core/src/__tests__/verify.test.ts
+++ b/packages/core/src/__tests__/verify.test.ts
@@ -556,6 +556,46 @@ describe("tool-call message parity", () => {
   });
 });
 
+describe("isErrorOutput against non-object output", () => {
+  it("treats string output as success (no error key possible)", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", "ok")]);
+    expect(err).toBeNull();
+  });
+
+  it("treats number output as success", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save", 42)]);
+    expect(err).toBeNull();
+  });
+
+  it("treats undefined output (no result reported) as success", () => {
+    const err = checkAnyToolCalled(["save"], [tc("save")]);
+    expect(err).toBeNull();
+  });
+});
+
+describe("output_matches matches operator with mixed pass/fail values", () => {
+  it("aggregates only the offending values under all-mode matches", () => {
+    const data = { urls: ["https://a", "ftp://b", "https://c", "ssh://d"] };
+    const err = checkOutputMatches([{ path: "urls[*]", matches: "^https://" }], data);
+    expect(err).toMatch(/"ftp:\/\/b"/);
+    expect(err).toMatch(/"ssh:\/\/d"/);
+    const offenders = err!.match(/got \[(.*)\]$/)![1]!;
+    expect(offenders).not.toContain("https://a");
+    expect(offenders).not.toContain("https://c");
+  });
+});
+
+describe("applyOperator defensive fallthrough", () => {
+  it("returns a clean error when no operator is declared (zod-bypass guard)", () => {
+    // Construct an OutputMatch that bypasses zod (cast-as-any) to exercise the
+    // applyOperator default branch. In real flow zod prevents this, but we want
+    // the runtime to degrade gracefully if a producer ever skips schema parsing.
+    const bogus = { path: "x" } as unknown as Parameters<typeof checkOutputMatches>[0][0];
+    const err = checkOutputMatches([bogus], { x: 1 });
+    expect(err).toMatch(/output_matches.*'x'.*no operator/);
+  });
+});
+
 describe("evaluateVerify exact failure-string format (public contract)", () => {
   it("produces the exact bulleted format", () => {
     const v = {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -208,11 +208,15 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     // Machine-checked post-condition. Enforced AFTER the LLM finishes so that
     // a model claiming success cannot bypass side-effect requirements (e.g.
     // reporting "issue created" when no `linear_create_issue` call was made).
-    const verifyError = evaluateVerify(node.verify, result);
-    if (verifyError && result.status === "success") {
-      result.status = "failed";
-      result.data = { ...result.data, error: verifyError };
-      logger.warn(`  verify failed: ${verifyError}`, { node: currentId });
+    // Skipped entirely when the node already failed — the node's own error is
+    // the root cause and verify would just add noise.
+    if (result.status === "success") {
+      const verifyError = evaluateVerify(node.verify, result);
+      if (verifyError) {
+        result.status = "failed";
+        result.data = { ...result.data, error: verifyError };
+        logger.warn(`  verify failed: ${verifyError}`, { node: currentId });
+      }
     }
 
     results.set(currentId, result);

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -34,6 +34,7 @@ import type {
 } from "./types.js";
 import { consoleLogger } from "./types.js";
 import { resolveSources } from "./source-resolver.js";
+import { evaluateVerify } from "./verify.js";
 
 export interface ExecuteOptions {
   /** Registered skills (id → Skill) */
@@ -258,36 +259,6 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
 }
 
 // ─── Internals ───────────────────────────────────────────────────
-
-/**
- * Evaluate a node's `verify` post-condition against the executed result.
- *
- * Returns an error string when the check fails, or null when the node
- * passes verification (or has no verify block).
- *
- * Keep this deterministic and side-effect free — the executor calls it
- * synchronously right after the LLM finishes.
- */
-function evaluateVerify(verify: import("./types.js").NodeVerify | undefined, result: NodeResult): string | null {
-  if (!verify) return null;
-
-  if (verify.any_tool_called && verify.any_tool_called.length > 0) {
-    const required = new Set(verify.any_tool_called);
-    const success = result.toolCalls.some(
-      (c) =>
-        required.has(c.tool) &&
-        // Treat explicit error outputs (from coreToolToSdkTool's catch branch)
-        // as failed calls so a swallowed handler throw doesn't count as success.
-        !(c.output && typeof c.output === "object" && "error" in (c.output as Record<string, unknown>)),
-    );
-    if (!success) {
-      const called = result.toolCalls.map((c) => c.tool).join(", ") || "none";
-      return `verify.any_tool_called failed — required one of [${verify.any_tool_called.join(", ")}] to succeed, but tool calls were: [${called}]`;
-    }
-  }
-
-  return null;
-}
 
 /**
  * Build the full instruction for a node.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -87,13 +87,41 @@ export const nodeSourcesZ = z.union([
   }),
 ]);
 
+export const outputMatchZ = z
+  .object({
+    path: z.string().min(1),
+    equals: z.unknown().optional(),
+    in: z.array(z.unknown()).optional(),
+    matches: z.string().min(1).optional(),
+  })
+  .refine(
+    (m) => {
+      const operators = [m.equals !== undefined, m.in !== undefined, m.matches !== undefined];
+      return operators.filter(Boolean).length === 1;
+    },
+    { message: "output_matches entry must declare exactly one of: equals, in, matches" },
+  );
+
 export const nodeVerifyZ = z
   .object({
     any_tool_called: z.array(z.string().min(1)).min(1).optional(),
+    all_tools_called: z.array(z.string().min(1)).min(1).optional(),
+    no_tool_called: z.array(z.string().min(1)).min(1).optional(),
+    output_required: z.array(z.string().min(1)).min(1).optional(),
+    output_matches: z.array(outputMatchZ).min(1).optional(),
   })
-  .refine((v) => v.any_tool_called !== undefined, {
-    message: "verify must declare at least one check (e.g. any_tool_called)",
-  });
+  .refine(
+    (v) =>
+      v.any_tool_called !== undefined ||
+      v.all_tools_called !== undefined ||
+      v.no_tool_called !== undefined ||
+      v.output_required !== undefined ||
+      v.output_matches !== undefined,
+    {
+      message:
+        "verify must declare at least one check (any_tool_called, all_tools_called, no_tool_called, output_required, or output_matches)",
+    },
+  );
 
 export const nodeZ = z.object({
   name: z.string().min(1),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -73,22 +73,42 @@ export type NodeSources = _Source[] | { only?: boolean; sources: _Source[] };
 /**
  * Machine-checked post-condition for a node.
  *
- * Evaluated by the executor AFTER the LLM finishes. If the check fails, the
- * node is marked `failed` even if the LLM itself returned success — this
- * catches the common case of the model claiming success without actually
- * invoking the side-effectful tool (e.g. reporting "issue created" when no
- * `linear_create_issue` call was made, or the call errored).
+ * Evaluated by the executor AFTER the LLM finishes. If any declared check
+ * fails, the node is marked `failed` even if the LLM itself returned success.
  *
- * Keep the shape small and declarative. Anything richer should be a skill
- * or a dedicated workflow node, not a verify clause.
+ * All declared checks are AND-ed. The executor runs every check (no fast-fail)
+ * and concatenates failures into a single error string on `result.data.error`.
+ *
+ * Keep the shape small and declarative. Anything richer should be a skill or
+ * a dedicated workflow node, not a verify clause.
  */
 export interface NodeVerify {
-  /**
-   * At least one of the named tools must have been invoked successfully during
-   * this node's execution (no `output.error` recorded in `toolCalls`). The
-   * node is marked failed otherwise.
-   */
+  /** At least one of these tools was called and succeeded during this node. */
   any_tool_called?: string[];
+  /** Every named tool was called and succeeded at least once during this node. */
+  all_tools_called?: string[];
+  /** None of these tools may have been invoked during this node. */
+  no_tool_called?: string[];
+  /** Listed paths must be present and non-null in `result.data` (see Path resolution in the spec). */
+  output_required?: string[];
+  /** Each assertion must hold against `result.data`. */
+  output_matches?: OutputMatch[];
+}
+
+/**
+ * A single output assertion. Exactly one of `equals | in | matches` must be set.
+ *
+ * `path` is a dotted path that may include `[*]` wildcard segments and may be
+ * prefixed with `all:` or `any:` to set wildcard semantics (default `all:`).
+ *
+ * Examples: `prUrl`, `findings[*].severity`, `any:checks[*].conclusion`.
+ */
+export interface OutputMatch {
+  path: string;
+  equals?: unknown;
+  in?: unknown[];
+  /** Regex source (no surrounding slashes, no flags). Value is coerced to string. */
+  matches?: string;
 }
 
 /** A node in the workflow DAG */

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -1,0 +1,79 @@
+// ─── Verify: path resolver + check evaluators ───────────────────────
+//
+// Evaluates `node.verify` post-conditions after the LLM finishes.
+// All checks are AND-ed; failures are aggregated into one error string.
+
+export type Resolution = { ok: true; mode: "all" | "any"; values: unknown[] } | { ok: false; reason: string };
+
+interface Segment {
+  name: string;
+  wildcard: boolean;
+}
+
+const SEGMENT_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)(\[\*\])?$/;
+
+function parsePath(path: string): { mode: "all" | "any"; segments: Segment[] } | string {
+  if (path.length === 0) return "empty path";
+
+  let mode: "all" | "any" = "all";
+  let body = path;
+  const colon = path.indexOf(":");
+  if (colon !== -1 && /^[a-z]+$/.test(path.slice(0, colon))) {
+    const prefix = path.slice(0, colon);
+    if (prefix === "all" || prefix === "any") {
+      mode = prefix;
+      body = path.slice(colon + 1);
+    } else {
+      return `unknown prefix '${prefix}' (expected 'all' or 'any')`;
+    }
+    if (body.length === 0) return "empty path after prefix";
+  }
+
+  const parts = body.split(".");
+  const segments: Segment[] = [];
+  for (const part of parts) {
+    const m = SEGMENT_RE.exec(part);
+    if (!m) return `malformed segment '${part}'`;
+    segments.push({ name: m[1]!, wildcard: m[2] === "[*]" });
+  }
+  return { mode, segments };
+}
+
+export function resolvePath(data: unknown, path: string): Resolution {
+  const parsed = parsePath(path);
+  if (typeof parsed === "string") return { ok: false, reason: parsed };
+
+  let current: unknown[] = [data];
+
+  for (const seg of parsed.segments) {
+    const next: unknown[] = [];
+    for (const v of current) {
+      if (v === null) return { ok: false, reason: `null encountered before segment '${seg.name}'` };
+      if (typeof v !== "object") {
+        return { ok: false, reason: `expected object before segment '${seg.name}', got ${typeof v}` };
+      }
+      const obj = v as Record<string, unknown>;
+      if (!(seg.name in obj)) {
+        return { ok: false, reason: `missing segment '${seg.name}'` };
+      }
+      const child = obj[seg.name];
+      if (seg.wildcard) {
+        if (!Array.isArray(child)) {
+          return {
+            ok: false,
+            reason: `expected array at '${seg.name}', got ${child === null ? "null" : typeof child}`,
+          };
+        }
+        for (const el of child) next.push(el);
+      } else {
+        next.push(child);
+      }
+    }
+    current = next;
+    if (current.length === 0) {
+      return { ok: true, mode: parsed.mode, values: [] };
+    }
+  }
+
+  return { ok: true, mode: parsed.mode, values: current };
+}

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -3,6 +3,8 @@
 // Evaluates `node.verify` post-conditions after the LLM finishes.
 // All checks are AND-ed; failures are aggregated into one error string.
 
+import type { ToolCall } from "./types.js";
+
 export type Resolution = { ok: true; mode: "all" | "any"; values: unknown[] } | { ok: false; reason: string };
 
 interface Segment {
@@ -76,4 +78,37 @@ export function resolvePath(data: unknown, path: string): Resolution {
   }
 
   return { ok: true, mode: parsed.mode, values: current };
+}
+
+function isErrorOutput(output: unknown): boolean {
+  return !!(output && typeof output === "object" && "error" in (output as Record<string, unknown>));
+}
+
+function succeededTools(toolCalls: ToolCall[]): Set<string> {
+  const names = new Set<string>();
+  for (const c of toolCalls) {
+    if (!isErrorOutput(c.output)) names.add(c.tool);
+  }
+  return names;
+}
+
+export function checkAnyToolCalled(required: string[], toolCalls: ToolCall[]): string | null {
+  const succeeded = succeededTools(toolCalls);
+  if (required.some((t) => succeeded.has(t))) return null;
+  const called = toolCalls.map((c) => c.tool).join(", ") || "none";
+  return `any_tool_called: required one of [${required.join(", ")}] to succeed, called: [${called}]`;
+}
+
+export function checkAllToolsCalled(required: string[], toolCalls: ToolCall[]): string | null {
+  const succeeded = succeededTools(toolCalls);
+  const missing = required.filter((t) => !succeeded.has(t));
+  if (missing.length === 0) return null;
+  return `all_tools_called: missing successful calls to [${missing.join(", ")}]`;
+}
+
+export function checkNoToolCalled(forbidden: string[], toolCalls: ToolCall[]): string | null {
+  const calledNames = new Set(toolCalls.map((c) => c.tool));
+  const violated = forbidden.filter((t) => calledNames.has(t));
+  if (violated.length === 0) return null;
+  return `no_tool_called: forbidden tools were invoked: [${violated.join(", ")}]`;
 }

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -3,7 +3,7 @@
 // Evaluates `node.verify` post-conditions after the LLM finishes.
 // All checks are AND-ed; failures are aggregated into one error string.
 
-import type { ToolCall } from "./types.js";
+import type { OutputMatch, ToolCall } from "./types.js";
 
 export type Resolution = { ok: true; mode: "all" | "any"; values: unknown[] } | { ok: false; reason: string };
 
@@ -111,4 +111,89 @@ export function checkNoToolCalled(forbidden: string[], toolCalls: ToolCall[]): s
   const violated = forbidden.filter((t) => calledNames.has(t));
   if (violated.length === 0) return null;
   return `no_tool_called: forbidden tools were invoked: [${violated.join(", ")}]`;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function formatValue(v: unknown): string {
+  if (v === null) return "null";
+  if (v === undefined) return "undefined";
+  if (typeof v === "string") return v;
+  return JSON.stringify(v);
+}
+
+export function checkOutputRequired(paths: string[], data: unknown): string | null {
+  const failures: string[] = [];
+  for (const path of paths) {
+    const r = resolvePath(data, path);
+    if (!r.ok) {
+      failures.push(`'${path}' ${r.reason}`);
+      continue;
+    }
+    if (r.mode === "all") {
+      if (r.values.length > 0 && !r.values.every((v) => v !== null && v !== undefined)) {
+        failures.push(`'${path}' resolved to null/undefined value(s)`);
+      }
+    } else {
+      if (r.values.length === 0) {
+        failures.push(`'${path}' (any:) resolved to no elements`);
+      } else if (!r.values.some((v) => v !== null && v !== undefined)) {
+        failures.push(`'${path}' (any:) all resolved values are null/undefined`);
+      }
+    }
+  }
+  if (failures.length === 0) return null;
+  return `output_required: ${failures.join("; ")}`;
+}
+
+function applyOperator(m: OutputMatch, value: unknown): { ok: true } | { ok: false; reason: string } {
+  if (m.equals !== undefined) {
+    if (deepEqual(value, m.equals)) return { ok: true };
+    return { ok: false, reason: `equals ${formatValue(m.equals)}, got ${formatValue(value)}` };
+  }
+  if (m.in !== undefined) {
+    if (m.in.some((x) => deepEqual(value, x))) return { ok: true };
+    return {
+      ok: false,
+      reason: `in [${m.in.map(formatValue).join(", ")}], got ${formatValue(value)}`,
+    };
+  }
+  if (m.matches !== undefined) {
+    const re = new RegExp(m.matches);
+    const s = typeof value === "string" ? value : JSON.stringify(value);
+    if (re.test(s)) return { ok: true };
+    return { ok: false, reason: `matches /${m.matches}/, got ${formatValue(value)}` };
+  }
+  return { ok: false, reason: "no operator declared (zod should have caught this)" };
+}
+
+export function checkOutputMatches(matches: OutputMatch[], data: unknown): string | null {
+  const failures: string[] = [];
+  for (const m of matches) {
+    const r = resolvePath(data, m.path);
+    if (!r.ok) {
+      failures.push(`'${m.path}' ${r.reason}`);
+      continue;
+    }
+    if (r.mode === "all") {
+      if (r.values.length === 0) continue;
+      const firstFailure = r.values
+        .map((v) => applyOperator(m, v))
+        .find((res): res is { ok: false; reason: string } => !res.ok);
+      if (firstFailure) failures.push(`'${m.path}' ${firstFailure.reason}`);
+    } else {
+      if (r.values.length === 0) {
+        failures.push(`'${m.path}' (any:) resolved to no elements`);
+        continue;
+      }
+      const anyOk = r.values.some((v) => applyOperator(m, v).ok);
+      if (!anyOk) {
+        failures.push(`'${m.path}' (any:) no element satisfied operator`);
+      }
+    }
+  }
+  if (failures.length === 0) return null;
+  return `output_matches: ${failures.join("; ")}`;
 }

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -197,3 +197,42 @@ export function checkOutputMatches(matches: OutputMatch[], data: unknown): strin
   if (failures.length === 0) return null;
   return `output_matches: ${failures.join("; ")}`;
 }
+
+import type { NodeResult, NodeVerify } from "./types.js";
+
+/**
+ * Evaluate every declared check and return a concatenated error string,
+ * or null when the node passes verification (or has no verify block).
+ *
+ * Deterministic and side-effect free — the executor calls this synchronously
+ * after the LLM finishes.
+ */
+export function evaluateVerify(verify: NodeVerify | undefined, result: NodeResult): string | null {
+  if (!verify) return null;
+
+  const failures: string[] = [];
+
+  if (verify.any_tool_called && verify.any_tool_called.length > 0) {
+    const e = checkAnyToolCalled(verify.any_tool_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.all_tools_called && verify.all_tools_called.length > 0) {
+    const e = checkAllToolsCalled(verify.all_tools_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.no_tool_called && verify.no_tool_called.length > 0) {
+    const e = checkNoToolCalled(verify.no_tool_called, result.toolCalls);
+    if (e) failures.push(e);
+  }
+  if (verify.output_required && verify.output_required.length > 0) {
+    const e = checkOutputRequired(verify.output_required, result.data);
+    if (e) failures.push(e);
+  }
+  if (verify.output_matches && verify.output_matches.length > 0) {
+    const e = checkOutputMatches(verify.output_matches, result.data);
+    if (e) failures.push(e);
+  }
+
+  if (failures.length === 0) return null;
+  return `verify failed:\n  - ${failures.join("\n  - ")}`;
+}

--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -3,7 +3,7 @@
 // Evaluates `node.verify` post-conditions after the LLM finishes.
 // All checks are AND-ed; failures are aggregated into one error string.
 
-import type { OutputMatch, ToolCall } from "./types.js";
+import type { NodeResult, NodeVerify, OutputMatch, ToolCall } from "./types.js";
 
 export type Resolution = { ok: true; mode: "all" | "any"; values: unknown[] } | { ok: false; reason: string };
 
@@ -13,21 +13,21 @@ interface Segment {
 }
 
 const SEGMENT_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)(\[\*\])?$/;
+const PREFIX_RE = /^([a-z]+):/;
 
 function parsePath(path: string): { mode: "all" | "any"; segments: Segment[] } | string {
   if (path.length === 0) return "empty path";
 
   let mode: "all" | "any" = "all";
   let body = path;
-  const colon = path.indexOf(":");
-  if (colon !== -1 && /^[a-z]+$/.test(path.slice(0, colon))) {
-    const prefix = path.slice(0, colon);
-    if (prefix === "all" || prefix === "any") {
-      mode = prefix;
-      body = path.slice(colon + 1);
-    } else {
+  const prefixMatch = PREFIX_RE.exec(path);
+  if (prefixMatch) {
+    const prefix = prefixMatch[1]!;
+    if (prefix !== "all" && prefix !== "any") {
       return `unknown prefix '${prefix}' (expected 'all' or 'any')`;
     }
+    mode = prefix;
+    body = path.slice(prefixMatch[0].length);
     if (body.length === 0) return "empty path after prefix";
   }
 
@@ -80,8 +80,13 @@ export function resolvePath(data: unknown, path: string): Resolution {
   return { ok: true, mode: parsed.mode, values: current };
 }
 
+// A tool call "succeeded" when its output does not carry a non-null `error` field.
+// `{ error: null }` and `{ error: false }` are treated as success — many real
+// tools include the key with a null sentinel.
 function isErrorOutput(output: unknown): boolean {
-  return !!(output && typeof output === "object" && "error" in (output as Record<string, unknown>));
+  if (!output || typeof output !== "object") return false;
+  const err = (output as Record<string, unknown>).error;
+  return err !== undefined && err !== null && err !== false;
 }
 
 function succeededTools(toolCalls: ToolCall[]): Set<string> {
@@ -92,35 +97,64 @@ function succeededTools(toolCalls: ToolCall[]): Set<string> {
   return names;
 }
 
+function calledList(toolCalls: ToolCall[]): string {
+  return toolCalls.map((c) => c.tool).join(", ") || "none";
+}
+
 export function checkAnyToolCalled(required: string[], toolCalls: ToolCall[]): string | null {
   const succeeded = succeededTools(toolCalls);
   if (required.some((t) => succeeded.has(t))) return null;
-  const called = toolCalls.map((c) => c.tool).join(", ") || "none";
-  return `any_tool_called: required one of [${required.join(", ")}] to succeed, called: [${called}]`;
+  return `any_tool_called: required one of [${required.join(", ")}] to succeed, called: [${calledList(toolCalls)}]`;
 }
 
 export function checkAllToolsCalled(required: string[], toolCalls: ToolCall[]): string | null {
   const succeeded = succeededTools(toolCalls);
   const missing = required.filter((t) => !succeeded.has(t));
   if (missing.length === 0) return null;
-  return `all_tools_called: missing successful calls to [${missing.join(", ")}]`;
+  return `all_tools_called: missing successful calls to [${missing.join(", ")}], called: [${calledList(toolCalls)}]`;
 }
 
 export function checkNoToolCalled(forbidden: string[], toolCalls: ToolCall[]): string | null {
   const calledNames = new Set(toolCalls.map((c) => c.tool));
   const violated = forbidden.filter((t) => calledNames.has(t));
   if (violated.length === 0) return null;
-  return `no_tool_called: forbidden tools were invoked: [${violated.join(", ")}]`;
+  return `no_tool_called: forbidden tools were invoked: [${violated.join(", ")}], called: [${calledList(toolCalls)}]`;
 }
 
+// Structural deep equality for JSON-shaped values. Handles object key-order
+// (compares by key set, not insertion order), NaN (NaN === NaN here), arrays
+// (element-wise), and treats `undefined` distinctly from missing keys. Does
+// not handle Date/Map/Set/RegExp — verify only ever sees agent-produced JSON.
 function deepEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  const bKeys = Object.keys(bo);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
 }
 
 function formatValue(v: unknown): string {
   if (v === null) return "null";
   if (v === undefined) return "undefined";
-  if (typeof v === "string") return v;
   return JSON.stringify(v);
 }
 
@@ -148,7 +182,22 @@ export function checkOutputRequired(paths: string[], data: unknown): string | nu
   return `output_required: ${failures.join("; ")}`;
 }
 
-function applyOperator(m: OutputMatch, value: unknown): { ok: true } | { ok: false; reason: string } {
+interface CompiledMatch {
+  match: OutputMatch;
+  regex?: RegExp;
+}
+
+function compileMatch(m: OutputMatch): CompiledMatch {
+  if (m.matches !== undefined) {
+    // Throws synchronously if the regex source is invalid; surfaced as a
+    // verify failure rather than a crash because the executor catches.
+    return { match: m, regex: new RegExp(m.matches) };
+  }
+  return { match: m };
+}
+
+function applyOperator(c: CompiledMatch, value: unknown): { ok: true } | { ok: false; reason: string } {
+  const m = c.match;
   if (m.equals !== undefined) {
     if (deepEqual(value, m.equals)) return { ok: true };
     return { ok: false, reason: `equals ${formatValue(m.equals)}, got ${formatValue(value)}` };
@@ -160,10 +209,9 @@ function applyOperator(m: OutputMatch, value: unknown): { ok: true } | { ok: fal
       reason: `in [${m.in.map(formatValue).join(", ")}], got ${formatValue(value)}`,
     };
   }
-  if (m.matches !== undefined) {
-    const re = new RegExp(m.matches);
+  if (c.regex) {
     const s = typeof value === "string" ? value : JSON.stringify(value);
-    if (re.test(s)) return { ok: true };
+    if (c.regex.test(s)) return { ok: true };
     return { ok: false, reason: `matches /${m.matches}/, got ${formatValue(value)}` };
   }
   return { ok: false, reason: "no operator declared (zod should have caught this)" };
@@ -172,6 +220,14 @@ function applyOperator(m: OutputMatch, value: unknown): { ok: true } | { ok: fal
 export function checkOutputMatches(matches: OutputMatch[], data: unknown): string | null {
   const failures: string[] = [];
   for (const m of matches) {
+    let compiled: CompiledMatch;
+    try {
+      compiled = compileMatch(m);
+    } catch (err) {
+      failures.push(`'${m.path}' invalid regex /${m.matches}/: ${(err as Error).message}`);
+      continue;
+    }
+
     const r = resolvePath(data, m.path);
     if (!r.ok) {
       failures.push(`'${m.path}' ${r.reason}`);
@@ -179,18 +235,24 @@ export function checkOutputMatches(matches: OutputMatch[], data: unknown): strin
     }
     if (r.mode === "all") {
       if (r.values.length === 0) continue;
-      const firstFailure = r.values
-        .map((v) => applyOperator(m, v))
-        .find((res): res is { ok: false; reason: string } => !res.ok);
-      if (firstFailure) failures.push(`'${m.path}' ${firstFailure.reason}`);
+      const offenders: string[] = [];
+      for (const v of r.values) {
+        const res = applyOperator(compiled, v);
+        if (!res.ok) offenders.push(formatValue(v));
+      }
+      if (offenders.length > 0) {
+        const opDescription = describeOperator(compiled);
+        failures.push(`'${m.path}' ${opDescription}, got [${offenders.join(", ")}]`);
+      }
     } else {
       if (r.values.length === 0) {
         failures.push(`'${m.path}' (any:) resolved to no elements`);
         continue;
       }
-      const anyOk = r.values.some((v) => applyOperator(m, v).ok);
+      const anyOk = r.values.some((v) => applyOperator(compiled, v).ok);
       if (!anyOk) {
-        failures.push(`'${m.path}' (any:) no element satisfied operator`);
+        const opDescription = describeOperator(compiled);
+        failures.push(`'${m.path}' (any:) no element satisfies ${opDescription}`);
       }
     }
   }
@@ -198,7 +260,13 @@ export function checkOutputMatches(matches: OutputMatch[], data: unknown): strin
   return `output_matches: ${failures.join("; ")}`;
 }
 
-import type { NodeResult, NodeVerify } from "./types.js";
+function describeOperator(c: CompiledMatch): string {
+  const m = c.match;
+  if (m.equals !== undefined) return `equals ${formatValue(m.equals)}`;
+  if (m.in !== undefined) return `in [${m.in.map(formatValue).join(", ")}]`;
+  if (m.matches !== undefined) return `matches /${m.matches}/`;
+  return "no operator";
+}
 
 /**
  * Evaluate every declared check and return a concatenated error string,

--- a/spec/src/content/docs/nodes.mdx
+++ b/spec/src/content/docs/nodes.mdx
@@ -347,9 +347,9 @@ A representative failure message:
 
 ```
 verify failed:
-  - any_tool_called: required one of [linear_create_issue, github_create_issue], called: [linear_search_issues]
-  - output_required: 'prUrl' missing
-  - output_matches: findings[*].severity not in [critical, high, medium, low] (got: [urgent])
+  - any_tool_called: required one of [linear_create_issue, github_create_issue] to succeed, called: [linear_search_issues]
+  - output_required: 'prUrl' missing segment 'prUrl'
+  - output_matches: 'findings[*].severity' in ["critical", "high", "medium", "low"], got ["urgent"]
 ```
 
 ### Worked example

--- a/spec/src/content/docs/nodes.mdx
+++ b/spec/src/content/docs/nodes.mdx
@@ -16,6 +16,7 @@ A Node represents a single step in a [Workflow](/workflow). Each node contains a
 | `max_turns`   | integer &ge; 1                   | OPTIONAL | implementation&#8209;defined | Maximum AI model turns for this node's execution.                              |
 | `rules`       | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Rules for this node. Additive by default; see [cascade](#cascade-semantics).   |
 | `context`     | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Context for this node. Additive by default; see [cascade](#cascade-semantics). |
+| `verify`      | [Verify](#verify)                | OPTIONAL | —                            | Machine-checked post-conditions evaluated after the AI finishes the node.      |
 
 ## Max Turns Semantics
 
@@ -216,6 +217,177 @@ A conforming executor:
 - **MUST** request structured output from the AI model conforming to this schema when `output` is present.
 - The structured output becomes the node's result data, available to downstream nodes via [context accumulation](/execution#context-accumulation).
 - When `output` is absent, the node's result data is implementation-defined.
+
+## Verify
+
+The `verify` field declares machine-checked post-conditions the executor evaluates after the AI model finishes a node. A node passes only if every declared check passes; otherwise the node is marked failed and the workflow halts (or routes to the next failure edge).
+
+Verify catches the common "the model claims success without doing the work" failure mode: a tool was supposed to be called and wasn't, a required field is missing from the structured output, a value is outside the allowed set. It complements — and does not replace — [conditional edges](/edges#conditional-routing), which decide _where to go next_ based on the result.
+
+### Fields
+
+| Field              | Type                               | Meaning                                                               |
+| ------------------ | ---------------------------------- | --------------------------------------------------------------------- |
+| `any_tool_called`  | string[]                           | At least one of the named tools was called and succeeded.             |
+| `all_tools_called` | string[]                           | Every named tool was called and succeeded at least once.              |
+| `no_tool_called`   | string[]                           | None of the named tools may have been invoked at all.                 |
+| `output_required`  | string[]                           | Each path resolves to a present, non-null value in `result.data`.     |
+| `output_matches`   | [OutputMatch](#outputmatch-type)[] | Each assertion holds against the value(s) at `path` in `result.data`. |
+
+A `verify` block MUST declare at least one of these fields. Each string-array field MUST be non-empty.
+
+### Tool-call checks
+
+A tool "was called and succeeded" when it appears in the node's tool-call trace with no error. The same rule applies to all three checks. For `no_tool_called`, _any_ appearance — successful or not — counts as a violation.
+
+```yaml
+implement-fix:
+  name: Implement Fix
+  instruction: Open a PR that fixes the issue.
+  skills:
+    - github
+  verify:
+    all_tools_called: [github_create_pr]
+    no_tool_called: [github_force_push]
+```
+
+```yaml
+triage:
+  name: Triage
+  instruction: Either create a follow-up issue or escalate to the on-call engineer.
+  skills:
+    - linear
+    - github
+  verify:
+    any_tool_called: [linear_create_issue, github_create_issue]
+```
+
+### Output checks
+
+`output_required` and `output_matches` operate on the node's structured `output` (`result.data`).
+
+```yaml
+implement-fix:
+  name: Implement Fix
+  instruction: Open a PR that fixes the issue and report the URL.
+  skills:
+    - github
+  output:
+    type: object
+    properties:
+      prUrl: { type: string }
+      branchName: { type: string }
+    required: [prUrl, branchName]
+  verify:
+    output_required: [prUrl, branchName]
+    output_matches:
+      - { path: prUrl, matches: "^https://github.com/" }
+      - { path: branchName, matches: "^sweny/" }
+```
+
+#### OutputMatch type
+
+| Field     | Type   | Required | Description                                                                                            |
+| --------- | ------ | -------- | ------------------------------------------------------------------------------------------------------ |
+| `path`    | string | REQUIRED | A path into `result.data` (see [Path grammar](#path-grammar)).                                         |
+| `equals`  | any    | one-of   | Strict deep equality against the resolved value.                                                       |
+| `in`      | any[]  | one-of   | The resolved value is in the array (deep equality per element).                                        |
+| `matches` | string | one-of   | A JavaScript regex source (no flags); the resolved value is coerced to a string and tested against it. |
+
+Exactly one of `equals`, `in`, or `matches` MUST be set per entry.
+
+### Path grammar
+
+A path is a `.`-separated sequence of segments. A segment is either:
+
+- An identifier matching `[a-zA-Z_][a-zA-Z0-9_]*` — object property access, OR
+- An identifier followed by `[*]` — wildcard expansion over an array.
+
+The path MAY be prefixed with `all:` or `any:` (see [Wildcard semantics](#wildcard-semantics)). When no prefix is present, `all:` is implied.
+
+Examples:
+
+| Path                       | Resolves to                                                       |
+| -------------------------- | ----------------------------------------------------------------- |
+| `prUrl`                    | The `prUrl` property of `result.data`.                            |
+| `findings[*].severity`     | The `severity` property of every element of the `findings` array. |
+| `any:checks[*].conclusion` | The `conclusion` property of any element of the `checks` array.   |
+| `issue.metadata.url`       | A nested object property.                                         |
+
+The grammar is intentionally minimal so workflow authors can read it in a sentence and tooling (Studio, linters) can parse it in a few lines. Richer expressions (filter predicates, JSONPath, CEL) are out of scope.
+
+### Path resolution
+
+A path is resolved by walking segments left-to-right against `result.data`:
+
+- A non-wildcard segment that doesn't exist on its parent object → resolution **fails**.
+- A `[*]` segment requires its parent to be an array. If the parent is not an array, resolution fails. If the parent is an empty array, expansion succeeds and the wildcard rule below applies.
+- Encountering `null` mid-path → resolution fails.
+
+`output_required` and `output_matches` both treat a failed resolution as a failed check. The error message names the missing segment.
+
+### Wildcard semantics
+
+When a path contains `[*]` and resolves successfully:
+
+- `all:` (default) — every resolved value MUST satisfy the operator. An empty array is vacuously true.
+- `any:` — at least one resolved value MUST satisfy the operator. An empty array is false.
+
+`output_required` follows the same rule. `output_required: [findings[*].severity]` means the `findings` array is present and every finding has a non-null `severity`. `output_required: ["any:findings[*].severity"]` means at least one finding does.
+
+### Combining checks & failure reporting
+
+All checks declared on a node are AND-ed; order does not matter. A conforming executor:
+
+- **MUST** evaluate every declared check (no fast-fail), so the workflow author sees every problem in one pass.
+- **MUST** mark the node failed if any check fails, with a single `error` message that lists every failing check.
+- **MUST NOT** evaluate `verify` when the AI model already failed the node (verify only runs against successful node executions).
+
+A representative failure message:
+
+```
+verify failed:
+  - any_tool_called: required one of [linear_create_issue, github_create_issue], called: [linear_search_issues]
+  - output_required: 'prUrl' missing
+  - output_matches: findings[*].severity not in [critical, high, medium, low] (got: [urgent])
+```
+
+### Worked example
+
+```yaml
+implement-fix:
+  name: Implement Fix
+  instruction: Open a PR that fixes the issue and verify CI is green.
+  skills:
+    - github
+  output:
+    type: object
+    properties:
+      prUrl:      { type: string }
+      branchName: { type: string }
+      checks:
+        type: array
+        items:
+          type: object
+          properties:
+            name:       { type: string }
+            conclusion: { type: string }
+    required: [prUrl, branchName]
+  verify:
+    all_tools_called: [github_create_pr]
+    no_tool_called:   [github_force_push]
+    output_required:  [prUrl, branchName]
+    output_matches:
+      - { path: prUrl,                    matches: "^https://github.com/" }
+      - { path: branchName,               matches: "^sweny/" }
+      - { path: any:checks[*].conclusion, equals:  "success" }
+```
+
+### When to use verify
+
+- Use `verify` for _post-conditions_: facts that must be true once the node has run.
+- Use [conditional edges](/edges#conditional-routing) for _routing_: which node runs next based on the result.
+- Use the node's `output` JSON Schema for _shape_: the structural contract on the data. `verify` is for the looser "did the model actually do the right thing" check that JSON Schema can't express.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Extend `NodeVerify` from a single `any_tool_called` check into a small declarative post-condition language: `any_tool_called`, `all_tools_called`, `no_tool_called`, `output_required`, `output_matches`.
- Move verify logic into a dedicated `packages/core/src/verify.ts` module with a tiny path grammar (dotted segments + `[*]` wildcards, optional `all:`/`any:` prefix). Aggregate failures into one error string — `NodeResult` shape unchanged, so cloud worker / studio / MCP need no changes.
- Document the entire feature (previously undocumented) as a new top-level **Verify** section in `spec/src/content/docs/nodes.mdx`, plus a row in the node Fields table.
- Backwards-compatible: `any_tool_called` keeps its current shape; `triage.yml` works unchanged.

Design doc: `docs/superpowers/specs/2026-04-18-verify-v2-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-18-verify-v2.md`

## Test Plan

- [x] `cd packages/core && npm test` — 2232 passing, 5 skipped (58 new in `verify.test.ts`, 13 new schema tests, 6 new executor integration tests)
- [x] `npx vitest run packages/core/src/__tests__/spec-conformance.test.ts` — 44 passing
- [x] `cd spec && npm run build` — Astro build clean
- [x] Full monorepo build (core → studio:lib → web) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)