### PR TITLE
fix(core): surface tool errors in CI logs + add retry to triage action nodes

### DIFF
--- a/.changeset/tool-error-observability.md
+++ b/.changeset/tool-error-observability.md
@@ -1,0 +1,29 @@
+---
+"@sweny-ai/core": patch
+---
+
+Surface tool errors in the CI log stream and add retry blocks to the bundled
+triage workflow's action-taking nodes.
+
+Before this, when a tool returned an error during a node turn, the error body
+was captured onto the `ToolCall.output.error` field for in-memory verify
+evaluation but never written to the log stream. The only CI-visible signal
+was the downstream `verify failed: any_tool_called` message, which names the
+tool but gives no hint as to *why* it failed. Every triage postmortem on a
+tool failure became a diagnostic wall: "the tool was called and errored; no
+idea what it said."
+
+The `ClaudeClient` tool-result handler now calls `logger.warn` with the tool
+name and a short, single-line summary of the error body (collapsed
+whitespace, capped at 300 chars). The full parsed payload is still attached
+to the `ToolCall` for verify and downstream consumers — this is only about
+observability.
+
+Also adds `retry: { max: 1, instruction: { auto: true } }` to the `create_issue`
+and `create_pr` nodes in the bundled triage workflow. These are single
+action-taking nodes most exposed to transient provider errors (GitHub or
+Linear rate limits, 422s on bad inputs, network blips). One auto-reflection
+retry gives the agent a chance to adjust its inputs based on the error it
+just saw — previously a single failure killed the whole pipeline before
+the real fix (which had already been written to a branch by the `implement`
+node) ever got a PR opened for it.

--- a/packages/core/src/__tests__/claude.test.ts
+++ b/packages/core/src/__tests__/claude.test.ts
@@ -809,5 +809,79 @@ describe("ClaudeClient", () => {
       expect(result.toolCalls).toHaveLength(0);
       expect(result.status).toBe("success");
     });
+
+    it("surfaces tool errors at warn level so CI logs show the failure body", async () => {
+      // Observability gap this closes: before, a tool_result with
+      // is_error=true was captured onto the ToolCall for in-memory verify
+      // evaluation but never logged. The only signal was the downstream
+      // verify failure message, which names the tool but not the why.
+      mockQuery.mockReturnValueOnce(
+        makeStream([
+          {
+            type: "assistant",
+            message: {
+              content: [{ type: "tool_use", id: "u1", name: "github_create_pr", input: {} }],
+            },
+          },
+          {
+            type: "user",
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "u1",
+                  content: '[GitHub] API request failed (HTTP 422): {"message":"Validation Failed"}',
+                  is_error: true,
+                },
+              ],
+            },
+          },
+          { type: "result", subtype: "success", result: "{}" },
+        ]),
+      );
+
+      const warnSpy = vi.fn();
+      const logger = {
+        info: () => undefined,
+        warn: warnSpy,
+        error: () => undefined,
+        debug: () => undefined,
+      };
+      const client = new ClaudeClient({ logger });
+      const result = await client.run({ instruction: "x", context: {}, tools: [] });
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].status).toBe("error");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/tool github_create_pr failed: .*HTTP 422.*Validation Failed/),
+      );
+    });
+  });
+});
+
+describe("summarizeToolError", () => {
+  it("stringifies objects", async () => {
+    const { summarizeToolError } = await import("../claude.js");
+    expect(summarizeToolError({ message: "boom", code: 422 })).toBe('{"message":"boom","code":422}');
+  });
+
+  it("collapses whitespace on strings", async () => {
+    const { summarizeToolError } = await import("../claude.js");
+    expect(summarizeToolError("line one\n\nline two\n   indented")).toBe("line one line two indented");
+  });
+
+  it("caps very long payloads at 300 chars with ellipsis", async () => {
+    const { summarizeToolError } = await import("../claude.js");
+    const s = "x".repeat(500);
+    const out = summarizeToolError(s);
+    expect(out).toHaveLength(300);
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("coerces primitives without crashing", async () => {
+    const { summarizeToolError } = await import("../claude.js");
+    expect(summarizeToolError(null)).toBe("null");
+    expect(summarizeToolError(undefined)).toBe("undefined");
+    expect(summarizeToolError(42)).toBe("42");
   });
 });

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -191,6 +191,16 @@ export class ClaudeClient implements Claude {
               call.status = isError ? "error" : "success";
               const parsed = parseToolResultContent(block.content);
               call.output = isError ? { error: parsed } : parsed;
+
+              // Surface tool errors in the CI log stream at warn level so
+              // postmortems don't have to reconstruct them from verify-time
+              // tool-call summaries. Without this, "verify failed: tool X
+              // did not succeed" never answers the WHY question, because
+              // the error body is buried in the per-call output captured
+              // only for in-memory verify evaluation.
+              if (isError) {
+                this.logger.warn(`  tool ${call.tool} failed: ${summarizeToolError(parsed)}`);
+              }
             }
           }
         } else if (message.type === "result") {
@@ -405,6 +415,31 @@ export function parseToolResultContent(content: unknown): unknown {
   } catch {
     return content;
   }
+}
+
+/**
+ * Produce a short, single-line description of a tool-error payload suitable
+ * for the CI log stream. The full parsed value stays on the ToolCall for
+ * verify and downstream tooling — this is only for inline observability.
+ *
+ * Collapses newlines, trims whitespace, and caps to 300 chars so a huge
+ * API response body doesn't flood the log.
+ */
+export function summarizeToolError(parsed: unknown): string {
+  let raw: string;
+  if (typeof parsed === "string") {
+    raw = parsed;
+  } else if (parsed && typeof parsed === "object") {
+    try {
+      raw = JSON.stringify(parsed);
+    } catch {
+      raw = String(parsed);
+    }
+  } else {
+    raw = String(parsed);
+  }
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  return collapsed.length > 300 ? collapsed.slice(0, 297) + "..." : collapsed;
 }
 
 // ─── JSON Schema → Zod conversion ───────────────────────────────

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -289,6 +289,10 @@ nodes:
         - issueTitle
         - issueUrl
         - issues
+    retry:
+      max: 1
+      instruction:
+        auto: true
   skip:
     name: Skip — All Duplicates or Low Priority
     instruction: >-
@@ -378,6 +382,10 @@ nodes:
     verify:
       any_tool_called:
         - github_create_pr
+    retry:
+      max: 1
+      instruction:
+        auto: true
   notify:
     name: Notify Team
     instruction: |-


### PR DESCRIPTION
## Summary

Two fixes needed to make the sweny triage pipeline actually work end-to-end.

### 1. Tool-error observability

`ClaudeClient` already captures `tool_result` errors onto `ToolCall.output.error` for in-memory verify evaluation, but never logs them. The only CI-visible signal was the downstream `verify failed: any_tool_called: required one of [X] to succeed, called: [..., X]` message, which names the tool but never tells you *why* it failed. Every triage postmortem became a diagnostic wall.

Now the tool_result handler calls `logger.warn(\`  tool ${name} failed: ${summary}\`)` inline. Full payload still on the ToolCall for verify.

### 2. Retry on the triage action nodes

`create_issue` and `create_pr` in the bundled triage workflow now have `retry: { max: 1, instruction: { auto: true } }`. These are single action-taking nodes most exposed to transient provider errors (GitHub/Linear rate limits, 422s on slightly-wrong inputs, network blips). One auto-reflection retry lets the agent adjust inputs based on the error it just saw.

### Motivating case

A fresh offload triage run after PR #165 got all the way through investigate → create_issue → implement (branch pushed with a real cleanupStaleSessions race-condition fix + tests), then died at create_pr because `github_create_pr` errored once. No retry on the node = node fails = pipeline fails. The fix was there. Nothing to open a PR for it. Had to open [PR #356](https://github.com/letsoffload/offload/pull/356) by hand.

## Test plan

- [x] 45 ClaudeClient tests pass, including a new case asserting `logger.warn` fires with a tool-name + error-body summary when `is_error=true`.
- [x] 4 new unit tests on `summarizeToolError` (objects, whitespace collapse, 300-char cap, primitive coercion).
- [x] Full suite: 1400 tests pass, typecheck clean.
- [x] Browser workflow bundle regenerated to match the YAML retry additions.
- [ ] Post-merge: dispatch triage on letsoffload/offload and confirm any tool error now shows its body in the log, and that transient errors don't fail the pipeline on first occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)