### PR TITLE
feat(core): standardize agent label convention on issues + PRs

### DIFF
--- a/.changeset/agent-label-convention.md
+++ b/.changeset/agent-label-convention.md
@@ -1,0 +1,17 @@
+---
+"@sweny-ai/core": minor
+---
+
+Standardize the labels SWEny applies to issues and PRs it files. Old default
+was a single `sweny` label; new default is two-tier: `sweny` (provenance) +
+`agent` (who) + role tag (`task`, `feature`, or `triage`).
+
+- `github_create_pr` now accepts an optional `labels` array. Default when
+  omitted is `["sweny", "agent"]`; callers can pass an explicit set.
+- New `linear_list_labels` skill (id, name, color, team — workspace-wide or
+  scoped to a team) so workflows can resolve label names to `labelIds` at
+  runtime. Aliases to the Linear MCP `list_issue_labels` tool.
+- `triage` workflow: file Linear / GitHub issues with
+  `["sweny", "agent", "triage"]` and PRs with the same set.
+- `implement` workflow: open PRs with `["sweny", "agent", "task"]` (or
+  `["sweny", "agent", "feature"]` for feature requests).

--- a/packages/core/src/skills/github.test.ts
+++ b/packages/core/src/skills/github.test.ts
@@ -112,6 +112,45 @@ describe("github_create_pr", () => {
     );
   });
 
+  it("defaults the label set to [sweny, agent] when caller omits labels", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(201, { number: 7, html_url: "https://github.com/o/r/pull/7" }))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "sweny" }, { name: "agent" }]));
+
+    await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx());
+
+    const labelCall = fetchMock.mock.calls[1];
+    expect(labelCall[0]).toBe("https://api.github.com/repos/o/r/issues/7/labels");
+    expect(JSON.parse(labelCall[1].body)).toEqual({ labels: ["sweny", "agent"] });
+  });
+
+  it("forwards an explicit labels array verbatim", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(201, { number: 8, html_url: "https://github.com/o/r/pull/8" }))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "sweny" }, { name: "agent" }, { name: "triage" }]));
+
+    await createPr.handler(
+      { repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix", labels: ["sweny", "agent", "triage"] },
+      ctx(),
+    );
+
+    const labelCall = fetchMock.mock.calls[1];
+    expect(JSON.parse(labelCall[1].body)).toEqual({ labels: ["sweny", "agent", "triage"] });
+  });
+
+  it("does not relabel a reused PR (idempotent path skips labeling)", async () => {
+    const existingPr = { number: 99, html_url: "https://github.com/o/r/pull/99", state: "open" };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(422, ALREADY_EXISTS_422))
+      .mockResolvedValueOnce(jsonResponse(200, [existingPr]));
+
+    await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx());
+
+    // Exactly two calls: POST /pulls (422) + GET /pulls?head=... (lookup).
+    // No third call to /issues/:n/labels because reused === true.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("propagates the 422 if the existing-PR lookup itself fails", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(422, ALREADY_EXISTS_422))

--- a/packages/core/src/skills/github.ts
+++ b/packages/core/src/skills/github.ts
@@ -143,10 +143,18 @@ export const github: Skill = {
           body: { type: "string" },
           head: { type: "string", description: "Branch with changes" },
           base: { type: "string", description: "Target branch (default: main)" },
+          labels: {
+            type: "array",
+            items: { type: "string" },
+            description: 'Labels to apply (default: ["sweny", "agent"])',
+          },
         },
         required: ["repo", "title", "head"],
       },
-      handler: async (input: { repo: string; title: string; body?: string; head: string; base?: string }, ctx) => {
+      handler: async (
+        input: { repo: string; title: string; body?: string; head: string; base?: string; labels?: string[] },
+        ctx,
+      ) => {
         let pr: { number?: number; html_url?: string } & Record<string, unknown>;
         let reused = false;
         try {
@@ -188,7 +196,7 @@ export const github: Skill = {
           if (pr.number && !reused) {
             await gh(`/repos/${input.repo}/issues/${pr.number}/labels`, ctx, {
               method: "POST",
-              body: JSON.stringify({ labels: ["sweny"] }),
+              body: JSON.stringify({ labels: input.labels ?? ["sweny", "agent"] }),
             });
           }
         } catch {

--- a/packages/core/src/skills/linear.test.ts
+++ b/packages/core/src/skills/linear.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { linear } from "./linear.js";
+import type { ToolContext } from "../types.js";
+
+const ctx = (): ToolContext => ({
+  config: { LINEAR_API_KEY: "test-token" },
+  logger: console,
+});
+
+const listLabels = linear.tools.find((t) => t.name === "linear_list_labels")!;
+
+function gqlResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("linear_list_labels", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("scopes the query to a team when teamId is provided", async () => {
+    fetchMock.mockResolvedValueOnce(
+      gqlResponse({ team: { labels: { nodes: [{ id: "lab_1", name: "agent", color: "#000" }] } } }),
+    );
+
+    const result: any = await listLabels.handler({ teamId: "team_abc" }, ctx());
+
+    expect(result.team.labels.nodes[0]).toMatchObject({ name: "agent" });
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.variables).toEqual({ teamId: "team_abc" });
+    expect(sent.query).toContain("team(id: $teamId)");
+  });
+
+  it("falls back to a workspace-wide query when teamId is omitted", async () => {
+    fetchMock.mockResolvedValueOnce(
+      gqlResponse({
+        issueLabels: {
+          nodes: [
+            { id: "lab_1", name: "sweny", color: "#111", team: { key: "OFF" } },
+            { id: "lab_2", name: "triage", color: "#222", team: { key: "OFF" } },
+          ],
+        },
+      }),
+    );
+
+    const result: any = await listLabels.handler({}, ctx());
+
+    expect(result.issueLabels.nodes).toHaveLength(2);
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.variables).toEqual({});
+    expect(sent.query).toContain("issueLabels");
+  });
+
+  it("is exposed as an alias for the Linear MCP list_issue_labels tool", () => {
+    expect(linear.mcpAliases?.linear_list_labels).toEqual(["list_issue_labels"]);
+  });
+});

--- a/packages/core/src/skills/linear.ts
+++ b/packages/core/src/skills/linear.ts
@@ -149,6 +149,29 @@ export const linear: Skill = {
         ),
     },
     {
+      name: "linear_list_labels",
+      description: "List issue labels for a Linear team — returns id, name, and color for each label",
+      input_schema: {
+        type: "object",
+        properties: {
+          teamId: {
+            type: "string",
+            description: "Linear team ID (optional — returns all workspace labels if omitted)",
+          },
+        },
+      },
+      handler: async (input: { teamId?: string }, ctx) => {
+        if (input.teamId) {
+          return linearGql(
+            `query($teamId: String!) { team(id: $teamId) { labels { nodes { id name color } } } }`,
+            { teamId: input.teamId },
+            ctx,
+          );
+        }
+        return linearGql(`query { issueLabels { nodes { id name color team { key } } } }`, {}, ctx);
+      },
+    },
+    {
       name: "linear_update_issue",
       description: "Update an existing Linear issue",
       input_schema: {
@@ -195,5 +218,6 @@ export const linear: Skill = {
     linear_search_issues: ["list_issues"],
     linear_add_comment: ["save_comment"],
     linear_list_teams: ["list_teams"],
+    linear_list_labels: ["list_issue_labels"],
   },
 };

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -91,7 +91,7 @@ nodes:
 
       3. Reference the original issue in the PR body.
 
-      4. Add appropriate reviewers or labels if possible.
+      4. Pass `labels: ["sweny", "agent", "task"]` to `github_create_pr` (or `["sweny", "agent", "feature"]` if the issue is a feature request).
 
 
       If context.prTemplate is provided, use it as the format for the PR body. Otherwise use a clear structure with:

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -196,7 +196,10 @@ nodes:
 
       3. Include: root cause, severity, affected services, reproduction steps, and recommended fix.
 
-      4. Add appropriate labels (bug, severity level, affected service).
+      4. Apply the `sweny`, `agent`, and `triage` labels. For Linear: call `linear_list_labels` to find the
+      IDs for labels named `sweny`, `agent`, and `triage`, then pass those IDs in `labelIds` when calling
+      `linear_create_issue` (skip any that don't exist in the team — don't invent IDs). For GitHub: pass
+      `labels: ["sweny", "agent", "triage"]` to `github_create_issue`.
 
       5. Link to relevant commits, PRs, or existing issues.
 
@@ -623,7 +626,7 @@ nodes:
       (context.create_issue.issueUrl). If the investigation found a Sentry issue, include "Fixes {sentryShortId}"
       in the PR body so Sentry auto-resolves on merge.
 
-      5. Add appropriate labels if available.
+      5. Pass `labels: ["sweny", "agent", "triage"]` to `github_create_pr`.
 
 
       If context.prTemplate is provided, use it as the format for the PR body. Otherwise use a clear structure with:


### PR DESCRIPTION
## Summary

- Replace single `sweny` label with `sweny` + `agent` + role (`task`, `feature`, or `triage`)
- `github_create_pr` accepts optional `labels` array; default `["sweny", "agent"]`
- New `linear_list_labels` skill returns id/name/color for workspace or a team, aliased to Linear MCP `list_issue_labels`
- `triage` workflow files Linear/GitHub issues + PRs with `["sweny", "agent", "triage"]`
- `implement` workflow opens PRs with `["sweny", "agent", "task"]` (or `feature`)

## Test plan

- [x] `npm run build` in `packages/core`
- [x] `npm run typecheck` in `packages/core`
- [x] `npx vitest run` in `packages/core` (1641 passed)
- [x] New tests cover: labels passthrough, default labels, no-relabel-on-reused-PR (idempotent path), `linear_list_labels` team vs workspace queries, alias mapping
- [ ] Verify via a real triage run that Linear `labelIds` resolution gracefully skips missing labels (workflow instructs the agent to do this; not enforced in code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)