### PR TITLE
test(skill-cli): add runner coverage and document data category

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ $ sweny workflow create "audit our repo for security issues, \
 
 ## Custom skills
 
-Extend any workflow with your own skills. Create a `SKILL.md` with instructions or wire up an MCP server:
+Extend any workflow with your own skills. Scaffold one in a single command:
+
+```bash
+sweny skill new code-standards -d "Team TypeScript conventions"
+sweny skill list
+```
+
+Or write the file by hand at `.sweny/skills/code-standards/SKILL.md`:
 
 ```
 .sweny/skills/code-standards/SKILL.md

--- a/packages/core/src/__tests__/skills-index.test.ts
+++ b/packages/core/src/__tests__/skills-index.test.ts
@@ -149,6 +149,28 @@ describe("skills registry", () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
+  // Contract test for the CLI workflow-run error formatter. main.ts splits
+  // `result.missing` into "unknown" (scaffold-it path) vs "env-gap" (set-env-
+  // vars path) by checking `m.category === "unknown"`. If this contract
+  // changes, the CLI message degrades silently. Catch it here, not in prod.
+  it("validateWorkflowSkills tags unknown ids with category='unknown' and built-in env-gaps with their real category", () => {
+    const workflow = {
+      nodes: {
+        gather: { skills: ["github", "totally-made-up-skill"] },
+      },
+    };
+    // No env vars set, so `github` is built-in but not configured.
+    const available = createSkillMap([]);
+    const result = validateWorkflowSkills(workflow, available);
+
+    const made = result.missing.find((m) => m.id === "totally-made-up-skill");
+    expect(made?.category).toBe("unknown");
+
+    const github = result.missing.find((m) => m.id === "github");
+    expect(github?.category).toBe("git");
+    expect(github?.missingEnv).toContain("GITHUB_TOKEN");
+  });
+
   it("validateWorkflowSkills passes when all categories covered", () => {
     const workflow = {
       nodes: {

--- a/packages/core/src/__tests__/skills-index.test.ts
+++ b/packages/core/src/__tests__/skills-index.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   github,
   linear,
@@ -12,6 +14,7 @@ import {
   isSkillConfigured,
   validateWorkflowSkills,
 } from "../skills/index.js";
+import { SKILL_CATEGORIES } from "../types.js";
 
 describe("skills registry", () => {
   it("exports all builtin skills", () => {
@@ -183,6 +186,16 @@ describe("skills registry", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.warnings).toHaveLength(0);
     expect(result.configured).toHaveLength(2);
+  });
+
+  // Drift catcher: the published JSON Schema's `category` enum MUST match the
+  // runtime SKILL_CATEGORIES list. The original `data` bug landed because
+  // these two sources diverged silently. This test fails loudly the next time.
+  it("SKILL_CATEGORIES matches the published spec schema enum", () => {
+    const schemaPath = join(__dirname, "../../../../spec/public/schemas/skill.json");
+    const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+    const enumValues = schema.properties.category.enum as string[];
+    expect([...SKILL_CATEGORIES].sort()).toEqual([...enumValues].sort());
   });
 
   it("config fields have env vars matching canonical names", () => {

--- a/packages/core/src/cli/__tests__/skill.test.ts
+++ b/packages/core/src/cli/__tests__/skill.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { parse as parseYaml } from "yaml";
 
-import { renderSkillTemplate } from "../skill.js";
+import { renderSkillTemplate, runSkillNew, runSkillList } from "../skill.js";
 import { discoverSkillsWithDiagnostics } from "../../skills/custom-loader.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -70,5 +70,221 @@ describe("scaffolded skill is round-trippable through discovery", () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("custom skill 'category' frontmatter is honored by the discovery loader", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-skill-cat-"));
+    try {
+      const skillDir = path.join(tmp, ".claude", "skills", "voyage-embeddings");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        renderSkillTemplate({ id: "voyage-embeddings", description: "x", category: "data" }),
+        "utf-8",
+      );
+      const skill = discoverSkillsWithDiagnostics(tmp).skills.find((s) => s.id === "voyage-embeddings");
+      expect(skill?.category).toBe("data");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("invalid 'category' frontmatter falls back to 'general' rather than throwing", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-skill-cat-fallback-"));
+    try {
+      const skillDir = path.join(tmp, ".claude", "skills", "weird");
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        "---\nname: weird\ndescription: bad category\ncategory: not-a-real-category\n---\nbody",
+        "utf-8",
+      );
+      const result = discoverSkillsWithDiagnostics(tmp);
+      const skill = result.skills.find((s) => s.id === "weird");
+      expect(skill?.category).toBe("general");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runSkillNew", () => {
+  let tmp: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-skill-new-"));
+    // process.exit must throw so a failing assertion in the runner doesn't
+    // actually terminate the test process.
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("writes .claude/skills/<id>/SKILL.md by default and prints next steps", () => {
+    runSkillNew("voyage-embeddings", { description: "Embed text via Voyage", category: "data" }, tmp);
+
+    const skillFile = path.join(tmp, ".claude", "skills", "voyage-embeddings", "SKILL.md");
+    expect(fs.existsSync(skillFile)).toBe(true);
+    expect(fs.readFileSync(skillFile, "utf-8")).toContain("name: voyage-embeddings");
+    const stdout = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+    expect(stdout).toContain("Next steps");
+    expect(stdout).toContain("skills: [voyage-embeddings]");
+  });
+
+  it("respects --harness sweny and writes to .sweny/skills/<id>/", () => {
+    runSkillNew("foo", { description: "x", category: "general", harness: "sweny" }, tmp);
+    expect(fs.existsSync(path.join(tmp, ".sweny", "skills", "foo", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, ".claude", "skills", "foo", "SKILL.md"))).toBe(false);
+  });
+
+  it("respects --harness agents and gemini variants", () => {
+    runSkillNew("a", { description: "x", category: "general", harness: "agents" }, tmp);
+    runSkillNew("g", { description: "x", category: "general", harness: "gemini" }, tmp);
+    expect(fs.existsSync(path.join(tmp, ".agents", "skills", "a", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, ".gemini", "skills", "g", "SKILL.md"))).toBe(true);
+  });
+
+  it("rejects an invalid skill id with exit code 2 and writes nothing", () => {
+    expect(() => runSkillNew("Bad_ID!", { description: "x", category: "general" }, tmp)).toThrow("process.exit(2)");
+    expect(fs.existsSync(path.join(tmp, ".claude"))).toBe(false);
+    expect(errSpy.mock.calls.join(" ")).toMatch(/Invalid skill id/);
+  });
+
+  it("rejects consecutive hyphens (mirrors the loader's validation)", () => {
+    expect(() => runSkillNew("foo--bar", { description: "x", category: "general" }, tmp)).toThrow("process.exit(2)");
+  });
+
+  it("rejects an unknown category with exit code 2", () => {
+    expect(() => runSkillNew("foo", { description: "x", category: "made-up" }, tmp)).toThrow("process.exit(2)");
+    expect(errSpy.mock.calls.join(" ")).toMatch(/Invalid category/);
+  });
+
+  it("rejects an unknown harness with exit code 2", () => {
+    // Cast through unknown to bypass the HarnessKey constraint at the test
+    // boundary: we want to assert the runtime guard, not the type guard.
+    expect(() =>
+      runSkillNew("foo", { description: "x", category: "general", harness: "vscode" as unknown as "claude" }, tmp),
+    ).toThrow("process.exit(2)");
+    expect(errSpy.mock.calls.join(" ")).toMatch(/Unknown harness/);
+  });
+
+  it("refuses to overwrite an existing SKILL.md without --force (exit 1)", () => {
+    const skillDir = path.join(tmp, ".claude", "skills", "existing");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "preserve me", "utf-8");
+
+    expect(() => runSkillNew("existing", { description: "x", category: "general" }, tmp)).toThrow("process.exit(1)");
+    expect(fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf-8")).toBe("preserve me");
+    expect(errSpy.mock.calls.join(" ")).toMatch(/already exists/);
+  });
+
+  it("overwrites an existing SKILL.md when --force is passed", () => {
+    const skillDir = path.join(tmp, ".claude", "skills", "existing");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "old contents", "utf-8");
+
+    runSkillNew("existing", { description: "new desc", category: "general", force: true }, tmp);
+    const updated = fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf-8");
+    expect(updated).toContain("name: existing");
+    expect(updated).toContain("description: new desc");
+    expect(updated).not.toContain("old contents");
+  });
+
+  it("normalizes ids to lowercase before validating", () => {
+    runSkillNew("MyCoolSkill", { description: "x", category: "general" }, tmp);
+    expect(fs.existsSync(path.join(tmp, ".claude", "skills", "mycoolskill", "SKILL.md"))).toBe(true);
+  });
+
+  it("scaffolded SKILL.md is round-trippable through discovery", () => {
+    runSkillNew("voyage-embeddings", { description: "Embed text via Voyage", category: "data" }, tmp);
+    const result = discoverSkillsWithDiagnostics(tmp);
+    expect(result.warnings).toEqual([]);
+    const skill = result.skills.find((s) => s.id === "voyage-embeddings");
+    expect(skill).toBeDefined();
+    expect(skill?.category).toBe("data");
+    expect(skill?.description).toBe("Embed text via Voyage");
+  });
+});
+
+describe("runSkillList", () => {
+  let tmp: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-skill-list-"));
+    // --json writes via process.stdout.write; the human format uses console.log.
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    stdoutSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  function jsonOutput(): Array<Record<string, unknown>> {
+    const writes = stdoutSpy.mock.calls.map((c: unknown[]) => c[0] as string).join("");
+    return JSON.parse(writes);
+  }
+
+  it("--json includes every built-in skill with kind=builtin", () => {
+    runSkillList({ json: true }, tmp, {});
+    const data = jsonOutput();
+    const ids = data.filter((s) => s.kind === "builtin").map((s) => s.id);
+    for (const expected of ["github", "linear", "slack", "sentry"]) {
+      expect(ids).toContain(expected);
+    }
+  });
+
+  it("--json marks a custom skill with kind=custom and merges it into the list", () => {
+    runSkillNew("voyage-embeddings", { description: "Embed", category: "data" }, tmp);
+    runSkillList({ json: true }, tmp, {});
+    const data = jsonOutput();
+    const custom = data.find((s) => s.id === "voyage-embeddings");
+    expect(custom).toMatchObject({ id: "voyage-embeddings", kind: "custom", category: "data" });
+  });
+
+  it("--json marks configured=true when required env vars are set", () => {
+    runSkillList({ json: true }, tmp, { GITHUB_TOKEN: "ghp_abc" });
+    const data = jsonOutput();
+    expect(data.find((s) => s.id === "github")?.configured).toBe(true);
+    expect(data.find((s) => s.id === "linear")?.configured).toBe(false);
+  });
+
+  it("custom skill that overrides a built-in id appears once with kind=custom", () => {
+    const skillDir = path.join(tmp, ".claude", "skills", "github");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: github\ndescription: Team-specific GitHub guidance\n---\nUse the corp instance.",
+      "utf-8",
+    );
+
+    runSkillList({ json: true }, tmp, {});
+    const data = jsonOutput();
+    const githubEntries = data.filter((s) => s.id === "github");
+    expect(githubEntries).toHaveLength(1);
+    expect(githubEntries[0].kind).toBe("custom");
+  });
+
+  it("human output renders an 'Available skills' header and a scaffold hint", () => {
+    runSkillList({}, tmp, {});
+    const printed = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+    expect(printed).toContain("Available skills");
+    expect(printed).toContain("sweny skill new");
   });
 });

--- a/packages/core/src/cli/skill.ts
+++ b/packages/core/src/cli/skill.ts
@@ -21,12 +21,10 @@ import chalk from "chalk";
 
 import { builtinSkills } from "../skills/index.js";
 import { configuredSkillsWithDiagnostics, discoverSkillsWithDiagnostics } from "../skills/custom-loader.js";
+import { SKILL_CATEGORIES, type SkillCategory } from "../types.js";
 
 // Mirror of the loader's regex so authoring-side validation matches discovery.
 const VALID_SKILL_ID = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
-
-const VALID_CATEGORIES = ["general", "git", "tasks", "notification", "observability", "data"] as const;
-type SkillCategory = (typeof VALID_CATEGORIES)[number];
 
 const HARNESS_DIRS = {
   claude: ".claude/skills",
@@ -120,8 +118,8 @@ export function runSkillNew(idArg: string, options: NewOptions, cwd: string = pr
 
   const description = (options.description ?? `Custom ${id} skill`).trim();
   const category = (options.category ?? "general") as SkillCategory;
-  if (!VALID_CATEGORIES.includes(category)) {
-    console.error(chalk.red(`  Invalid category "${category}".\n  Allowed: ${VALID_CATEGORIES.join(", ")}`));
+  if (!SKILL_CATEGORIES.includes(category)) {
+    console.error(chalk.red(`  Invalid category "${category}".\n  Allowed: ${SKILL_CATEGORIES.join(", ")}`));
     process.exit(2);
     return;
   }
@@ -240,7 +238,7 @@ export function registerSkillCommand(program: Command): void {
     .command("new <id>")
     .description("Scaffold a new SKILL.md in .claude/skills/<id>/")
     .option("-d, --description <text>", "One-line description (required field in frontmatter)")
-    .option("-c, --category <category>", `Skill category (${VALID_CATEGORIES.join("|")})`, "general")
+    .option("-c, --category <category>", `Skill category (${SKILL_CATEGORIES.join("|")})`, "general")
     .option("--harness <harness>", `Where to place the skill (${Object.keys(HARNESS_DIRS).join("|")})`, "claude")
     .option("--force", "Overwrite an existing SKILL.md")
     .action((id: string, options: NewOptions) => runSkillNew(id, options));

--- a/packages/core/src/cli/skill.ts
+++ b/packages/core/src/cli/skill.ts
@@ -101,7 +101,12 @@ interface NewOptions {
   force?: boolean;
 }
 
-function runSkillNew(idArg: string, options: NewOptions): void {
+/**
+ * Action handler for `sweny skill new`. Exported for unit tests; production
+ * code goes through `registerSkillCommand`. `cwd` defaults to `process.cwd()`
+ * so the CLI works as expected; tests pass a tmp dir for isolation.
+ */
+export function runSkillNew(idArg: string, options: NewOptions, cwd: string = process.cwd()): void {
   const id = idArg.toLowerCase();
   if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
     console.error(
@@ -129,7 +134,6 @@ function runSkillNew(idArg: string, options: NewOptions): void {
     return;
   }
 
-  const cwd = process.cwd();
   const skillDir = path.join(cwd, baseDir, id);
   const skillFile = path.join(skillDir, "SKILL.md");
 
@@ -157,17 +161,25 @@ interface ListOptions {
   json?: boolean;
 }
 
-function runSkillList(options: ListOptions): void {
-  const cwd = process.cwd();
-  // We want the FULL list — built-in + custom — even when env vars
-  // aren't set. configuredSkills filters by env, which hides authoring-
-  // time skills the user just scaffolded. So combine sources directly.
+/**
+ * Action handler for `sweny skill list`. Exported for unit tests; production
+ * code goes through `registerSkillCommand`. `cwd` and `env` injection lets
+ * tests exercise the configured-badge logic without polluting global state.
+ */
+export function runSkillList(
+  options: ListOptions,
+  cwd: string = process.cwd(),
+  env: Record<string, string | undefined> = process.env,
+): void {
+  // We want the FULL list (built-in + custom) even when env vars aren't set.
+  // configuredSkills filters by env, which hides authoring-time skills the
+  // user just scaffolded, so combine sources directly.
   const { skills: customSkills, warnings: customWarnings } = discoverSkillsWithDiagnostics(cwd);
   const customIds = new Set(customSkills.map((s) => s.id));
   const builtinList = builtinSkills.filter((s) => !customIds.has(s.id));
 
-  // Configured map drives the "configured?" badge — required env vars present.
-  const configuredIds = new Set(configuredSkillsWithDiagnostics(process.env, cwd).skills.map((s) => s.id));
+  // Configured map drives the "configured?" badge: required env vars present.
+  const configuredIds = new Set(configuredSkillsWithDiagnostics(env, cwd).skills.map((s) => s.id));
 
   if (options.json) {
     const data = [

--- a/packages/core/src/skills/custom-loader.ts
+++ b/packages/core/src/skills/custom-loader.ts
@@ -13,7 +13,8 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import YAML from "yaml";
 
-import type { Skill, SkillCategory, McpServerConfig, ConfigField } from "../types.js";
+import type { Skill, McpServerConfig, ConfigField } from "../types.js";
+import { SKILL_CATEGORIES, type SkillCategory } from "../types.js";
 import { builtinSkills, isSkillConfigured } from "./index.js";
 
 /** Directories to scan, in ascending priority order. Last match wins. */
@@ -134,9 +135,8 @@ function parseSkillMd(content: string, path: string): ParseResult {
     mcp?: Record<string, unknown>;
   };
 
-  const VALID_CATEGORIES: SkillCategory[] = ["general", "git", "tasks", "notification", "observability", "data"];
   const category: SkillCategory =
-    typeof fm.category === "string" && (VALID_CATEGORIES as string[]).includes(fm.category)
+    typeof fm.category === "string" && (SKILL_CATEGORIES as readonly string[]).includes(fm.category)
       ? (fm.category as SkillCategory)
       : "general";
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,8 +35,16 @@ export interface ConfigField {
   env?: string;
 }
 
-/** Skill categories — used for validation and grouping */
-export type SkillCategory = "git" | "observability" | "tasks" | "notification" | "data" | "general";
+/**
+ * Skill categories: used for per-node validation and grouping.
+ *
+ * Single source of truth for runtime + compile-time. The `as const` tuple
+ * lets the CLI iterate it for help text and the loader use it for runtime
+ * validation; `SkillCategory` is derived so adding a category requires
+ * only this line.
+ */
+export const SKILL_CATEGORIES = ["general", "git", "tasks", "notification", "observability", "data"] as const;
+export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
 
 /** A skill groups related tools with shared config requirements */
 export interface Skill {

--- a/packages/web/src/content/docs/cli/commands.md
+++ b/packages/web/src/content/docs/cli/commands.md
@@ -331,7 +331,7 @@ sweny workflow edit my-workflow.yml
 
 ### sweny workflow list
 
-List all available skills that can be used in workflow nodes.
+List the skills currently configured (required env vars present) and available to workflow nodes.
 
 ```bash
 sweny workflow list [options]
@@ -341,7 +341,7 @@ sweny workflow list [options]
 |--------|-------------|---------|
 | `--json` | Output as JSON array | `false` |
 
-Prints each skill's ID, category, and description. Skills are the building blocks that workflow nodes reference via the `skills` field.
+Prints each configured skill's ID, category, and description. For the full picture (built-in plus custom, configured plus unconfigured), use [`sweny skill list`](#sweny-skill-list) instead.
 
 ## sweny e2e
 
@@ -371,6 +371,56 @@ sweny e2e run [file] [options]
 | `--timeout <ms>` | Timeout per workflow in milliseconds | `900000` (15 min) |
 
 Without a file argument, runs all `.yml` files in `.sweny/e2e/` sequentially. Loads `.env`, resolves template variables (`{base_url}`, `{test_email}`, `{run_id}`, etc.), and executes each workflow. Exits `0` if all pass, `1` if any fail.
+
+## sweny skill
+
+Author and inspect skills. Skills are the unit of capability a workflow node references via its `skills:` array. The CLI ships built-ins (`github`, `linear`, `slack`, ...) and discovers custom skills from `.{sweny,claude,agents,gemini}/skills/<id>/SKILL.md`.
+
+### sweny skill new
+
+Scaffold a `SKILL.md` template for a new custom skill.
+
+```bash
+sweny skill new <id> [options]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-d, --description <text>` | One-line description (becomes the `description:` frontmatter field). | `Custom <id> skill` |
+| `-c, --category <category>` | One of `general`, `git`, `tasks`, `notification`, `observability`, `data`. | `general` |
+| `--harness <name>` | Where to place the skill: `claude`, `sweny`, `agents`, `gemini`. | `claude` |
+| `--force` | Overwrite an existing `SKILL.md` instead of refusing. | off |
+
+The scaffold writes frontmatter (with commented-out `config:` and `mcp:` blocks ready to uncomment) and a body skeleton documenting when to use the skill, what it provides, common failure modes, and an example invocation. See [Custom Skills](/skills/custom/) for the full format.
+
+```bash
+sweny skill new voyage-embeddings -d "Embed text via Voyage AI" -c data
+# Created .claude/skills/voyage-embeddings/SKILL.md
+```
+
+Exit codes: `0` on success, `1` when the target file already exists and `--force` is not set, `2` for invalid id, category, or harness.
+
+### sweny skill list
+
+List built-in and custom skills together with their configuration status.
+
+```bash
+sweny skill list [--json]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Output the full list as JSON (for scripting). | off |
+
+Each row shows `✓` (required env vars present) or `·` (skill is discoverable but not configured), plus the skill's category and a `builtin` or `custom` tag. Custom skills that override a built-in id appear once, marked `custom`.
+
+```bash
+sweny skill list --json
+# [
+#   { "id": "github", "kind": "builtin", "category": "git", "configured": true, ... },
+#   { "id": "voyage-embeddings", "kind": "custom", "category": "data", "configured": false, ... }
+# ]
+```
 
 ## sweny publish
 

--- a/packages/web/src/content/docs/skills/custom.md
+++ b/packages/web/src/content/docs/skills/custom.md
@@ -7,6 +7,17 @@ description: Create custom instruction and MCP-backed skills for SWEny workflows
 
 Custom skills let you extend SWEny workflows with domain-specific expertise and external tool integrations. There are two approaches: **instruction skills** (natural language guidance) and **MCP skills** (external tool servers).
 
+## Scaffold a skill
+
+The fastest way to start: `sweny skill new <id>`. It writes `.claude/skills/<id>/SKILL.md` with templated frontmatter and a body skeleton.
+
+```bash
+sweny skill new voyage-embeddings -d "Embed text via Voyage AI" -c data
+sweny skill list   # confirms it discovers
+```
+
+Flags: `-d/--description`, `-c/--category` (`general|git|tasks|notification|observability|data`), `--harness` (`claude|sweny|agents|gemini`), `--force`. See [`sweny skill`](/cli/commands/#sweny-skill) for the full reference.
+
 ## SKILL.md Format
 
 Create a directory with a `SKILL.md` file:
@@ -35,9 +46,31 @@ When writing or reviewing TypeScript code:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Skill ID. Lowercase letters, numbers, hyphens. Must match directory name. |
-| `description` | No | What this skill provides. Falls back to "Custom skill: {name}" if omitted. |
-| `mcp` | No | MCP server config (see below). |
+| `name` | Yes | Skill ID. Lowercase letters, numbers, hyphens (no consecutive `--`), max 64 chars. Must match the directory name. |
+| `description` | No | One-line summary shown in `sweny skill list`. Falls back to `Custom skill: <name>` if omitted. |
+| `category` | No | One of `general`, `git`, `tasks`, `notification`, `observability`, `data`. Drives per-node category validation. Defaults to `general` (also when the value is invalid). |
+| `config` | No | Map of env-var-backed config fields the skill needs (see below). |
+| `mcp` | No | MCP server config (see [MCP Skills](#mcp-skills)). |
+
+### Declaring required env vars
+
+If your skill needs environment variables, declare them under `config:`. `sweny check` and the workflow pre-flight use this to verify the env is set before running:
+
+```markdown
+---
+name: voyage-embeddings
+description: Embed text via Voyage AI
+category: data
+config:
+  VOYAGE_API_KEY:
+    description: API key for the Voyage AI embeddings service
+    required: true
+---
+
+When embedding documents, use `voyage-3-large` for retrieval and `voyage-3-lite` when latency matters.
+```
+
+The map key is the env var name. `description` is shown by `sweny check`; `required: true` makes the skill unavailable when the var is missing.
 
 ## Instruction Skills
 

--- a/packages/web/src/content/docs/skills/index.md
+++ b/packages/web/src/content/docs/skills/index.md
@@ -42,6 +42,8 @@ Every skill belongs to a category. Categories are used for validation — the ex
 | `observability` | Logs, errors, metrics, incidents | [Sentry](/skills/sentry/), [Datadog](/skills/datadog/), [BetterStack](/skills/betterstack/) |
 | `tasks` | Issue tracking | [Linear](/skills/linear/) |
 | `notification` | Alerting the team | [Slack](/skills/slack/), [Notification](/skills/notification/) |
+| `data` | Embeddings, vector stores, databases, ETL | (custom skills) |
+| `general` | Catch-all when no other category fits | (custom skills) |
 
 ## Built-in skills
 

--- a/spec/public/schemas/skill.json
+++ b/spec/public/schemas/skill.json
@@ -25,7 +25,7 @@
     },
     "category": {
       "type": "string",
-      "enum": ["git", "observability", "tasks", "notification", "general"],
+      "enum": ["git", "observability", "tasks", "notification", "data", "general"],
       "description": "Functional category."
     },
     "config": {

--- a/spec/src/content/docs/skills.mdx
+++ b/spec/src/content/docs/skills.mdx
@@ -30,6 +30,7 @@ The `category` field classifies a skill's function. Valid values:
 | `observability` | Error tracking, logs, metrics, incident management.    |
 | `tasks`         | Issue tracking and project management.                 |
 | `notification`  | Messaging and alerting.                                |
+| `data`          | Embeddings, vector stores, databases, ETL.             |
 | `general`       | Catch-all for skills that don't fit other categories.  |
 
 ## Config Field Object
@@ -133,7 +134,15 @@ When writing TypeScript code, follow these standards:
 - Use PascalCase for types and interfaces
 ```
 
-The markdown body becomes the skill's `instruction` — injected into the node prompt when the skill is referenced. The `mcp` frontmatter field is a SWEny-specific extension for declaring an MCP server.
+The markdown body becomes the skill's `instruction`, injected into the node prompt when the skill is referenced. The `mcp`, `category`, and `config` frontmatter fields are SWEny-specific extensions:
+
+| Frontmatter field | Required | Description                                                                                                 |
+| ----------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `name`            | REQUIRED | Skill ID. MUST satisfy [Skill ID Conventions](#skill-id-conventions).                                       |
+| `description`     | OPTIONAL | One-line summary. Defaults to `Custom skill: <name>` when omitted.                                          |
+| `category`        | OPTIONAL | One of the [Skill Categories](#skill-categories). Defaults to `general` when omitted or invalid.            |
+| `config`          | OPTIONAL | Map of env-var-backed config fields with the same shape as the [Config Field Object](#config-field-object). |
+| `mcp`             | OPTIONAL | External MCP server definition with the same shape as [McpServerConfig](#mcpserverconfig-object).           |
 
 ### Multi-Harness Discovery
 


### PR DESCRIPTION
## Summary

Follow-ups to #176, in three small streams:

- **Refactor**: thread `cwd` / `env` into `runSkillNew` / `runSkillList` and export them so tests can drive the CLI without `process.chdir` or argv hacks. Defaults preserve current behavior.
- **Tests** (+19): `skill.test.ts` 4 → 22, `skills-index.test.ts` +1 contract test. Covers harness flag (`claude|sweny|agents|gemini`), invalid id / category / harness, `--force`, JSON list shape, custom-overrides-builtin merge, configured-badge logic, and the `validateWorkflowSkills` `category: "unknown"` contract the CLI formatter relies on.
- **Docs / spec drift**: `spec/public/schemas/skill.json` and `spec/src/content/docs/skills.mdx` now include the `data` category (the runtime in #176 added it but the schema and docs lagged). Custom-skill `SKILL.md` frontmatter (`category`, `config`) is now documented in spec + web docs. `README.md` and `cli/commands.md` cross-reference `sweny skill new` / `sweny skill list`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 1528/1528 pass (was 1509 baseline + 19 new)
- [x] `astro build` for spec/ and packages/web/ both succeed
- [x] No em-dashes in user-facing additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)