### PR TITLE
chore(vercel): disable preview deploys for docs + spec

### DIFF
--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -2,5 +2,10 @@
   "buildCommand": "cd ../.. && npm run build --workspace=packages/core && npm run build:lib --workspace=packages/studio && npm run build --workspace=packages/web",
   "outputDirectory": "dist",
   "framework": "astro",
-  "installCommand": "cd ../.. && npm ci"
+  "installCommand": "cd ../.. && npm ci",
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
 }

--- a/spec/vercel.json
+++ b/spec/vercel.json
@@ -1,0 +1,8 @@
+{
+  "framework": "astro",
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Match cloud's pattern (cloud@3d39ba7): only deploy on push to \`main\`, not on every preview branch. Cuts the noisy Vercel preview-deploy lifecycle on every push to a feature branch.

- \`packages/web/vercel.json\` (docs.sweny.ai) — adds \`git.deploymentEnabled.main: true\`
- \`spec/vercel.json\` (spec.sweny.ai) — new file with the same setting; the project was deploying with default settings before

Production deploys on push to \`main\` are unaffected.

## Test plan

- [x] Both vercel.json files are valid JSON
- [ ] After merge: open a feature branch off main, push it, confirm no Vercel preview deploy triggers for either project
- [ ] After merge: push to main, confirm production deploys still fire for both docs.sweny.ai and spec.sweny.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)