### PR TITLE
feat(cli): sweny skill new + sweny skill list scaffold

### DIFF
--- a/packages/core/src/cli/__tests__/skill.test.ts
+++ b/packages/core/src/cli/__tests__/skill.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+import { renderSkillTemplate } from "../skill.js";
+import { discoverSkillsWithDiagnostics } from "../../skills/custom-loader.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+describe("renderSkillTemplate", () => {
+  it("emits valid YAML frontmatter parseable by the discovery loader", () => {
+    const md = renderSkillTemplate({
+      id: "voyage-embeddings",
+      description: "Embed text via Voyage AI",
+      category: "data",
+    });
+
+    const fmMatch = md.match(/^---\s*\n([\s\S]*?)\n---/);
+    expect(fmMatch).not.toBeNull();
+    const fm = parseYaml(fmMatch![1]) as Record<string, unknown>;
+    expect(fm.name).toBe("voyage-embeddings");
+    expect(fm.description).toBe("Embed text via Voyage AI");
+    expect(fm.category).toBe("data");
+  });
+
+  it("includes a body the LLM can actually consume as instruction", () => {
+    const md = renderSkillTemplate({
+      id: "my-skill",
+      description: "Do a thing",
+      category: "general",
+    });
+    const body = md.split(/\n---\n/)[1] ?? "";
+    expect(body).toContain("# my-skill");
+    expect(body).toContain("Do a thing");
+    expect(body).toContain("skills: [my-skill]");
+  });
+
+  it("commented-out config and mcp blocks are syntactically valid YAML when uncommented", () => {
+    const md = renderSkillTemplate({ id: "x", description: "x", category: "general" });
+    // Strip leading "# " from any commented frontmatter lines and re-parse.
+    const fmMatch = md.match(/^---\s*\n([\s\S]*?)\n---/)!;
+    const uncommented = fmMatch[1]
+      .split("\n")
+      .map((line) => (line.startsWith("# ") ? line.slice(2) : line.replace(/^#$/, "")))
+      .join("\n");
+    expect(() => parseYaml(uncommented)).not.toThrow();
+  });
+});
+
+describe("scaffolded skill is round-trippable through discovery", () => {
+  it("a SKILL.md created from the template is discovered with the right id", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-skill-test-"));
+    try {
+      const skillDir = path.join(tmp, ".claude", "skills", "voyage-embeddings");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        renderSkillTemplate({
+          id: "voyage-embeddings",
+          description: "Embed text via Voyage AI",
+          category: "data",
+        }),
+        "utf-8",
+      );
+
+      const result = discoverSkillsWithDiagnostics(tmp);
+      expect(result.warnings).toEqual([]);
+      const ids = result.skills.map((s) => s.id);
+      expect(ids).toContain("voyage-embeddings");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -59,6 +59,7 @@ import {
 import { checkProviderConnectivity } from "./check.js";
 import { registerSetupCommand } from "./setup.js";
 import { registerPublishCommand } from "./publish.js";
+import { registerSkillCommand } from "./skill.js";
 import { reportToCloud } from "./cloud-report.js";
 import { runUpgrade, fetchLatestFromNpm } from "./upgrade.js";
 import { maybeNudge, defaultCachePath } from "./version-check.js";
@@ -138,6 +139,7 @@ program
 
 registerSetupCommand(program);
 registerPublishCommand(program);
+registerSkillCommand(program);
 
 // ── Credential map builder ──────────────────────────────────────────
 // buildCredentialMap lives in ./credentials.ts so tests can import it
@@ -700,15 +702,27 @@ export async function workflowRunAction(
   if (validation.errors.length > 0) {
     console.error(chalk.red(`\n  Workflow cannot run — missing required skills:\n`));
     for (const err of validation.errors) console.error(chalk.red(`    \u2717 ${err}`));
-    if (validation.missing.length > 0) {
-      console.error(chalk.dim(`\n  Set the missing env vars and try again:`));
-      for (const m of validation.missing) {
-        if (m.missingEnv.length > 0) {
-          console.error(chalk.dim(`    - ${m.id}: ${m.missingEnv.join(", ")}`));
-        }
+
+    const unknown = validation.missing.filter((m) => m.category === "unknown");
+    const envGaps = validation.missing.filter((m) => m.category !== "unknown" && m.missingEnv.length > 0);
+
+    if (unknown.length > 0) {
+      console.error(
+        chalk.dim(
+          `\n  These skill IDs aren't built-in or discovered in .{claude,sweny,agents,gemini}/skills/.\n  Scaffold one with:\n`,
+        ),
+      );
+      for (const m of unknown) {
+        console.error(chalk.dim(`    sweny skill new ${m.id}`));
       }
     }
-    console.error("");
+    if (envGaps.length > 0) {
+      console.error(chalk.dim(`\n  These skills are built-in but their env vars aren't set:`));
+      for (const m of envGaps) {
+        console.error(chalk.dim(`    - ${m.id}: ${m.missingEnv.join(", ")}`));
+      }
+    }
+    console.error(chalk.dim(`\n  Run \`sweny skill list\` to see what's available.\n`));
     process.exit(1);
     return;
   }

--- a/packages/core/src/cli/skill.ts
+++ b/packages/core/src/cli/skill.ts
@@ -1,0 +1,241 @@
+/**
+ * `sweny skill` command group — discover, list, and scaffold skills.
+ *
+ * Skills are the unit of capability a workflow node names in its `skills`
+ * array. Sweny ships built-ins (github, linear, slack, ...) and discovers
+ * custom skills from `.{gemini,agents,claude,sweny}/skills/<id>/SKILL.md`.
+ *
+ * This module owns the *authoring* side of that loop:
+ *
+ *   sweny skill new <id>     scaffold a SKILL.md template
+ *   sweny skill list         list built-in + custom skills together
+ *
+ * Discovery and validation already live in `../skills/custom-loader.js`
+ * and `../skills/index.js`; this CLI is a thin authoring shell over them.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+
+import { builtinSkills } from "../skills/index.js";
+import { configuredSkillsWithDiagnostics, discoverSkillsWithDiagnostics } from "../skills/custom-loader.js";
+
+// Mirror of the loader's regex so authoring-side validation matches discovery.
+const VALID_SKILL_ID = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+const VALID_CATEGORIES = ["general", "git", "tasks", "notification", "observability", "data"] as const;
+type SkillCategory = (typeof VALID_CATEGORIES)[number];
+
+const HARNESS_DIRS = {
+  claude: ".claude/skills",
+  sweny: ".sweny/skills",
+  agents: ".agents/skills",
+  gemini: ".gemini/skills",
+} as const;
+type HarnessKey = keyof typeof HARNESS_DIRS;
+
+/** Build the SKILL.md body for a fresh scaffold. Exported for tests. */
+export function renderSkillTemplate(opts: { id: string; description: string; category: SkillCategory }): string {
+  const { id, description, category } = opts;
+  const lines: string[] = [];
+  lines.push("---");
+  lines.push(`name: ${id}`);
+  lines.push(`description: ${description}`);
+  lines.push(`category: ${category}`);
+  lines.push("# config:");
+  lines.push("#   EXAMPLE_ENV_VAR:");
+  lines.push("#     description: Human-readable description shown by `sweny check`");
+  lines.push("#     required: true");
+  lines.push("# mcp:");
+  lines.push("#   command: npx");
+  lines.push('#   args: ["-y", "@your-org/your-mcp-server"]');
+  lines.push("#   env:");
+  lines.push("#     SOMETHING: ${SOMETHING}");
+  lines.push("---");
+  lines.push("");
+  lines.push(`# ${id}`);
+  lines.push("");
+  lines.push(description);
+  lines.push("");
+  lines.push("## When to use");
+  lines.push("");
+  lines.push(`Reference this skill from a workflow node when the node needs ${description.toLowerCase()}.`);
+  lines.push("");
+  lines.push("```yaml");
+  lines.push("nodes:");
+  lines.push("  my_node:");
+  lines.push("    name: My Node");
+  lines.push(`    instruction: >-`);
+  lines.push(`      Use the ${id} capability described in this skill.`);
+  lines.push(`    skills: [${id}]`);
+  lines.push("```");
+  lines.push("");
+  lines.push("## What this skill provides");
+  lines.push("");
+  lines.push(
+    "Describe the contract this skill exposes. Custom skills are *instruction-only* by default — the markdown body becomes guidance the LLM sees when the node runs. Add an `mcp:` block in the frontmatter above to wire in tool execution via an MCP server.",
+  );
+  lines.push("");
+  lines.push("Concrete things to document here:");
+  lines.push("");
+  lines.push("- Required environment variables (also declare in `config:` above so `sweny check` validates them).");
+  lines.push("- The exact commands or tool calls the node should make.");
+  lines.push("- Common failure modes and how to recover.");
+  lines.push("- Any preconditions the workflow must satisfy before invoking this skill.");
+  lines.push("");
+  lines.push("## Example invocation");
+  lines.push("");
+  lines.push(
+    "Replace this section with a concrete usage example, including the exact bash, MCP tool call, or LLM prompt the node should produce.",
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+interface NewOptions {
+  description?: string;
+  category?: string;
+  harness?: HarnessKey;
+  force?: boolean;
+}
+
+function runSkillNew(idArg: string, options: NewOptions): void {
+  const id = idArg.toLowerCase();
+  if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
+    console.error(
+      chalk.red(
+        `  Invalid skill id "${idArg}".\n  Skill ids must be lowercase alphanumeric + hyphens (no consecutive hyphens), max 64 chars.`,
+      ),
+    );
+    process.exit(2);
+    return;
+  }
+
+  const description = (options.description ?? `Custom ${id} skill`).trim();
+  const category = (options.category ?? "general") as SkillCategory;
+  if (!VALID_CATEGORIES.includes(category)) {
+    console.error(chalk.red(`  Invalid category "${category}".\n  Allowed: ${VALID_CATEGORIES.join(", ")}`));
+    process.exit(2);
+    return;
+  }
+
+  const harness = options.harness ?? "claude";
+  const baseDir = HARNESS_DIRS[harness];
+  if (!baseDir) {
+    console.error(chalk.red(`  Unknown harness "${harness}". Allowed: ${Object.keys(HARNESS_DIRS).join(", ")}`));
+    process.exit(2);
+    return;
+  }
+
+  const cwd = process.cwd();
+  const skillDir = path.join(cwd, baseDir, id);
+  const skillFile = path.join(skillDir, "SKILL.md");
+
+  if (fs.existsSync(skillFile) && !options.force) {
+    console.error(chalk.red(`  ${path.relative(cwd, skillFile)} already exists. Pass --force to overwrite.`));
+    process.exit(1);
+    return;
+  }
+
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(skillFile, renderSkillTemplate({ id, description, category }), "utf-8");
+
+  const rel = path.relative(cwd, skillFile);
+  console.log(chalk.green(`\n  Created ${rel}\n`));
+  console.log(chalk.dim("  Next steps:"));
+  console.log(chalk.dim(`    1. Open ${rel} and replace the placeholder sections.`));
+  console.log(chalk.dim(`    2. If your skill needs env vars, uncomment the 'config:' block in the frontmatter.`));
+  console.log(chalk.dim(`    3. If your skill executes tools via MCP, uncomment the 'mcp:' block.`));
+  console.log(chalk.dim(`    4. Reference the skill in a workflow node:  skills: [${id}]`));
+  console.log(chalk.dim(`    5. Run \`sweny skill list\` to confirm it discovers correctly.`));
+  console.log();
+}
+
+interface ListOptions {
+  json?: boolean;
+}
+
+function runSkillList(options: ListOptions): void {
+  const cwd = process.cwd();
+  // We want the FULL list — built-in + custom — even when env vars
+  // aren't set. configuredSkills filters by env, which hides authoring-
+  // time skills the user just scaffolded. So combine sources directly.
+  const { skills: customSkills, warnings: customWarnings } = discoverSkillsWithDiagnostics(cwd);
+  const customIds = new Set(customSkills.map((s) => s.id));
+  const builtinList = builtinSkills.filter((s) => !customIds.has(s.id));
+
+  // Configured map drives the "configured?" badge — required env vars present.
+  const configuredIds = new Set(configuredSkillsWithDiagnostics(process.env, cwd).skills.map((s) => s.id));
+
+  if (options.json) {
+    const data = [
+      ...builtinList.map((s) => ({
+        id: s.id,
+        kind: "builtin",
+        category: s.category,
+        description: s.description,
+        configured: configuredIds.has(s.id),
+      })),
+      ...customSkills.map((s) => ({
+        id: s.id,
+        kind: "custom",
+        category: s.category,
+        description: s.description,
+        configured: configuredIds.has(s.id),
+      })),
+    ];
+    process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+    return;
+  }
+
+  const renderRow = (s: { id: string; category: string; description: string }, kind: "builtin" | "custom") => {
+    const tag = kind === "custom" ? chalk.magenta("custom") : chalk.dim("builtin");
+    const ok = configuredIds.has(s.id) ? chalk.green("✓") : chalk.yellow("·");
+    console.log(`  ${ok} ${chalk.cyan(s.id)} ${chalk.dim(`(${s.category})`)} ${tag}`);
+    console.log(chalk.dim(`      ${s.description}`));
+  };
+
+  console.log(chalk.bold("\nAvailable skills:\n"));
+  console.log(chalk.dim("  ✓ = configured (required env vars present)"));
+  console.log(chalk.dim("  · = present but not configured"));
+  console.log();
+  if (builtinList.length === 0 && customSkills.length === 0) {
+    console.log(chalk.dim("  (no skills found)\n"));
+  } else {
+    for (const s of builtinList) renderRow(s, "builtin");
+    for (const s of customSkills) renderRow(s, "custom");
+  }
+
+  if (customWarnings.length > 0) {
+    console.log();
+    console.log(chalk.yellow(`  ${customWarnings.length} skill discovery warning(s):`));
+    for (const w of customWarnings) {
+      console.log(chalk.yellow(`    ${w.kind}: ${w.message}`));
+    }
+  }
+  console.log();
+  console.log(chalk.dim(`  Scaffold a new skill:  sweny skill new <id>`));
+  console.log();
+}
+
+/** Register the `sweny skill` subcommand group on the parent program. */
+export function registerSkillCommand(program: Command): void {
+  const skillCmd = program.command("skill").description("Author and inspect skills");
+
+  skillCmd
+    .command("new <id>")
+    .description("Scaffold a new SKILL.md in .claude/skills/<id>/")
+    .option("-d, --description <text>", "One-line description (required field in frontmatter)")
+    .option("-c, --category <category>", `Skill category (${VALID_CATEGORIES.join("|")})`, "general")
+    .option("--harness <harness>", `Where to place the skill (${Object.keys(HARNESS_DIRS).join("|")})`, "claude")
+    .option("--force", "Overwrite an existing SKILL.md")
+    .action((id: string, options: NewOptions) => runSkillNew(id, options));
+
+  skillCmd
+    .command("list")
+    .description("List built-in and custom skills together with configuration status")
+    .option("--json", "Output as JSON array")
+    .action((options: ListOptions) => runSkillList(options));
+}

--- a/packages/core/src/skills/custom-loader.ts
+++ b/packages/core/src/skills/custom-loader.ts
@@ -129,9 +129,16 @@ function parseSkillMd(content: string, path: string): ParseResult {
   const fm = raw as {
     name: string;
     description?: string;
+    category?: string;
     config?: Record<string, unknown>;
     mcp?: Record<string, unknown>;
   };
+
+  const VALID_CATEGORIES: SkillCategory[] = ["general", "git", "tasks", "notification", "observability", "data"];
+  const category: SkillCategory =
+    typeof fm.category === "string" && (VALID_CATEGORIES as string[]).includes(fm.category)
+      ? (fm.category as SkillCategory)
+      : "general";
 
   const id = String(fm.name);
   if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
@@ -183,7 +190,7 @@ function parseSkillMd(content: string, path: string): ParseResult {
       id,
       name: id,
       description: typeof fm.description === "string" ? fm.description : `Custom skill: ${id}`,
-      category: "general" as SkillCategory,
+      category,
       config,
       tools: [],
       instruction: instruction || undefined,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,7 +36,7 @@ export interface ConfigField {
 }
 
 /** Skill categories — used for validation and grouping */
-export type SkillCategory = "git" | "observability" | "tasks" | "notification" | "general";
+export type SkillCategory = "git" | "observability" | "tasks" | "notification" | "data" | "general";
 
 /** A skill groups related tools with shared config requirements */
 export interface Skill {


### PR DESCRIPTION
## Summary

Authoring custom skills used to be undocumented surface area: a user had to know the directory layout (`.{claude,sweny,agents,gemini}/skills/<id>/SKILL.md`), the frontmatter format, the valid ID regex, and that custom skills are instruction-only by default. Now there's a one-liner.

```bash
sweny skill new voyage-embeddings -d "Embed via Voyage" -c data
sweny skill list
```

## Changes

- **`sweny skill new <id>`** writes `.claude/skills/<id>/SKILL.md` with templated frontmatter (commented-out `config:` and `mcp:` blocks ready to uncomment) and a body skeleton documenting when to use, inputs/outputs, failure modes, and an invocation example. Flags: `--description`, `--category`, `--harness`, `--force`.
- **`sweny skill list`** shows built-in + custom skills together with `✓` (configured) / `·` (env vars missing) badges. JSON via `--json`.
- **`custom-loader`** now honors `category:` from frontmatter (was hardcoded `general`). Falls back to `general` when omitted or invalid.
- **`SkillCategory`** adds `data` for embedding/vector/db skills.
- **Workflow validation** now points users at `sweny skill new <id>` when a referenced skill ID isn't built-in or discovered, instead of the bare "missing required skills" error. Existing env-gap path unchanged.

## Test plan

- [x] `sweny skill new <id>` creates a SKILL.md that round-trips through discovery (new test).
- [x] Frontmatter shape is parseable as YAML; commented-out `config`/`mcp` blocks are valid YAML once uncommented (new test).
- [x] `sweny skill list --json` shows both built-in and custom skills with the right `kind` field (smoke-tested via the regs-researcher integration that motivated this PR).
- [x] Workflow validation surfaces `sweny skill new <id>` for unknown skill IDs (smoke-tested).
- [x] All 1,509 existing core tests still pass.

## Motivation

Building [the regs-researcher facts pipeline](https://github.com/letsoffload/regs-researcher/commit/eeb2470) kept hitting `skills: []` on every workflow node because there was no obvious way to author a custom skill. The fix had to be drop-dead easy or it'd keep getting skipped — now it's `sweny skill new`. PR'ing the lessons back so others don't hit the same friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)