### PR TITLE
feat(core): per-node disallowed_tools

### DIFF
--- a/.changeset/per-node-disallowed-tools.md
+++ b/.changeset/per-node-disallowed-tools.md
@@ -1,0 +1,18 @@
+---
+"@sweny-ai/core": minor
+---
+
+Add per-node `disallowed_tools` to the workflow schema. The executor forwards
+this list to the Claude Agent SDK's `disallowedTools` option, which removes
+the named built-in tools (e.g. `Bash`, `WebFetch`, `WebSearch`) from the
+model's context entirely for the duration of that node.
+
+This is the foundational mechanism for tool-enforcing per-node scope
+boundaries. As a first application, the `triage` and `implement` workflows
+now lock `WebFetch` + `WebSearch` off the implement node so the agent
+cannot drift off-task into external research mid-implementation. `Bash`
+remains available because the implement node legitimately needs it for
+`git add` / `git commit` and to run the project's test command; pattern-
+based restriction of `Bash` invocations (e.g. blocking `gh pr create` and
+`git push`) belongs to a separate follow-up that wires the SDK's
+`canUseTool` callback to a per-node Bash deny pattern list.

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -2027,4 +2027,69 @@ describe("executor", () => {
       });
     });
   });
+
+  describe("disallowed_tools", () => {
+    it("forwards Node.disallowed_tools to claude.run as disallowedTools", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "implement",
+        nodes: {
+          implement: {
+            name: "Implement",
+            instruction: "Do the thing",
+            skills: [],
+            disallowed_tools: ["WebFetch", "WebSearch"],
+          },
+        },
+        edges: [],
+      };
+
+      const captured: { disallowedTools?: string[] }[] = [];
+      const claude: any = {
+        async run(opts: any) {
+          captured.push({ disallowedTools: opts.disallowedTools });
+          return { status: "success", data: {}, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].disallowedTools).toEqual(["WebFetch", "WebSearch"]);
+    });
+
+    it("forwards undefined when a node omits disallowed_tools", async () => {
+      const wf: Workflow = {
+        id: "wf",
+        name: "wf",
+        description: "",
+        entry: "implement",
+        nodes: {
+          implement: { name: "Implement", instruction: "Do the thing", skills: [] },
+        },
+        edges: [],
+      };
+
+      const captured: { disallowedTools?: string[] }[] = [];
+      const claude: any = {
+        async run(opts: any) {
+          captured.push({ disallowedTools: opts.disallowedTools });
+          return { status: "success", data: {}, toolCalls: [] };
+        },
+        async evaluate(opts: any) {
+          return opts.choices[0]?.id;
+        },
+      };
+
+      await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].disallowedTools).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -89,6 +89,24 @@ describe("Zod schemas", () => {
       expect(() => nodeZ.parse({ name: "S", instruction: "I", eval: [] })).toThrow();
     });
 
+    it("accepts disallowed_tools as a string array", () => {
+      const result = nodeZ.parse({
+        name: "S",
+        instruction: "I",
+        disallowed_tools: ["WebFetch", "WebSearch"],
+      });
+      expect(result.disallowed_tools).toEqual(["WebFetch", "WebSearch"]);
+    });
+
+    it("rejects disallowed_tools with an empty-string entry", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", disallowed_tools: ["WebFetch", ""] })).toThrow();
+    });
+
+    it("defaults disallowed_tools to undefined when omitted", () => {
+      const result = nodeZ.parse({ name: "S", instruction: "I" });
+      expect(result.disallowed_tools).toBeUndefined();
+    });
+
     it("rejects an evaluator missing a name", () => {
       expect(() =>
         nodeZ.parse({

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -70,8 +70,9 @@ export class ClaudeClient implements Claude {
     outputSchema?: JSONSchema;
     onProgress?: (message: string) => void;
     maxTurns?: number;
+    disallowedTools?: string[];
   }): Promise<NodeResult> {
-    const { instruction, context, tools, outputSchema, onProgress, maxTurns } = opts;
+    const { instruction, context, tools, outputSchema, onProgress, maxTurns, disallowedTools } = opts;
 
     // Tool-call accounting (Fix #1).
     //
@@ -134,6 +135,7 @@ export class ClaudeClient implements Claude {
           stderr: (data: string) => this.logger.debug(`[claude-code] ${data}`),
           ...(this.model ? { model: this.model } : {}),
           ...(Object.keys(allMcpServers).length > 0 ? { mcpServers: allMcpServers } : {}),
+          ...(disallowedTools && disallowedTools.length > 0 ? { disallowedTools } : {}),
         },
       });
 

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -264,6 +264,7 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
         tools: trackedTools,
         outputSchema: node.output,
         maxTurns: node.max_turns,
+        disallowedTools: node.disallowed_tools,
         onProgress: (message) => {
           safeObserve(observer, { type: "node:progress", node: currentId!, message }, logger);
         },

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -227,6 +227,7 @@ export const nodeZ = z
     skills: z.array(z.string()).default([]),
     output: jsonSchemaZ.optional(),
     max_turns: z.number().int().min(1).optional(),
+    disallowed_tools: z.array(z.string().min(1)).optional(),
     rules: nodeSourcesZ.optional(),
     context: nodeSourcesZ.optional(),
     eval: z.array(evaluatorZ).min(1).optional(),
@@ -670,6 +671,12 @@ export const workflowJsonSchema = {
             type: "integer",
             minimum: 1,
             description: "Max AI model turns for this node. When absent, the executor's default applies.",
+          },
+          disallowed_tools: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            description:
+              "Built-in tool names the agent cannot use at this node (e.g. ['Bash']). Forwarded to the Claude Agent SDK's disallowedTools, which removes the tools from the model context entirely.",
           },
           rules: {
             $ref: "#/$defs/NodeSources",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -302,6 +302,15 @@ export interface Node {
   requires?: NodeRequires;
   /** Node-local retry on eval failure (with optional autonomous reflection). */
   retry?: NodeRetry;
+  /**
+   * Built-in tool names the agent must NOT have access to during this node.
+   * Forwarded to the Claude Agent SDK's `disallowedTools` option, which
+   * removes the named tools from the model's context entirely (not just
+   * blocked-via-permission). Use this to scope a node — e.g. an implement
+   * node that should commit but must not shell out `gh pr create` or
+   * `git push`. Names follow the SDK's tool naming (e.g. `Bash`, `Write`).
+   */
+  disallowed_tools?: string[];
 }
 
 /** An edge connecting two nodes */
@@ -463,6 +472,8 @@ export interface Claude {
     onProgress?: (message: string) => void;
     /** Per-node turn limit. Overrides the client default when set. */
     maxTurns?: number;
+    /** Built-in SDK tool names to disallow for this node (e.g. ["Bash"]). */
+    disallowedTools?: string[];
   }): Promise<NodeResult>;
 
   /** Evaluate a routing condition — pick one of N choices */

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -51,6 +51,12 @@ nodes:
       If the fix is too risky or complex, explain why and skip.
     skills:
       - github
+    # Same rationale as the triage workflow: keep the implement node focused
+    # on the repo. Bash stays available because `git add`/`git commit` and
+    # test runners are essential.
+    disallowed_tools:
+      - WebFetch
+      - WebSearch
   create_pr:
     name: Open Pull Request
     instruction: >-

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -432,6 +432,18 @@ nodes:
       explain why — do not force a bad fix.
     skills:
       - github
+    # Defense-in-depth: the implement node should read repo files, edit
+    # them, run tests, and commit — not browse the web. Disallowing the
+    # built-in web tools removes them from the model context so the agent
+    # cannot drift off-task into external research mid-implementation.
+    # Note: Bash is intentionally NOT in this list because the agent needs
+    # it for `git add`/`git commit` and to run test commands. Restricting
+    # *which* Bash invocations are allowed (e.g. blocking `gh pr create`
+    # / `git push`) belongs to a follow-up that wires the SDK's
+    # canUseTool callback to a per-node Bash deny pattern list.
+    disallowed_tools:
+      - WebFetch
+      - WebSearch
     output:
       type: object
       properties:

--- a/spec/public/schemas/workflow.json
+++ b/spec/public/schemas/workflow.json
@@ -292,6 +292,14 @@
             "minimum": 1,
             "description": "Max AI model turns for this node. When absent, the executor's default applies."
           },
+          "disallowed_tools": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": "Built-in tool names the agent cannot use at this node (e.g. ['Bash']). Forwarded to the Claude Agent SDK's disallowedTools, which removes the tools from the model context entirely."
+          },
           "rules": {
             "$ref": "#/$defs/NodeSources",
             "description": "Per-node rules. Additive by default; set { only: true } to block cascade."


### PR DESCRIPTION
## Summary

- New optional Node field: `disallowed_tools: string[]`. Executor forwards it to `claude.run`, which passes it to the Claude Agent SDK's `disallowedTools` option. The SDK removes the named built-in tools (e.g. `Bash`, `WebFetch`, `WebSearch`) from the model's context entirely for that node.
- Apply on the implement node of both `triage.yml` and `implement.yml`: `[WebFetch, WebSearch]`. Defense in depth — the implement node reads/edits repo files and runs tests; external research mid-implementation is off-task.

## Why

Follow-up to [#189](https://github.com/swenyai/sweny/pull/189). The root cause behind that PR's incident was: the `implement` node's scope is enforced only by the prompt, but the Claude Agent SDK is invoked with `permissionMode: \"bypassPermissions\"` + the full default toolset, so the agent can shell out anything it wants. PR #189 made `github_create_pr` idempotent so the workflow no longer self-closes its own PR, but the underlying \"prompt-only scope\" weakness still applies to every node.

This PR introduces the foundational mechanism to enforce per-node scope at the runtime level. The SDK's `disallowedTools` removes the listed tools from the model's context entirely — not just \"would be blocked via permission rule.\" The agent never sees them.

## Why we didn't include `Bash` in the default lockdown

The implement node legitimately needs `Bash` for `git add` / `git commit` and to run the project's test command. Blocking `Bash` entirely would break the workflow.

What we actually want to block is specific shell invocations (`gh pr create`, `git push`) while keeping the rest of `Bash` available. That needs the SDK's `canUseTool` callback to inspect the Bash input. It is a separate follow-up — call it `denied_bash_patterns: string[]` plumbed through to a `canUseTool` handler in `claude.ts` — because it changes the permission model rather than just the tool surface.

## Changes

- `packages/core/src/types.ts` — Node.disallowed_tools; Claude.run accepts disallowedTools.
- `packages/core/src/schema.ts` — Zod schema and JSON schema both gain `disallowed_tools`.
- `packages/core/src/executor.ts` — passes node.disallowed_tools to claude.run.
- `packages/core/src/claude.ts` — passes disallowedTools through to the SDK `query()` options when non-empty.
- `packages/core/src/workflows/triage.yml` and `implement.yml` — `disallowed_tools: [WebFetch, WebSearch]` on implement nodes, with an inline comment explaining why Bash is left in.
- `packages/core/src/__tests__/executor.test.ts` — two tests: forwards to claude.run when set; forwards undefined when omitted.
- `packages/core/src/__tests__/schema.test.ts` — three tests: accepts string array; rejects empty entries; defaults to undefined.
- `spec/public/schemas/workflow.json` — regenerated.
- `.changeset/per-node-disallowed-tools.md` — minor bump for `@sweny-ai/core` (new public field).

## Test plan

- [x] `npm test` in `packages/core` — 53 files / 1611 tests pass.
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean (public JSON schema regenerated, no drift).
- [x] Targeted: `npx vitest run src/__tests__/schema.test.ts src/__tests__/executor.test.ts` — 180/180 pass.

## Follow-ups not in this PR

- `denied_bash_patterns` (or similar) wired through `canUseTool` to block `gh pr create`, `git push`, etc. without disabling `Bash` outright. That closes the actual gh-pr-create vector from the original incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)