### PR TITLE
fix(core): make github_create_pr idempotent on 422 "already exists"

### DIFF
--- a/.changeset/github-create-pr-idempotent.md
+++ b/.changeset/github-create-pr-idempotent.md
@@ -1,0 +1,19 @@
+---
+"@sweny-ai/core": patch
+---
+
+`github_create_pr` is now idempotent. When GitHub responds 422 "A pull request
+already exists for {owner}:{branch}" (typical when a prior node or run already
+opened a PR for the same head branch), the tool now looks up that PR via
+`GET /pulls?head={owner}:{branch}` and returns it as the result, with an extra
+`reused: true` field, instead of throwing.
+
+Fixes the self-close-and-recreate workaround observed in production: the
+`create_pr` node's eval (`github_create_pr` must succeed) could not pass on a
+re-run, so the agent posted "Closing to recreate via the correct PR creation
+flow." on the existing PR and reopened a new one against the same branch. With
+this change, `github_create_pr` returns the existing PR and the eval passes.
+
+Also tightens the `triage` and `implement` workflow instructions so the
+`implement` node stops after the commit and lets `create_pr` push and open the
+PR, and the `create_pr` node treats `reused: true` as success.

--- a/packages/core/src/skills/github.test.ts
+++ b/packages/core/src/skills/github.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { github } from "./github.js";
+import type { ToolContext } from "../types.js";
+
+const ctx = (): ToolContext => ({
+  config: { GITHUB_TOKEN: "test-token" },
+  logger: console,
+});
+
+const createPr = github.tools.find((t) => t.name === "github_create_pr")!;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const ALREADY_EXISTS_422 = {
+  message: "Validation Failed",
+  errors: [
+    {
+      resource: "PullRequest",
+      code: "custom",
+      message: "A pull request already exists for letsoffload:off-1768-fix.",
+    },
+  ],
+  documentation_url: "https://docs.github.com/rest/pulls/pulls#create-a-pull-request",
+};
+
+describe("github_create_pr", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the new PR on the happy path", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(201, { number: 42, html_url: "https://github.com/o/r/pull/42" }))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "sweny" }]));
+
+    const result: any = await createPr.handler(
+      { repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix", body: "body" },
+      ctx(),
+    );
+
+    expect(result).toMatchObject({ number: 42 });
+    expect(result.reused).toBeFalsy();
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/o/r/pulls",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("returns the existing open PR when GitHub responds 422 'pull request already exists'", async () => {
+    const existingPr = {
+      number: 572,
+      html_url: "https://github.com/o/r/pull/572",
+      head: { ref: "x-1-fix" },
+      state: "open",
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(422, ALREADY_EXISTS_422))
+      .mockResolvedValueOnce(jsonResponse(200, [existingPr]))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "sweny" }]));
+
+    const result: any = await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx());
+
+    expect(result).toMatchObject({ number: 572, reused: true });
+    const listCall = fetchMock.mock.calls[1][0] as string;
+    expect(listCall).toContain("/repos/o/r/pulls");
+    expect(listCall).toContain("head=o%3Ax-1-fix");
+    expect(listCall).toContain("state=open");
+  });
+
+  it("falls back to a closed-state lookup if no open PR matches", async () => {
+    const closedPr = { number: 9, html_url: "https://github.com/o/r/pull/9", state: "closed" };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(422, ALREADY_EXISTS_422))
+      .mockResolvedValueOnce(jsonResponse(200, []))
+      .mockResolvedValueOnce(jsonResponse(200, [closedPr]));
+
+    const result: any = await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx());
+
+    expect(result).toMatchObject({ number: 9, reused: true });
+  });
+
+  it("still throws on a 422 that is not the 'already exists' shape", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(422, {
+        message: "Validation Failed",
+        errors: [{ resource: "PullRequest", code: "invalid", message: "Base branch was modified." }],
+      }),
+    );
+
+    await expect(createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx())).rejects.toThrow(
+      /HTTP 422/,
+    );
+  });
+
+  it("still throws on other non-2xx statuses", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { message: "Server error" }));
+    await expect(createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx())).rejects.toThrow(
+      /HTTP 500/,
+    );
+  });
+
+  it("propagates the 422 if the existing-PR lookup itself fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(422, ALREADY_EXISTS_422))
+      .mockResolvedValueOnce(jsonResponse(200, []))
+      .mockResolvedValueOnce(jsonResponse(200, []));
+
+    await expect(createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx())).rejects.toThrow(
+      /already exists/i,
+    );
+  });
+});

--- a/packages/core/src/skills/github.ts
+++ b/packages/core/src/skills/github.ts
@@ -7,6 +7,17 @@
 
 import type { Skill, ToolContext, SkillCategory } from "../types.js";
 
+class GitHubApiError extends Error {
+  status: number;
+  body: string;
+  constructor(status: number, body: string) {
+    super(`[GitHub] API request failed (HTTP ${status}): ${body}`);
+    this.name = "GitHubApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function gh(path: string, ctx: ToolContext, init?: RequestInit): Promise<unknown> {
   const res = await fetch(`https://api.github.com${path}`, {
     ...init,
@@ -18,8 +29,13 @@ async function gh(path: string, ctx: ToolContext, init?: RequestInit): Promise<u
     },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!res.ok) throw new Error(`[GitHub] API request failed (HTTP ${res.status}): ${await res.text()}`);
+  if (!res.ok) throw new GitHubApiError(res.status, await res.text());
   return res.json();
+}
+
+function isAlreadyExistsError(err: unknown): err is GitHubApiError {
+  if (!(err instanceof GitHubApiError) || err.status !== 422) return false;
+  return /pull request already exists/i.test(err.body);
 }
 
 export const github: Skill = {
@@ -131,17 +147,45 @@ export const github: Skill = {
         required: ["repo", "title", "head"],
       },
       handler: async (input: { repo: string; title: string; body?: string; head: string; base?: string }, ctx) => {
-        const pr = (await gh(`/repos/${input.repo}/pulls`, ctx, {
-          method: "POST",
-          body: JSON.stringify({
-            title: input.title,
-            body: input.body,
-            head: input.head,
-            base: input.base ?? "main",
-          }),
-        })) as { number?: number };
+        let pr: { number?: number; html_url?: string } & Record<string, unknown>;
+        let reused = false;
         try {
-          if (pr.number) {
+          pr = (await gh(`/repos/${input.repo}/pulls`, ctx, {
+            method: "POST",
+            body: JSON.stringify({
+              title: input.title,
+              body: input.body,
+              head: input.head,
+              base: input.base ?? "main",
+            }),
+          })) as { number?: number; html_url?: string };
+        } catch (err) {
+          // Recovery: GitHub rejects POST /pulls with 422 when an open PR
+          // already exists for the same head branch. Look up that PR and
+          // return it as if newly created. Without this the workflow's
+          // create_pr eval (`github_create_pr` must succeed) cannot pass
+          // on a re-run, and the agent will close the existing PR to
+          // satisfy the eval — observed in production as a self-close-
+          // and-recreate loop on the same branch.
+          if (!isAlreadyExistsError(err)) throw err;
+          const owner = input.repo.split("/")[0];
+          const headQ = encodeURIComponent(`${owner}:${input.head}`);
+          const open = (await gh(`/repos/${input.repo}/pulls?head=${headQ}&state=open&per_page=1`, ctx)) as Array<{
+            number?: number;
+          }>;
+          const existing =
+            open[0] ??
+            (
+              (await gh(`/repos/${input.repo}/pulls?head=${headQ}&state=all&per_page=1`, ctx)) as Array<{
+                number?: number;
+              }>
+            )[0];
+          if (!existing) throw err;
+          pr = existing as { number?: number };
+          reused = true;
+        }
+        try {
+          if (pr.number && !reused) {
             await gh(`/repos/${input.repo}/issues/${pr.number}/labels`, ctx, {
               method: "POST",
               body: JSON.stringify({ labels: ["sweny"] }),
@@ -150,7 +194,7 @@ export const github: Skill = {
         } catch {
           // Label failure is non-fatal
         }
-        return pr;
+        return reused ? { ...pr, reused: true } : pr;
       },
     },
     {

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -72,6 +72,10 @@ nodes:
       3. Ensure changes are minimal and focused — fix the bug, nothing more.
       4. Stage and commit with a clear commit message referencing the issue.
 
+      Stop after the commit. Do NOT push or open the PR — the dedicated `create_pr`
+      node handles that via `github_create_pr` and its eval gate is what unblocks
+      the rest of the workflow.
+
       If the fix is too risky or complex, explain why and skip.
     skills:
       - github

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -431,6 +431,17 @@ nodes:
          issue identifier in brackets, e.g.
          `[OFF-1234] fix: guard null projectId before database lookup`.
 
+      ## Scope boundary — do NOT open the PR here
+
+      Stop after the commit. Do NOT push the branch, do NOT run `gh pr create`,
+      do NOT call any PR-creation tool. The dedicated `create_pr` node opens the
+      PR via `github_create_pr`. Opening it from this node bypasses the workflow's
+      eval gate and triggers a self-close-and-recreate workaround (PR opened via
+      shell, then `github_create_pr` returns 422 "already exists" against the same
+      branch, then the agent closes the first PR to satisfy the eval). The
+      idempotent fallback in `github_create_pr` will recover if you ignore this,
+      but the cleaner path is: commit only here, let `create_pr` push and open.
+
       ## Test Requirements
 
       A code change without a test is unfinished work. Every fix this node ships
@@ -599,6 +610,11 @@ nodes:
       2. Create the PR using the `github_create_pr` tool. **Use this exact tool name** — do NOT
       use `create_pull_request` or any other variant from ToolSearch. The eval check requires
       `github_create_pr` specifically.
+
+      **If `github_create_pr` returns a result with `reused: true`**, the implement
+      node (or a prior run) already opened a PR for this branch and the tool
+      recovered it instead of failing on 422. Treat this as success and return the
+      PR's URL and number — do NOT close it and call `github_create_pr` again.
 
       3. PR title MUST start with the issue identifier in brackets.
       Format: `[{context.create_issue.issueIdentifier}] fix: {short description}`.


### PR DESCRIPTION
## Summary

- `github_create_pr` no longer throws when GitHub responds 422 "A pull request already exists for {owner}:{branch}". It now looks up the existing PR via `GET /pulls?head={owner}:{branch}` and returns it with `reused: true`.
- Tighten the `triage` and `implement` workflow node prompts so the implement node stops at commit and lets `create_pr` push and open the PR.
- Note in `create_pr` instructions that `reused: true` is success, not a signal to close and recreate.

## Why

Observed in a [SWEny triage run](https://github.com/letsoffload/offload/pull/572) against `letsoffload/offload`:

1. The `implement` node opened PR #572 itself via a shell `gh pr create` (its prompt forbade this, but the Claude runtime is launched with `permissionMode: "bypassPermissions"`, so Bash + `gh` are available).
2. The `create_pr` node then called `github_create_pr` and got HTTP 422 *"A pull request already exists for letsoffload:off-1768-fix-routes-service-error-masking."* twice in a row.
3. The eval policy `pr_was_created (any_tool_called: github_create_pr)` requires `github_create_pr` to succeed, so the node kept failing.
4. On retry, the LLM resolved this by commenting "Closing to recreate via the correct PR creation flow." on PR #572, closing it, and reopening the exact same diff as PR #573.

That comment string is not hardcoded anywhere in this repo — the LLM invented it as a workaround. The actual bug is `github_create_pr`'s lack of recovery for "PR already exists for this head branch," which is a legitimate success state for the workflow's goal.

## Changes

- `packages/core/src/skills/github.ts`
  - Promote the inline `Error` thrown from `gh()` to a typed `GitHubApiError` so callers can introspect `status` and `body`.
  - `github_create_pr` handler: on `GitHubApiError` with `status === 422` and body matching `/pull request already exists/i`, fall back to `GET /pulls?head={owner}:{branch}&state=open` (then `state=all` if needed) and return the first match with `reused: true`.
  - Skip the auto-label POST when `reused` (the existing PR already has its labels).
- `packages/core/src/workflows/triage.yml`
  - Implement node: explicit "stop after commit; do NOT push or `gh pr create`" boundary, citing the close-and-recreate workaround.
  - Create_pr node: instruct the agent that `reused: true` is success and not to close-and-recreate.
- `packages/core/src/workflows/implement.yml`
  - Same "stop after commit" boundary on the implement node.
- `packages/core/src/skills/github.test.ts` (new)
  - 6 unit tests: happy path, 422 → open existing PR returned, fallback to closed-state lookup, non-recoverable 422, other non-2xx, lookup-finds-nothing.
- `.changeset/github-create-pr-idempotent.md` (patch bump for `@sweny-ai/core`).

## Test plan

- [x] `npm test` in `packages/core` — 54 files / 1612 tests pass.
- [x] `npx vitest run src/skills/github.test.ts` — 6/6 pass.
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean (schemas up to date, no drift).
- [x] `npx eslint packages/core/src/skills/github.ts packages/core/src/skills/github.test.ts` — no new warnings (2 pre-existing).
- [x] Manual trace: regenerated the prod failure path against the mock (422 with the exact body from run 25678132232) and asserted `reused: true` instead of throw.

## Follow-ups not in this PR

- Tool-enforce the implement-node scope boundary (today it's prompt-only). The cleanest fix is per-node `disallowedTools` / permission-mode plumbing so `Bash` can be restricted on `implement` and turned off entirely from `gh pr create`. Larger change; opening as a separate PR.
- Action-side `git config user.email`/`user.name` in `triage/action.yml` so the agent doesn't have to set its identity mid-run. The run log for this incident shows `Author identity unknown ... fatal: empty ident name` on the first commit attempt before the agent recovered itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)