### PR TITLE
feat(core): close S1-S4 silent-drift surfaces from contract-tests plan

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --exclude 'src/__tests__/integration/**' --exclude 'dist/**'",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "check:schema-drift": "node scripts/write-public-schema.mjs && git diff --exit-code -- ../../spec/public/schemas/workflow.json"
+    "check:schema-drift": "node scripts/write-public-schema.mjs && git diff --exit-code -- ../../spec/public/schemas/workflow.json ../../spec/public/schemas/skill.json"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",

--- a/packages/core/scripts/write-public-schema.mjs
+++ b/packages/core/scripts/write-public-schema.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 /**
- * Generate spec/public/schemas/workflow.json from the canonical
- * workflowJsonSchema in @sweny-ai/core.
+ * Generate spec/public/schemas/{workflow,skill}.json from the canonical
+ * JSON Schema constants in @sweny-ai/core.
  *
- * Fix #4: before this existed the published schema was hand-maintained and
- * drifted against the runtime (missing verify/requires/retry entirely).
- * This script makes the published file a build artifact of the TS source.
+ * Fix #4 introduced the workflow generator: before that, the published
+ * schema was hand-maintained and drifted against the runtime (missing
+ * verify/requires/retry entirely). The skill schema was added later
+ * for the same reason: the `data` category landed in runtime types but
+ * the hand-maintained schema didn't get updated, so external tooling
+ * silently rejected valid skills.
  *
  * Called from `npm run build --workspace=packages/core`. Writes to the
- * repo-root spec/ directory so the spec.sweny.ai Astro build can pick it
+ * repo-root spec/ directory so the spec.sweny.ai Astro build picks it
  * up without additional wiring.
  */
 
@@ -21,36 +24,44 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..", "..", "..");
 const require = createRequire(import.meta.url);
 
-const { workflowJsonSchema } = await import("../dist/schema.js");
-if (!workflowJsonSchema) {
-  console.error("write-public-schema: workflowJsonSchema not exported from dist/schema.js");
+const { workflowJsonSchema, skillJsonSchema } = await import("../dist/schema.js");
+if (!workflowJsonSchema || !skillJsonSchema) {
+  console.error(
+    "write-public-schema: workflowJsonSchema and skillJsonSchema must both be exported from dist/schema.js",
+  );
   process.exit(1);
 }
 
-const target = resolve(repoRoot, "spec", "public", "schemas", "workflow.json");
-mkdirSync(dirname(target), { recursive: true });
-
-// Format through prettier so the generated file matches the repo's
-// formatting conventions exactly. Otherwise the lint-staged hook would
-// reformat on commit and the CI schema-drift check would fail on every
-// build.
 const prettier = require("prettier");
-const prettierConfig = (await prettier.resolveConfig(target)) ?? {};
-const raw = JSON.stringify(workflowJsonSchema, null, 2);
-const next = await prettier.format(raw, { ...prettierConfig, filepath: target, parser: "json" });
 
-let current = "";
-try {
-  current = readFileSync(target, "utf-8");
-} catch {
-  // first write is fine
+async function writeSchema(name, schema) {
+  const target = resolve(repoRoot, "spec", "public", "schemas", `${name}.json`);
+  mkdirSync(dirname(target), { recursive: true });
+
+  // Format through prettier so the generated file matches the repo's
+  // formatting conventions exactly. Otherwise the lint-staged hook would
+  // reformat on commit and the CI schema-drift check would fail on every
+  // build.
+  const prettierConfig = (await prettier.resolveConfig(target)) ?? {};
+  const raw = JSON.stringify(schema, null, 2);
+  const next = await prettier.format(raw, { ...prettierConfig, filepath: target, parser: "json" });
+
+  let current = "";
+  try {
+    current = readFileSync(target, "utf-8");
+  } catch {
+    // first write is fine
+  }
+
+  if (current === next) {
+    // Don't touch mtime if the content is identical (keeps git diffs clean).
+    console.log(`write-public-schema: ${target} already up to date`);
+    return;
+  }
+
+  writeFileSync(target, next, "utf-8");
+  console.log(`write-public-schema: wrote ${target} (${next.length} bytes)`);
 }
 
-if (current === next) {
-  // Don't touch mtime if the content is identical — keeps git diffs clean.
-  console.log(`write-public-schema: ${target} already up to date`);
-  process.exit(0);
-}
-
-writeFileSync(target, next, "utf-8");
-console.log(`write-public-schema: wrote ${target} (${next.length} bytes)`);
+await writeSchema("workflow", workflowJsonSchema);
+await writeSchema("skill", skillJsonSchema);

--- a/packages/core/src/__tests__/contract-tests.test.ts
+++ b/packages/core/src/__tests__/contract-tests.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Contract tests for cross-module / cross-source-of-truth invariants.
+ *
+ * Each block here guards a fact that lives in two places (runtime + spec,
+ * cli + loader, ...) and would silently drift otherwise. The plan
+ * driving this file lives at docs/hardening/contract-tests.md.
+ *
+ * If a test fails: the two sources diverged. Pick one as canonical, fix
+ * the other, update or delete the test if the surface no longer applies.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  EVALUATOR_KINDS,
+  EVAL_POLICIES,
+  MCP_TRANSPORTS,
+  REQUIRES_ON_FAIL,
+  SKILL_CATEGORIES,
+  SKILL_HARNESSES,
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+  isValidSkillId,
+} from "../types.js";
+
+const SPEC_DIR = join(__dirname, "../../../../spec/public/schemas");
+const skillSchema = JSON.parse(readFileSync(join(SPEC_DIR, "skill.json"), "utf-8"));
+const workflowSchema = JSON.parse(readFileSync(join(SPEC_DIR, "workflow.json"), "utf-8"));
+
+describe("S1: skill ID validation contract", () => {
+  // The spec pattern, runtime regex, and `isValidSkillId` helper all
+  // describe the same rule. They MUST agree on every input.
+  const corpus: Array<[string, boolean]> = [
+    // Valid
+    ["github", true],
+    ["my-skill", true],
+    ["a", true],
+    ["a-b", true],
+    ["voyage-embeddings", true],
+    ["9foo", true], // digits allowed at start (runtime semantics)
+    ["a1", true],
+    ["x".repeat(64), true], // exactly at the cap
+
+    // Invalid: structural
+    ["", false],
+    ["A", false], // uppercase rejected
+    ["foo_bar", false], // underscores rejected
+    ["foo bar", false], // spaces rejected
+    ["foo!", false], // punctuation rejected
+
+    // Invalid: hyphen rules
+    ["-foo", false], // leading hyphen
+    ["foo-", false], // trailing hyphen
+    ["foo--bar", false], // consecutive hyphens
+
+    // Invalid: length
+    ["x".repeat(65), false], // one over the cap
+  ];
+
+  it.each(corpus)("isValidSkillId(%j) === %s", (id, expected) => {
+    expect(isValidSkillId(id)).toBe(expected);
+  });
+
+  it("the published JSON Schema's id pattern matches the runtime regex source", () => {
+    expect(skillSchema.properties.id.pattern).toBe(SKILL_ID_PATTERN.source);
+  });
+
+  it("the published JSON Schema's maxLength matches the runtime cap", () => {
+    expect(skillSchema.properties.id.maxLength).toBe(SKILL_ID_MAX_LENGTH);
+  });
+});
+
+describe("S2: skill JSON Schema is generated from runtime", () => {
+  it("category enum matches SKILL_CATEGORIES", () => {
+    expect([...skillSchema.properties.category.enum].sort()).toEqual([...SKILL_CATEGORIES].sort());
+  });
+
+  it("McpServerConfig.type enum matches MCP_TRANSPORTS", () => {
+    expect([...skillSchema.$defs.McpServerConfig.properties.type.enum].sort()).toEqual([...MCP_TRANSPORTS].sort());
+  });
+});
+
+describe("S3: harness directories are a single source", () => {
+  // The CLI writes scaffolds; the loader scans for them. They must agree
+  // on which paths count as a skill harness.
+  it("SKILL_HARNESSES has one entry per harness key with no duplicates", () => {
+    const keys = SKILL_HARNESSES.map((h) => h.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("every harness path starts with a leading dot", () => {
+    for (const h of SKILL_HARNESSES) {
+      expect(h.path.startsWith(".")).toBe(true);
+    }
+  });
+});
+
+describe("S4: workflow JSON Schema enums match runtime tuples", () => {
+  // Each path here was located against the actual generated schema; if a
+  // generator refactor moves them, fix the path here. The point is that
+  // the enum *values* match runtime, regardless of nesting.
+  it("Evaluator.kind enum matches EVALUATOR_KINDS", () => {
+    const evalKindEnum = workflowSchema.$defs.Evaluator.properties.kind.enum;
+    expect([...evalKindEnum].sort()).toEqual([...EVALUATOR_KINDS].sort());
+  });
+
+  it("Node.eval_policy enum matches EVAL_POLICIES", () => {
+    const policyEnum = workflowSchema.properties.nodes.additionalProperties.properties.eval_policy.enum;
+    expect([...policyEnum].sort()).toEqual([...EVAL_POLICIES].sort());
+  });
+
+  it("NodeRequires.on_fail enum matches REQUIRES_ON_FAIL", () => {
+    const onFailEnum = workflowSchema.properties.nodes.additionalProperties.properties.requires.properties.on_fail.enum;
+    expect([...onFailEnum].sort()).toEqual([...REQUIRES_ON_FAIL].sort());
+  });
+
+  it("Inline skill McpServerConfig.type enum matches MCP_TRANSPORTS", () => {
+    const transportEnum = workflowSchema.properties.skills.additionalProperties.properties.mcp.properties.type.enum;
+    expect([...transportEnum].sort()).toEqual([...MCP_TRANSPORTS].sort());
+  });
+});

--- a/packages/core/src/__tests__/skills-index.test.ts
+++ b/packages/core/src/__tests__/skills-index.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import {
   github,
   linear,
@@ -14,7 +12,6 @@ import {
   isSkillConfigured,
   validateWorkflowSkills,
 } from "../skills/index.js";
-import { SKILL_CATEGORIES } from "../types.js";
 
 describe("skills registry", () => {
   it("exports all builtin skills", () => {
@@ -188,15 +185,9 @@ describe("skills registry", () => {
     expect(result.configured).toHaveLength(2);
   });
 
-  // Drift catcher: the published JSON Schema's `category` enum MUST match the
-  // runtime SKILL_CATEGORIES list. The original `data` bug landed because
-  // these two sources diverged silently. This test fails loudly the next time.
-  it("SKILL_CATEGORIES matches the published spec schema enum", () => {
-    const schemaPath = join(__dirname, "../../../../spec/public/schemas/skill.json");
-    const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
-    const enumValues = schema.properties.category.enum as string[];
-    expect([...SKILL_CATEGORIES].sort()).toEqual([...enumValues].sort());
-  });
+  // Drift catcher for SKILL_CATEGORIES vs the published schema lives in
+  // contract-tests.test.ts alongside the rest of the cross-source-of-truth
+  // invariants. See docs/hardening/contract-tests.md.
 
   it("config fields have env vars matching canonical names", () => {
     // Datadog should use DD_* prefix

--- a/packages/core/src/cli/publish.ts
+++ b/packages/core/src/cli/publish.ts
@@ -17,12 +17,11 @@ import type { Command } from "commander";
 import { parseWorkflow, validateWorkflow } from "../schema.js";
 import { builtinSkills } from "../skills/index.js";
 import { discoverSkillsWithDiagnostics } from "../skills/custom-loader.js";
+import { isValidSkillId } from "../types.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
 const VALID_CATEGORIES = ["triage", "security", "devops", "code-review", "testing", "content", "ops"] as const;
-
-const VALID_SKILL_ID = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
 export interface PublishResult {
   type: "workflow" | "skill";
@@ -156,8 +155,10 @@ export function validateSkillDir(dirPath: string): {
   const id = String(fm.name ?? "");
   if (!id) {
     errors.push("Missing 'name' field in frontmatter");
-  } else if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
-    errors.push(`Invalid skill ID: "${id}" — must be lowercase, hyphens, no consecutive hyphens, max 64 chars`);
+  } else if (!isValidSkillId(id)) {
+    errors.push(
+      `Invalid skill ID: "${id}" (must be lowercase alphanumeric + hyphens, no consecutive hyphens, max 64 chars)`,
+    );
   }
 
   // Check directory name matches skill name

--- a/packages/core/src/cli/skill.ts
+++ b/packages/core/src/cli/skill.ts
@@ -21,18 +21,20 @@ import chalk from "chalk";
 
 import { builtinSkills } from "../skills/index.js";
 import { configuredSkillsWithDiagnostics, discoverSkillsWithDiagnostics } from "../skills/custom-loader.js";
-import { SKILL_CATEGORIES, type SkillCategory } from "../types.js";
+import {
+  SKILL_CATEGORIES,
+  SKILL_HARNESSES,
+  isValidSkillId,
+  type SkillCategory,
+  type SkillHarnessKey,
+} from "../types.js";
 
-// Mirror of the loader's regex so authoring-side validation matches discovery.
-const VALID_SKILL_ID = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
-
-const HARNESS_DIRS = {
-  claude: ".claude/skills",
-  sweny: ".sweny/skills",
-  agents: ".agents/skills",
-  gemini: ".gemini/skills",
-} as const;
-type HarnessKey = keyof typeof HARNESS_DIRS;
+// Lookup table: harness key -> directory. Built once from SKILL_HARNESSES so
+// the CLI cannot drift from the loader's scan list.
+const HARNESS_DIRS: Record<SkillHarnessKey, string> = Object.fromEntries(
+  SKILL_HARNESSES.map((h) => [h.key, h.path]),
+) as Record<SkillHarnessKey, string>;
+const HARNESS_KEYS: readonly SkillHarnessKey[] = SKILL_HARNESSES.map((h) => h.key);
 
 /** Build the SKILL.md body for a fresh scaffold. Exported for tests. */
 export function renderSkillTemplate(opts: { id: string; description: string; category: SkillCategory }): string {
@@ -95,7 +97,7 @@ export function renderSkillTemplate(opts: { id: string; description: string; cat
 interface NewOptions {
   description?: string;
   category?: string;
-  harness?: HarnessKey;
+  harness?: SkillHarnessKey;
   force?: boolean;
 }
 
@@ -106,7 +108,7 @@ interface NewOptions {
  */
 export function runSkillNew(idArg: string, options: NewOptions, cwd: string = process.cwd()): void {
   const id = idArg.toLowerCase();
-  if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
+  if (!isValidSkillId(id)) {
     console.error(
       chalk.red(
         `  Invalid skill id "${idArg}".\n  Skill ids must be lowercase alphanumeric + hyphens (no consecutive hyphens), max 64 chars.`,
@@ -127,7 +129,7 @@ export function runSkillNew(idArg: string, options: NewOptions, cwd: string = pr
   const harness = options.harness ?? "claude";
   const baseDir = HARNESS_DIRS[harness];
   if (!baseDir) {
-    console.error(chalk.red(`  Unknown harness "${harness}". Allowed: ${Object.keys(HARNESS_DIRS).join(", ")}`));
+    console.error(chalk.red(`  Unknown harness "${harness}". Allowed: ${HARNESS_KEYS.join(", ")}`));
     process.exit(2);
     return;
   }
@@ -239,7 +241,7 @@ export function registerSkillCommand(program: Command): void {
     .description("Scaffold a new SKILL.md in .claude/skills/<id>/")
     .option("-d, --description <text>", "One-line description (required field in frontmatter)")
     .option("-c, --category <category>", `Skill category (${SKILL_CATEGORIES.join("|")})`, "general")
-    .option("--harness <harness>", `Where to place the skill (${Object.keys(HARNESS_DIRS).join("|")})`, "claude")
+    .option("--harness <harness>", `Where to place the skill (${HARNESS_KEYS.join("|")})`, "claude")
     .option("--force", "Overwrite an existing SKILL.md")
     .action((id: string, options: NewOptions) => runSkillNew(id, options));
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -9,6 +9,15 @@
 
 import { z } from "zod";
 import type { Workflow } from "./types.js";
+import {
+  EVALUATOR_KINDS,
+  EVAL_POLICIES,
+  MCP_TRANSPORTS,
+  REQUIRES_ON_FAIL,
+  SKILL_CATEGORIES,
+  SKILL_ID_MAX_LENGTH,
+  SKILL_ID_PATTERN,
+} from "./types.js";
 import { sourceZ } from "./sources.js";
 export { sourceZ };
 
@@ -33,11 +42,11 @@ export const toolZ = z.object({
   input_schema: jsonSchemaZ,
 });
 
-export const skillCategoryZ = z.enum(["git", "observability", "tasks", "notification", "general"]);
+export const skillCategoryZ = z.enum(SKILL_CATEGORIES);
 
 export const mcpServerConfigZ = z
   .object({
-    type: z.enum(["stdio", "http"]).optional(),
+    type: z.enum(MCP_TRANSPORTS).optional(),
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
     url: z.string().optional(),
@@ -106,9 +115,9 @@ export const outputMatchZ = z
     { message: "output_matches entry must declare exactly one of: equals, in, matches" },
   );
 
-export const evaluatorKindZ = z.enum(["value", "function", "judge"]);
+export const evaluatorKindZ = z.enum(EVALUATOR_KINDS);
 
-export const evalPolicyZ = z.enum(["all_pass", "any_pass", "weighted"]);
+export const evalPolicyZ = z.enum(EVAL_POLICIES);
 
 export const evaluatorRuleZ = z
   .object({
@@ -194,7 +203,7 @@ export const nodeRequiresZ = z
   .object({
     output_required: z.array(z.string().min(1)).min(1).optional(),
     output_matches: z.array(outputMatchZ).min(1).optional(),
-    on_fail: z.enum(["fail", "skip"]).optional(),
+    on_fail: z.enum(REQUIRES_ON_FAIL).optional(),
   })
   .strict()
   .refine((r) => r.output_required !== undefined || r.output_matches !== undefined, {
@@ -546,7 +555,7 @@ export const workflowJsonSchema = {
           minLength: 1,
           description: "Stable identifier for this evaluator. Used in EvalResult and retry preambles.",
         },
-        kind: { type: "string", enum: ["value", "function", "judge"] },
+        kind: { type: "string", enum: [...EVALUATOR_KINDS] },
         rule: {
           type: "object",
           description: "Required for value and function kinds. Shape depends on kind.",
@@ -656,7 +665,7 @@ export const workflowJsonSchema = {
           },
           eval_policy: {
             type: "string",
-            enum: ["all_pass", "any_pass", "weighted"],
+            enum: [...EVAL_POLICIES],
             default: "all_pass",
             description: "How evaluator results aggregate. v1 implements all_pass; the others are reserved.",
           },
@@ -683,7 +692,7 @@ export const workflowJsonSchema = {
                 items: { $ref: "#/$defs/OutputMatch" },
                 minItems: 1,
               },
-              on_fail: { type: "string", enum: ["fail", "skip"] },
+              on_fail: { type: "string", enum: [...REQUIRES_ON_FAIL] },
             },
           },
           retry: {
@@ -754,7 +763,7 @@ export const workflowJsonSchema = {
             // Round 2: reject unknown keys to match Zod mcpServerConfigZ.strict().
             additionalProperties: false,
             properties: {
-              type: { type: "string", enum: ["stdio", "http"] },
+              type: { type: "string", enum: [...MCP_TRANSPORTS] },
               command: { type: "string" },
               args: { type: "array", items: { type: "string" } },
               url: { type: "string" },
@@ -762,6 +771,148 @@ export const workflowJsonSchema = {
               env: { type: "object", additionalProperties: { type: "string" } },
             },
           },
+        },
+      },
+    },
+  },
+} as const;
+
+/**
+ * Skill JSON Schema, generated from runtime constants.
+ *
+ * Companion to {@link workflowJsonSchema}: published at
+ * https://spec.sweny.ai/schemas/skill.json by the
+ * `write-public-schema.mjs` build step. Validates the structural shape
+ * of a Skill (id, name, description, category, config, plus optional
+ * tools/instruction/mcp).
+ *
+ * Every enum and the `id` pattern + maxLength are imported from
+ * `types.ts` so adding a category, harness, transport, or changing the
+ * id rule updates the published schema with no manual sync.
+ */
+export const skillJsonSchema = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://spec.sweny.ai/schemas/skill.json",
+  title: "SWEny Skill",
+  description: "A composable tool bundle that provides capabilities to workflow nodes.",
+  type: "object",
+  required: ["id", "name", "description", "category", "config"],
+  anyOf: [{ required: ["tools"] }, { required: ["instruction"] }, { required: ["mcp"] }],
+  additionalProperties: false,
+  properties: {
+    id: {
+      type: "string",
+      minLength: 1,
+      maxLength: SKILL_ID_MAX_LENGTH,
+      pattern: SKILL_ID_PATTERN.source,
+      description: "Unique skill identifier. Referenced by nodes' skills arrays. Lowercase kebab-case recommended.",
+    },
+    name: {
+      type: "string",
+      minLength: 1,
+      description: "Human-readable skill name.",
+    },
+    description: {
+      type: "string",
+      description: "What this skill provides.",
+    },
+    category: {
+      type: "string",
+      enum: [...SKILL_CATEGORIES],
+      description: "Functional category.",
+    },
+    config: {
+      type: "object",
+      description: "Configuration fields required by this skill.",
+      additionalProperties: { $ref: "#/$defs/ConfigField" },
+    },
+    tools: {
+      type: "array",
+      description: "Tools this skill provides to nodes.",
+      items: { $ref: "#/$defs/Tool" },
+    },
+    instruction: {
+      type: "string",
+      description: "Natural language expertise injected into the node prompt when this skill is referenced.",
+    },
+    mcp: {
+      $ref: "#/$defs/McpServerConfig",
+      description: "External MCP server definition wired for nodes referencing this skill.",
+    },
+  },
+  $defs: {
+    ConfigField: {
+      type: "object",
+      required: ["description"],
+      additionalProperties: false,
+      properties: {
+        description: {
+          type: "string",
+          description: "Human-readable description of this config field.",
+        },
+        required: {
+          type: "boolean",
+          default: false,
+          description: "Whether this field must be provided for the skill to function.",
+        },
+        env: {
+          type: "string",
+          description: "Default environment variable to read this value from.",
+        },
+      },
+    },
+    Tool: {
+      type: "object",
+      required: ["name", "description", "input_schema"],
+      additionalProperties: false,
+      properties: {
+        name: {
+          type: "string",
+          description: "Tool name. Must be unique within the skill.",
+        },
+        description: {
+          type: "string",
+          description: "What this tool does. Provided to the AI model for tool selection.",
+        },
+        input_schema: {
+          type: "object",
+          description: "JSON Schema defining the tool's input parameters.",
+        },
+      },
+    },
+    McpServerConfig: {
+      type: "object",
+      description: "External MCP server definition.",
+      additionalProperties: false,
+      properties: {
+        type: {
+          type: "string",
+          enum: [...MCP_TRANSPORTS],
+          description: "Transport type. Inferred from presence of command (stdio) or url (http) when omitted.",
+        },
+        command: {
+          type: "string",
+          description: "Spawn command (stdio transport).",
+        },
+        args: {
+          type: "array",
+          items: { type: "string" },
+          description: "Arguments for the command.",
+        },
+        url: {
+          type: "string",
+          format: "uri",
+          description: "HTTP endpoint (HTTP transport).",
+        },
+        headers: {
+          type: "object",
+          additionalProperties: { type: "string" },
+          description: "HTTP headers (HTTP transport only).",
+        },
+        env: {
+          type: "object",
+          additionalProperties: { type: "string" },
+          description: "Environment variable names the server needs. Values are descriptions, not secrets.",
         },
       },
     },

--- a/packages/core/src/skills/custom-loader.ts
+++ b/packages/core/src/skills/custom-loader.ts
@@ -14,14 +14,16 @@ import { join } from "node:path";
 import YAML from "yaml";
 
 import type { Skill, McpServerConfig, ConfigField } from "../types.js";
-import { SKILL_CATEGORIES, type SkillCategory } from "../types.js";
+import { SKILL_CATEGORIES, SKILL_HARNESSES, isValidSkillId, type SkillCategory } from "../types.js";
 import { builtinSkills, isSkillConfigured } from "./index.js";
 
-/** Directories to scan, in ascending priority order. Last match wins. */
-const SKILL_DIRS = [".gemini/skills", ".agents/skills", ".claude/skills", ".sweny/skills"];
-
-/** Valid skill ID: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 64 chars. */
-const VALID_SKILL_ID = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+/**
+ * Directories to scan, in ascending priority order. Last match wins.
+ *
+ * Derived from {@link SKILL_HARNESSES} so the loader and the CLI authoring
+ * side cannot disagree on what counts as a skill harness directory.
+ */
+const SKILL_DIRS: readonly string[] = SKILL_HARNESSES.map((h) => h.path);
 
 /**
  * Diagnostic emitted when a SKILL.md file is skipped or overridden during
@@ -141,7 +143,7 @@ function parseSkillMd(content: string, path: string): ParseResult {
       : "general";
 
   const id = String(fm.name);
-  if (!VALID_SKILL_ID.test(id) || id.includes("--") || id.length > 64) {
+  if (!isValidSkillId(id)) {
     return {
       kind: "err",
       diagnostic: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,44 @@ export interface ConfigField {
 export const SKILL_CATEGORIES = ["general", "git", "tasks", "notification", "observability", "data"] as const;
 export type SkillCategory = (typeof SKILL_CATEGORIES)[number];
 
+/**
+ * Skill harness directories, listed in ascending priority order.
+ *
+ * Both the loader (which scans these directories last-wins for ID
+ * collisions) and the CLI (which writes scaffolds into one of them)
+ * must agree on this list. A divergence means scaffolded skills land
+ * somewhere the loader doesn't read, or the loader reads from a
+ * directory the CLI can't target.
+ *
+ * Order matters: the loader treats later entries as higher priority,
+ * so `.sweny/skills/` overrides `.claude/skills/` on a name collision.
+ */
+export const SKILL_HARNESSES = [
+  { key: "gemini", path: ".gemini/skills" },
+  { key: "agents", path: ".agents/skills" },
+  { key: "claude", path: ".claude/skills" },
+  { key: "sweny", path: ".sweny/skills" },
+] as const;
+export type SkillHarnessKey = (typeof SKILL_HARNESSES)[number]["key"];
+
+/**
+ * Skill ID validation rules, declared once for runtime + spec.
+ *
+ * The pattern excludes consecutive hyphens via a negative lookahead so a
+ * single regex is the whole rule. JSON Schema regex follows ECMA 262, which
+ * supports lookaheads, so the spec can embed this string directly.
+ *
+ * Length cap is enforced separately because JSON Schema's `maxLength` is
+ * the canonical place to express it (vs. cramming `{1,64}` into the regex).
+ */
+export const SKILL_ID_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+export const SKILL_ID_MAX_LENGTH = 64;
+
+/** True when `id` is a structurally valid skill ID under the rules above. */
+export function isValidSkillId(id: string): boolean {
+  return typeof id === "string" && id.length > 0 && id.length <= SKILL_ID_MAX_LENGTH && SKILL_ID_PATTERN.test(id);
+}
+
 /** A skill groups related tools with shared config requirements */
 export interface Skill {
   id: string;
@@ -98,10 +136,20 @@ export interface Skill {
 export type NodeSources = _Source[] | { only?: boolean; sources: _Source[] };
 
 /** Kind of evaluator. See {@link Evaluator}. */
-export type EvaluatorKind = "value" | "function" | "judge";
+export const EVALUATOR_KINDS = ["value", "function", "judge"] as const;
+export type EvaluatorKind = (typeof EVALUATOR_KINDS)[number];
 
 /** Aggregation policy for a node's evaluator results. v1 implements `all_pass`. */
-export type EvalPolicy = "all_pass" | "any_pass" | "weighted";
+export const EVAL_POLICIES = ["all_pass", "any_pass", "weighted"] as const;
+export type EvalPolicy = (typeof EVAL_POLICIES)[number];
+
+/** Action when a `requires` precondition fails. */
+export const REQUIRES_ON_FAIL = ["fail", "skip"] as const;
+export type RequiresOnFail = (typeof REQUIRES_ON_FAIL)[number];
+
+/** MCP server transport type. Inferred from command/url when omitted. */
+export const MCP_TRANSPORTS = ["stdio", "http"] as const;
+export type McpTransport = (typeof MCP_TRANSPORTS)[number];
 
 /**
  * The deterministic rule body for a `value` or `function` evaluator.

--- a/spec/public/schemas/skill.json
+++ b/spec/public/schemas/skill.json
@@ -5,13 +5,24 @@
   "description": "A composable tool bundle that provides capabilities to workflow nodes.",
   "type": "object",
   "required": ["id", "name", "description", "category", "config"],
-  "anyOf": [{ "required": ["tools"] }, { "required": ["instruction"] }, { "required": ["mcp"] }],
+  "anyOf": [
+    {
+      "required": ["tools"]
+    },
+    {
+      "required": ["instruction"]
+    },
+    {
+      "required": ["mcp"]
+    }
+  ],
   "additionalProperties": false,
   "properties": {
     "id": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[a-z][a-z0-9-]*$",
+      "maxLength": 64,
+      "pattern": "^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$",
       "description": "Unique skill identifier. Referenced by nodes' skills arrays. Lowercase kebab-case recommended."
     },
     "name": {
@@ -25,7 +36,7 @@
     },
     "category": {
       "type": "string",
-      "enum": ["git", "observability", "tasks", "notification", "data", "general"],
+      "enum": ["general", "git", "tasks", "notification", "observability", "data"],
       "description": "Functional category."
     },
     "config": {
@@ -94,6 +105,7 @@
     "McpServerConfig": {
       "type": "object",
       "description": "External MCP server definition.",
+      "additionalProperties": false,
       "properties": {
         "type": {
           "type": "string",
@@ -106,7 +118,9 @@
         },
         "args": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Arguments for the command."
         },
         "url": {
@@ -116,16 +130,19 @@
         },
         "headers": {
           "type": "object",
-          "additionalProperties": { "type": "string" },
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "HTTP headers (HTTP transport only)."
         },
         "env": {
           "type": "object",
-          "additionalProperties": { "type": "string" },
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Environment variable names the server needs. Values are descriptions, not secrets."
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
Implements the first four surfaces named in [`docs/hardening/contract-tests.md`](docs/hardening/contract-tests.md) (#178). Each fixes a place where one fact was hardcoded in two or more sources and could drift silently. The class of bug that shipped the missing-`data`-category in #176.

## What's in it

**S3: harness directories are now a single source.** `SKILL_HARNESSES` tuple in `types.ts`. `cli/skill.ts` derives its lookup `Record` from it; `custom-loader.ts` derives its scan-order array from it. Adding a harness is one line.

**S1: skill ID validation centralized.** `SKILL_ID_PATTERN`, `SKILL_ID_MAX_LENGTH`, `isValidSkillId()` in `types.ts`. Both call sites use the helper. Pattern uses a negative lookahead so the no-`--` rule lives inside the regex itself, which JSON Schema (ECMA 262) can embed verbatim.

**S4: enum centralization.** `EVALUATOR_KINDS`, `EVAL_POLICIES`, `REQUIRES_ON_FAIL`, `MCP_TRANSPORTS` as `as const` tuples. Both zod schemas and `workflowJsonSchema` enums derive from them. **Bonus fix:** `skillCategoryZ` was missing `data` (a third silent drift behind the original bug).

**S2: skill JSON Schema is generated from runtime.** New `skillJsonSchema` in `schema.ts` mirrors the published shape but pulls regex, maxLength, and enums from runtime constants. `write-public-schema.mjs` now writes both `workflow.json` and `skill.json`. CI's `check:schema-drift` covers both.

Generated `skill.json` fixes a real spec/runtime divergence: the published id pattern was `^[a-z][a-z0-9-]*$` (which accepted `a--b`, `a-`, ids over 64 chars; rejected digit-leading ids). The runtime accepted/rejected the opposite set. They now agree.

## New tests

`packages/core/src/__tests__/contract-tests.test.ts`: 27 tests under one file, organized by surface (S1-S4). Each guards a specific cross-module invariant. The corpus test under S1 walks 17 valid/invalid IDs through `isValidSkillId` so we lock the contract behaviorally, not just structurally.

## Verification

- `npm run typecheck` clean
- `npm test`: 1,555/1,555 pass (was 1,529; +26 contract tests)
- `npm run build` regenerates schemas; both `workflow.json` and `skill.json` are produced
- Spec + web Astro builds clean
- No em-dashes in authored prose

## What's deferred (per the plan)

- **S5** (CLI formatter shape contracts): pick off as we touch helpers
- **S6** (SKILL.md docs vs runtime field set): waiting on a markdown-aware lint
- **S7** (workflow_type renderer registry): waiting on the registry to exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)