### PR TITLE
fix(workflows): add open-PR precondition to implement nodes (stop run-thrash)

### DIFF
--- a/packages/core/src/__tests__/workflow-yaml.test.ts
+++ b/packages/core/src/__tests__/workflow-yaml.test.ts
@@ -383,7 +383,13 @@ describe("triage implement node — Step 0b open-PR precondition", () => {
 
   it("instruction documents Step 0b PR-existence check", () => {
     expect(instruction).toMatch(/Step 0b|0b\.|Precondition.*existing open PR/i);
-    expect(instruction).toMatch(/github_search_prs/);
+    // Must reference an actual tool the github skill exposes. `github_search_issues`
+    // hits GitHub's /search/issues endpoint which returns PRs too when filtered
+    // with `type:pr`. There is no `github_search_prs` tool; referencing it would
+    // tell the agent to call a non-existent function.
+    expect(instruction).toMatch(/github_search_issues/);
+    expect(instruction).not.toMatch(/github_search_prs/);
+    expect(instruction).toMatch(/type:pr/);
     expect(instruction).toMatch(/state:open/);
   });
 
@@ -436,6 +442,18 @@ describe("triage implement node — Step 0b open-PR precondition", () => {
     // on the Step 0b short-circuit and burns the retry budget.
     expect(testFilesJudge!.rubric).toMatch(/"skipped"/);
   });
+
+  it("fail and not-run still trigger retry (NOT added to the allow-list)", () => {
+    // Adding `skipped` to the value gate must not inadvertently relax the
+    // gate for `fail` or `not-run`. Both should remain outside `in` so the
+    // retry path keeps firing on real test failures.
+    const evaluators = node.eval ?? [];
+    const valueEv = evaluators.find((e) => e.kind === "value" && e.rule?.output_matches !== undefined)!;
+    const match = valueEv.rule!.output_matches!.find((m) => m.path === "test_status")!;
+    const allowed = match.in as string[];
+    expect(allowed).not.toContain("fail");
+    expect(allowed).not.toContain("not-run");
+  });
 });
 
 // ─── Implement workflow specifics ───────────────────────────────
@@ -467,7 +485,12 @@ describe("implement workflow specifics", () => {
 
   it("analyze node instruction mentions the PR-existence check", () => {
     const instr = implementWorkflow.nodes.analyze.instruction as string;
-    expect(instr).toMatch(/github_search_prs/);
+    // Must reference a tool the github skill actually exposes — there is
+    // no `github_search_prs`. `github_search_issues` covers PRs via the
+    // /search/issues endpoint with a `type:pr` qualifier.
+    expect(instr).toMatch(/github_search_issues/);
+    expect(instr).not.toMatch(/github_search_prs/);
+    expect(instr).toMatch(/type:pr/);
     expect(instr).toMatch(/existing open PR|open PR.*already exists/i);
   });
 

--- a/packages/core/src/__tests__/workflow-yaml.test.ts
+++ b/packages/core/src/__tests__/workflow-yaml.test.ts
@@ -253,11 +253,32 @@ describe("triage implement node — fix-quality contract", () => {
       expect(required).toContain("test_status");
     });
 
-    it("declares test_status with exactly the four allowed values", () => {
+    it("declares test_status with exactly the five allowed values", () => {
       const props = output!.properties as Record<string, any>;
       expect(props.test_status).toBeDefined();
       // Order doesn't matter; set semantics for the enum.
-      expect(new Set(props.test_status.enum)).toEqual(new Set(["pass", "fail", "no-framework", "not-run"]));
+      // `skipped` was added to support the Step 0b open-PR precondition —
+      // when an open PR already exists for the issue identifier, implement
+      // short-circuits without running tests and the workflow routes to
+      // notify. See triage.yml implement instruction Step 0b.
+      expect(new Set(props.test_status.enum)).toEqual(new Set(["pass", "fail", "no-framework", "not-run", "skipped"]));
+    });
+
+    it("declares skipped_reason as an enum scoped to documented reasons", () => {
+      const props = output!.properties as Record<string, any>;
+      expect(props.skipped_reason).toBeDefined();
+      // Currently the only valid skip reason is open-pr-exists. Keeping
+      // this enum tight prevents drive-by additions; new reasons should
+      // come with a documented rationale and edge wiring.
+      expect(new Set(props.skipped_reason.enum)).toEqual(new Set(["open-pr-exists"]));
+    });
+
+    it("declares existing_pr_url as a URL string", () => {
+      const props = output!.properties as Record<string, any>;
+      expect(props.existing_pr_url).toBeDefined();
+      expect(props.existing_pr_url.type).toBe("string");
+      // Pattern guards against bare PR numbers or local paths.
+      expect(props.existing_pr_url.pattern).toBe("^https?://");
     });
 
     it("declares test_files_changed as an array of strings", () => {
@@ -278,13 +299,16 @@ describe("triage implement node — fix-quality contract", () => {
       expect(match).toBeDefined();
     });
 
-    it("allows pass and no-framework, and only those two", () => {
+    it("allows pass, no-framework, and skipped, and only those three", () => {
       const ev = evaluators!.find((e) => e.kind === "value" && e.rule?.output_matches !== undefined)!;
       const match = ev.rule!.output_matches!.find((m) => m.path === "test_status")!;
       // Behavior contract: pass is the happy path; no-framework is the
-      // documented escape valve for genuinely test-less repos. Anything
-      // else (fail, not-run) trips the gate and triggers retry.
-      expect(new Set(match.in as string[])).toEqual(new Set(["pass", "no-framework"]));
+      // documented escape valve for genuinely test-less repos; skipped is
+      // the Step 0b open-PR precondition that prevents the run-thrash
+      // observed in letsoffload/permit-service #81 → #82 and
+      // letsoffload/offload #572 → #573. Anything else (fail, not-run)
+      // trips the gate and triggers retry.
+      expect(new Set(match.in as string[])).toEqual(new Set(["pass", "no-framework", "skipped"]));
     });
   });
 
@@ -328,7 +352,7 @@ describe("triage implement node — fix-quality contract", () => {
       );
       expect(testStatusMatches.length).toBeGreaterThan(0);
       const allowedStatuses = testStatusMatches[0]!.in as string[];
-      expect(new Set(allowedStatuses)).toEqual(new Set(["pass", "no-framework"]));
+      expect(new Set(allowedStatuses)).toEqual(new Set(["pass", "no-framework", "skipped"]));
     });
 
     it("retains a single retry attempt with autonomous reflection", () => {
@@ -338,6 +362,79 @@ describe("triage implement node — fix-quality contract", () => {
       expect(node.retry!.max).toBe(1);
       expect(node.retry!.instruction).toEqual({ auto: true });
     });
+  });
+});
+
+// ─── Triage implement-node open-PR precondition (Step 0b) ───────
+//
+// Driving incident: in a single SWEny workflow run on 2026-04-26
+// (letsoffload/permit-service, run id 24958851295), PR #81 was opened
+// at 14:32:58, closed by github-actions[bot] at 14:47:57, and PR #82
+// was opened 12 seconds later — both for OFF-1481, different fix
+// approaches. Same pattern on 2026-05-11 in letsoffload/offload
+// (run id 25678132232): #572 closed and #573 opened 16 seconds apart
+// for OFF-1768. Cause: the implement node has no idempotency guard;
+// re-runs (and internal retries) re-implement a fix that already has
+// an open PR, then ad-hoc close the prior PR to land the new one.
+// The Step 0b check short-circuits before any branch is created.
+describe("triage implement node — Step 0b open-PR precondition", () => {
+  const node = triageWorkflow.nodes.implement;
+  const instruction = node.instruction as string;
+
+  it("instruction documents Step 0b PR-existence check", () => {
+    expect(instruction).toMatch(/Step 0b|0b\.|Precondition.*existing open PR/i);
+    expect(instruction).toMatch(/github_search_prs/);
+    expect(instruction).toMatch(/state:open/);
+  });
+
+  it("instruction tells the agent to STOP without creating a branch when an open PR exists", () => {
+    // The whole point of the precondition: no new branch, no new commit,
+    // no new PR. Pin the prohibition explicitly so a future "improvement"
+    // doesn't relax it back to "but if the title is slightly different..."
+    expect(instruction).toMatch(/STOP\.\s+Do\s+NOT create a branch/);
+  });
+
+  it("instruction prescribes the exact skipped-output shape", () => {
+    expect(instruction).toMatch(/test_status:\s*"skipped"/);
+    expect(instruction).toMatch(/skipped_reason:\s*"open-pr-exists"/);
+    expect(instruction).toMatch(/existing_pr_url/);
+  });
+
+  it("cites the driving incidents so the rationale survives future edits", () => {
+    // These are not flair — they are the specific evidence the precondition
+    // is for. Stripping the citation invites a future contributor to
+    // remove the precondition as "unmotivated."
+    expect(instruction).toMatch(/permit-service.*PR #81/);
+    expect(instruction).toMatch(/offload.*PR #572/);
+  });
+
+  it("has an edge from implement to notify gated on test_status skipped", () => {
+    const implementToNotify = triageWorkflow.edges.find((e) => e.from === "implement" && e.to === "notify");
+    expect(implementToNotify).toBeDefined();
+    expect(implementToNotify!.when).toBeDefined();
+    expect(implementToNotify!.when!).toMatch(/skipped/);
+  });
+
+  it("the implement→create_pr edge is now conditional, not unconditional", () => {
+    // Before this fix, implement→create_pr had no `when:` and always fired,
+    // which is what made the skipped path unrouteable. Make sure the edge
+    // stays conditional so the engine can choose between create_pr and
+    // notify based on the implement node's output.
+    const implementToCreatePr = triageWorkflow.edges.find((e) => e.from === "implement" && e.to === "create_pr");
+    expect(implementToCreatePr).toBeDefined();
+    expect(implementToCreatePr!.when).toBeDefined();
+    expect(implementToCreatePr!.when!).toMatch(/pass|no-framework/);
+  });
+
+  it("the judge rubric still covers the skipped case", () => {
+    const evaluators = node.eval ?? [];
+    const judges = evaluators.filter((e) => e.kind === "judge");
+    const testFilesJudge = judges.find((e) => (e.rubric ?? "").includes("test_files_changed"));
+    expect(testFilesJudge).toBeDefined();
+    // The rubric must explicitly allow empty test_files_changed when
+    // test_status is "skipped" — otherwise the judge fails the contract
+    // on the Step 0b short-circuit and burns the retry budget.
+    expect(testFilesJudge!.rubric).toMatch(/"skipped"/);
   });
 });
 
@@ -352,10 +449,33 @@ describe("implement workflow specifics", () => {
     expect(implementWorkflow.entry).toBe("analyze");
   });
 
-  it("has conditional edges from analyze", () => {
+  it("has three conditional edges from analyze (existing PR, fix, skip)", () => {
+    // analyze now branches three ways:
+    //   1. existing_pr_url is set → notify (no work to do)
+    //   2. risk low/medium with a clear plan → implement
+    //   3. too complex/risky/unclear → skip
     const analyzeEdges = implementWorkflow.edges.filter((e) => e.from === "analyze");
-    expect(analyzeEdges.length).toBe(2);
+    expect(analyzeEdges.length).toBe(3);
     expect(analyzeEdges.every((e) => e.when)).toBe(true);
+  });
+
+  it("analyze → notify edge mentions existing_pr_url", () => {
+    const analyzeToNotify = implementWorkflow.edges.find((e) => e.from === "analyze" && e.to === "notify");
+    expect(analyzeToNotify).toBeDefined();
+    expect(analyzeToNotify!.when!).toMatch(/existing_pr_url/);
+  });
+
+  it("analyze node instruction mentions the PR-existence check", () => {
+    const instr = implementWorkflow.nodes.analyze.instruction as string;
+    expect(instr).toMatch(/github_search_prs/);
+    expect(instr).toMatch(/existing open PR|open PR.*already exists/i);
+  });
+
+  it("analyze output schema declares existing_pr_url as a URL string", () => {
+    const props = implementWorkflow.nodes.analyze.output!.properties as Record<string, any>;
+    expect(props.existing_pr_url).toBeDefined();
+    expect(props.existing_pr_url.type).toBe("string");
+    expect(props.existing_pr_url.pattern).toBe("^https?://");
   });
 
   it("skip routes to notify (team always gets notified)", () => {

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -11,10 +11,12 @@ nodes:
 
       1. Fetch the issue from the tracker (GitHub or Linear).
       2. **Check for an existing open PR for this issue.** Call
-         `github_search_prs` with a query that includes the issue identifier
-         wrapped in brackets — e.g. `[OFF-1234] in:title state:open`. If you
-         find one or more open PRs whose title starts with
-         `[<issueIdentifier>]`, STOP analysis. Output `existing_pr_url`
+         `github_search_issues` (GitHub's `/search/issues` endpoint returns
+         both issues and PRs) with `type:pr state:open` and the issue
+         identifier wrapped in brackets — e.g. query
+         `[OFF-1234] in:title type:pr state:open`. If the response contains
+         one or more PRs whose title starts with `[<issueIdentifier>]`,
+         STOP analysis. Output `existing_pr_url`
          (the URL of the open PR) and a short `issue_summary` noting the
          skip; leave `fix_plan` set to a one-line "Skip: open PR
          <url> already exists". The workflow will route to `notify` and

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -10,9 +10,23 @@ nodes:
       Read the issue details and understand what needs to be fixed:
 
       1. Fetch the issue from the tracker (GitHub or Linear).
-      2. Read the relevant source files to understand the current code.
-      3. Identify the exact files and lines that need to change.
-      4. Plan the fix approach.
+      2. **Check for an existing open PR for this issue.** Call
+         `github_search_prs` with a query that includes the issue identifier
+         wrapped in brackets — e.g. `[OFF-1234] in:title state:open`. If you
+         find one or more open PRs whose title starts with
+         `[<issueIdentifier>]`, STOP analysis. Output `existing_pr_url`
+         (the URL of the open PR) and a short `issue_summary` noting the
+         skip; leave `fix_plan` set to a one-line "Skip: open PR
+         <url> already exists". The workflow will route to `notify` and
+         the team will be told the prior PR is still pending.
+         Rationale: re-implementing while an open PR exists produces a
+         duplicate (or worse, the agent closes its own prior PR mid-run
+         and opens a new one — exactly the thrash seen in
+         `letsoffload/permit-service` PR #81 → #82 and
+         `letsoffload/offload` PR #572 → #573).
+      3. Read the relevant source files to understand the current code.
+      4. Identify the exact files and lines that need to change.
+      5. Plan the fix approach.
 
       Output a clear analysis of what needs to change and why.
     skills:
@@ -35,6 +49,14 @@ nodes:
             - low
             - medium
             - high
+        existing_pr_url:
+          type: string
+          description: |
+            URL of an open PR found in step 2 whose title starts with the
+            issue identifier in brackets. Set ONLY when a prior PR exists
+            and the analyze node is short-circuiting. Triggers the
+            `analyze → notify` edge.
+          pattern: "^https?://"
       required:
         - issue_summary
         - fix_plan
@@ -96,6 +118,9 @@ nodes:
       - github
       - linear
 edges:
+  - from: analyze
+    to: notify
+    when: analyze.existing_pr_url is set (an open PR for this issue already exists; skip the implement and create_pr nodes)
   - from: analyze
     to: implement
     when: Fix risk level is low or medium and a clear plan exists

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -369,11 +369,13 @@ nodes:
          instead; the workflow will route to notify and a human will pick it up.
 
       0b. **Precondition — check for an existing open PR for this issue.** Call
-         `github_search_prs` (or the equivalent search-pull-requests tool) with a
-         query that includes the issue identifier wrapped in brackets — e.g.
-         `[OFF-1234] in:title state:open repo:<owner>/<repo>`. If you find one or
-         more open PRs whose title starts with `[<issueIdentifier>]`, STOP. Do
-         NOT create a branch, commit, or any new PR. Output:
+         `github_search_issues` (which hits GitHub's `/search/issues` endpoint
+         and returns both issues and PRs) with `type:pr state:open` and the
+         issue identifier wrapped in brackets — e.g. query
+         `[OFF-1234] in:title type:pr state:open` and pass `repo` for scoping.
+         If the response contains one or more PRs whose title starts with
+         `[<issueIdentifier>]`, STOP. Do NOT create a branch, commit, or any
+         new PR. Output:
 
          ```
          test_status: "skipped"

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -361,12 +361,42 @@ nodes:
 
       ## Steps
 
-      0. **Precondition — verify context.create_issue.issueIdentifier is well-formed.**
+      0a. **Precondition — verify context.create_issue.issueIdentifier is well-formed.**
          The identifier MUST match `^[A-Z][A-Z0-9]*-\d+$` (e.g. `OFF-1234`). If it
          is missing, empty, or matches a Sentry short-ID / slug / any other shape,
          STOP immediately — do NOT invent a branch name from the Sentry event,
          commit SHA, or alert payload. Return a failed status with a clear message
          instead; the workflow will route to notify and a human will pick it up.
+
+      0b. **Precondition — check for an existing open PR for this issue.** Call
+         `github_search_prs` (or the equivalent search-pull-requests tool) with a
+         query that includes the issue identifier wrapped in brackets — e.g.
+         `[OFF-1234] in:title state:open repo:<owner>/<repo>`. If you find one or
+         more open PRs whose title starts with `[<issueIdentifier>]`, STOP. Do
+         NOT create a branch, commit, or any new PR. Output:
+
+         ```
+         test_status: "skipped"
+         skipped_reason: "open-pr-exists"
+         existing_pr_url: "<url of the existing PR>"
+         test_files_changed: []
+         files_changed: []
+         branch: ""
+         commit_sha: ""
+         ```
+
+         The downstream `create_pr` node will be bypassed and the workflow will
+         route to `notify` so the team is told the prior PR is still pending.
+
+         Rationale: re-implementing a fix while an open PR already exists
+         produces a duplicate (or worse, the agent closes its own prior PR
+         mid-run and opens a new one with a different approach — exactly the
+         thrash observed in `letsoffload/permit-service` PR #81 → #82 and
+         `letsoffload/offload` PR #572 → #573, where two PRs for the same
+         identifier were opened-and-closed 12 to 16 seconds apart inside a
+         single workflow run).
+
+         Only proceed to Step 1 if no open PR exists for the identifier.
 
       1. Create a feature branch from the base branch (check context for
          baseBranch, default `main`). **Branch name MUST include the issue
@@ -460,7 +490,7 @@ nodes:
           description: Exact command run to validate (e.g. `npx nx test server`).
         test_status:
           type: string
-          enum: [pass, fail, no-framework, not-run]
+          enum: [pass, fail, no-framework, not-run, skipped]
           description: |
             Outcome of running the test suite.
             - `pass` — tests ran end-to-end and every assertion passed.
@@ -475,6 +505,26 @@ nodes:
               a broken fix. Return this status, retry will fire once.
             - `not-run` — tests exist but the environment couldn't
               execute them. Explain in `test_notes`. Retry will fire.
+            - `skipped` — the node short-circuited before running tests
+              because a precondition was not met. Today the only
+              accepted reason is `open-pr-exists` (Step 0b found an
+              open PR with the issue identifier in its title).
+              `skipped_reason` and `existing_pr_url` MUST be populated.
+              Downstream `create_pr` is bypassed and the workflow
+              routes to `notify`.
+        skipped_reason:
+          type: string
+          description: |
+            Why the node short-circuited. Only set when `test_status` is
+            `skipped`. Today the only valid value is `open-pr-exists`.
+          enum: [open-pr-exists]
+        existing_pr_url:
+          type: string
+          description: |
+            URL of the open PR that triggered the skip. Set when
+            `skipped_reason` is `open-pr-exists` so the notify node
+            can link to the prior PR.
+          pattern: "^https?://"
         test_notes:
           type: string
           description: One-paragraph explanation of which tests were added and what they assert.
@@ -485,14 +535,18 @@ nodes:
         - test_files_changed
         - test_status
     eval:
-      # `pass` and `no-framework` both clear the gate. `fail` and `not-run`
-      # trigger retry.
+      # `pass`, `no-framework`, and `skipped` clear the gate. `fail` and
+      # `not-run` trigger retry. `skipped` is the Step 0b short-circuit
+      # (open PR already exists for the issue identifier) — see the
+      # implement instruction for the driving incidents
+      # (letsoffload/permit-service #81 → #82,
+      # letsoffload/offload #572 → #573).
       - name: test_status_is_pass_or_no_framework
         kind: value
         rule:
           output_matches:
             - path: test_status
-              in: [pass, no-framework]
+              in: [pass, no-framework, skipped]
       # Conditional: when test_status is pass, test_files_changed MUST contain
       # at least one real test file path. Empty array with status pass is a
       # contract violation (the agent claimed it ran tests without actually
@@ -518,6 +572,11 @@ nodes:
             (README.md, package.json, source files), is a contract violation.
           - If test_status is "no-framework": test_files_changed MAY be empty.
             Pass vacuously.
+          - If test_status is "skipped": test_files_changed MAY be empty.
+            The node short-circuited before writing any code (Step 0b
+            found an open PR for the issue). `skipped_reason` and
+            `existing_pr_url` MUST be populated; if they are missing,
+            return no.
           - If test_status is "fail" or "not-run": this evaluator should not
             run (the prior value evaluator catches that). Pass vacuously.
 
@@ -601,6 +660,10 @@ edges:
   - from: skip
     to: notify
   - from: implement
+    to: notify
+    when: implement.test_status is "skipped" (Step 0b found an open PR already exists for the issue identifier)
+  - from: implement
     to: create_pr
+    when: implement.test_status is "pass" or "no-framework" (no existing PR; fix was implemented or there is no test framework)
   - from: create_pr
     to: notify


### PR DESCRIPTION
## Summary

- Added Step 0b to the triage `implement` node and the implement workflow's `analyze` node: before any branch is created, the agent searches for an open PR with the issue identifier in brackets (`[<ID>]`) in the title. If one exists, the node short-circuits.
- New routing: when the precondition trips, the workflow goes straight to `notify` so the team is told the prior PR is still pending. `create_pr` and downstream work are skipped.
- Output schema, value evaluator, and judge rubric all updated to accept the new `skipped` state without burning the retry budget.
- 12 new tests pin the precondition, output shape, enum membership, edge wiring, and that the driving-incident citations remain in the instruction.

## Motivation

Same SWEny workflow run, two PRs created for the same issue identifier with the first closed by the bot 12–16 seconds before the second opens. Real cases:

- **letsoffload/permit-service** (run [24958851295](https://github.com/letsoffload/permit-service/actions/runs/24958851295), OFF-1481): PR [#81](https://github.com/letsoffload/permit-service/pull/81) opened 14:32:58, closed by `github-actions[bot]` at 14:47:57. PR [#82](https://github.com/letsoffload/permit-service/pull/82) opened 14:48:09 — 12 seconds later, different fix approach.
- **letsoffload/offload** (run [25678132232](https://github.com/letsoffload/offload/actions/runs/25678132232), OFF-1768): PR [#572](https://github.com/letsoffload/offload/pull/572) closed by bot 15:21:45, PR [#573](https://github.com/letsoffload/offload/pull/573) opened 15:22:01.

Cause: the implement node had a tight issue-novelty check (4a–4d in `investigate` / step 1 in `create_issue`) but no PR-existence guard. Re-runs and the implement node's internal retry would re-implement, and the agent would ad-hoc close the prior PR to land the new one. Same root cause, different surface: wasted compute, wasted tokens, broken commit history, and a backlog where every ticket has one stale + one live PR.

The fix mirrors the existing issue-novelty pattern: search first, short-circuit if a matching artifact already exists.

## Test plan

- [x] `npm test --workspace=packages/core` — 1618 pass (12 new)
- [x] `npm run typecheck --workspace=packages/core` — clean
- [x] `npm run check:schema-drift --workspace=packages/core` — schemas already up to date
- [x] `npm run lint` — 0 errors (260 pre-existing warnings unchanged)
- [x] `npm run build --workspace=packages/core` — browser bundle regenerated, deep-equality test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)