### PR TITLE
feat(core): add --verbose to `workflow run` for human-readable tool call detail

### DIFF
--- a/.changeset/workflow-run-verbose.md
+++ b/.changeset/workflow-run-verbose.md
@@ -1,0 +1,14 @@
+---
+"@sweny-ai/core": minor
+---
+
+Add `--verbose` to `sweny workflow run` (and `verbose: true` to the GitHub
+Action). When set, the CLI prints every tool call's input and output inline
+in a human-readable form (truncated to ~1200 chars per side; use `--stream`
+for the full untruncated NDJSON).
+
+Motivation: when a node fails or routes to `notify_halt`, the default human
+output only shows `✓ node: success (N tool calls)`. The actual tool data
+that drove the routing decision is invisible. `--verbose` makes it
+debuggable from a CI log without re-running with `--stream` and post-
+processing NDJSON.

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
     required: false
     default: "false"
 
+  verbose:
+    description: "When 'true', print each tool call's input and output inline. Truncated for readability; use the CLI's --stream flag locally for full untruncated NDJSON. Helpful for debugging a node that halts or fails."
+    required: false
+    default: "false"
+
   cloud-token:
     description: "SWEny Cloud project token (sweny_pk_...) for reporting run results to cloud.sweny.ai. Optional. Equivalent to setting the SWENY_CLOUD_TOKEN env var; either form is accepted."
     required: false
@@ -75,6 +80,7 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         WORKFLOW_PATH: ${{ inputs.workflow }}
         DRY_RUN: ${{ inputs.dry-run }}
+        VERBOSE: ${{ inputs.verbose }}
         INPUT_CLOUD_TOKEN: ${{ inputs.cloud-token }}
       run: |
         # Forward the cloud token to the CLI. Prefer the explicit `cloud-token`
@@ -84,12 +90,17 @@ runs:
         if [ -n "$INPUT_CLOUD_TOKEN" ]; then
           export SWENY_CLOUD_TOKEN="$INPUT_CLOUD_TOKEN"
         fi
-        # Normalize so dry-run accepts true / TRUE / 1 / yes equivalently.
-        # GitHub Actions usually passes the literal "true"/"false" string,
-        # but workflow YAML can produce other truthy spellings.
-        DRY_NORM=$(echo "${DRY_RUN:-false}" | tr '[:upper:]' '[:lower:]')
-        if [ "$DRY_NORM" = "true" ] || [ "$DRY_NORM" = "1" ] || [ "$DRY_NORM" = "yes" ]; then
-          sweny workflow run "$WORKFLOW_PATH" --dry-run
-        else
-          sweny workflow run "$WORKFLOW_PATH"
-        fi
+        # Normalize boolean-ish inputs (true / TRUE / 1 / yes).
+        normalize() {
+          local v
+          v=$(echo "${1:-false}" | tr '[:upper:]' '[:lower:]')
+          case "$v" in true|1|yes) echo "true" ;; *) echo "false" ;; esac
+        }
+        DRY_NORM=$(normalize "$DRY_RUN")
+        VERBOSE_NORM=$(normalize "$VERBOSE")
+
+        FLAGS=()
+        [ "$DRY_NORM" = "true" ] && FLAGS+=("--dry-run")
+        [ "$VERBOSE_NORM" = "true" ] && FLAGS+=("--verbose")
+
+        sweny workflow run "$WORKFLOW_PATH" "${FLAGS[@]}"

--- a/packages/core/src/cli/__tests__/verbose-observer.test.ts
+++ b/packages/core/src/cli/__tests__/verbose-observer.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createVerboseToolObserver } from "../verbose-observer.js";
+import type { ExecutionEvent } from "../../types.js";
+
+describe("createVerboseToolObserver", () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  function output(): string {
+    return writeSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+  }
+
+  // ANSI color codes are noise for assertions — strip them.
+  function plain(): string {
+    return output().replace(/\x1B\[[0-9;]*m/g, "");
+  }
+
+  it("prints tool:call input to stderr with the tool name", () => {
+    const observe = createVerboseToolObserver();
+    const event: ExecutionEvent = {
+      type: "tool:call",
+      node: "draft",
+      tool: "Bash",
+      input: { command: "ls -la" },
+    };
+    observe(event);
+    const out = plain();
+    expect(out).toContain("Bash");
+    expect(out).toContain("(input)");
+    expect(out).toContain('"command": "ls -la"');
+  });
+
+  it("prints tool:result output to stderr with the tool name", () => {
+    const observe = createVerboseToolObserver();
+    const event: ExecutionEvent = {
+      type: "tool:result",
+      node: "draft",
+      tool: "Read",
+      output: "file contents here",
+    };
+    observe(event);
+    const out = plain();
+    expect(out).toContain("Read");
+    expect(out).toContain("(output)");
+    expect(out).toContain("file contents here");
+  });
+
+  it("truncates long payloads and reports how many chars were dropped", () => {
+    const observe = createVerboseToolObserver();
+    const long = "x".repeat(5_000);
+    observe({ type: "tool:result", node: "draft", tool: "Read", output: long });
+    const out = plain();
+    // Truncation note format: "[3800 more chars]" — exact number isn't load-bearing,
+    // but the suffix should be present and the full 5000 chars should not.
+    expect(out).toMatch(/\[\d+ more chars\]/);
+    expect(out.length).toBeLessThan(long.length);
+  });
+
+  it("survives circular references in tool input/output without throwing", () => {
+    const observe = createVerboseToolObserver();
+    type Cyc = { name: string; self?: unknown };
+    const circular: Cyc = { name: "loop" };
+    circular.self = circular;
+
+    expect(() => observe({ type: "tool:call", node: "draft", tool: "X", input: circular })).not.toThrow();
+    expect(() => observe({ type: "tool:result", node: "draft", tool: "X", output: circular })).not.toThrow();
+
+    // Should fall back to a string representation, not blow up the stream.
+    expect(plain()).toContain("X");
+  });
+
+  it("renders null and undefined as readable tokens", () => {
+    const observe = createVerboseToolObserver();
+    observe({ type: "tool:call", node: "draft", tool: "X", input: null });
+    observe({ type: "tool:result", node: "draft", tool: "X", output: undefined });
+    const out = plain();
+    expect(out).toContain("null");
+    expect(out).toContain("undefined");
+  });
+
+  it("ignores non-tool events", () => {
+    const observe = createVerboseToolObserver();
+    observe({ type: "node:enter", node: "draft", instruction: "do a thing" });
+    observe({ type: "node:exit", node: "draft", result: { status: "success", data: {}, toolCalls: [] } });
+    observe({ type: "workflow:start", workflow: "wf" });
+    observe({ type: "workflow:end", results: {} });
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -34,6 +34,7 @@ import { loadDotenv, loadConfigFile } from "./config-file.js";
 import { buildCredentialMap } from "./credentials.js";
 import { runNew } from "./new.js";
 import { runE2eRun } from "./e2e.js";
+import { createVerboseToolObserver } from "./verbose-observer.js";
 import {
   registerTriageCommand,
   registerImplementCommand,
@@ -77,42 +78,8 @@ function createStreamObserver(): Observer {
   };
 }
 
-// ── Verbose observer (human-readable tool detail) ──────────────────
-/**
- * Create an observer that prints each tool call's input and output to stderr
- * inline, in a human-readable format. Useful when debugging a node that's
- * failing — the default human output only shows step transitions, leaving
- * "why" invisible. Inputs and outputs are truncated to keep the log readable;
- * use `--stream` for the full untruncated NDJSON.
- */
-function createVerboseToolObserver(): Observer {
-  const TRUNCATE = 1200;
-  const truncate = (s: string): string =>
-    s.length > TRUNCATE ? `${s.slice(0, TRUNCATE)}\n      ${chalk.dim(`… [${s.length - TRUNCATE} more chars]`)}` : s;
-  const fmt = (v: unknown): string => {
-    if (v === undefined) return "undefined";
-    if (v === null) return "null";
-    if (typeof v === "string") return v;
-    try {
-      return JSON.stringify(v, null, 2);
-    } catch {
-      return String(v);
-    }
-  };
-  const indent = (s: string): string => s.split("\n").join("\n      ");
-  return (event: ExecutionEvent) => {
-    switch (event.type) {
-      case "tool:call":
-        process.stderr.write(`    ${chalk.dim("→")} ${chalk.cyan(event.tool)} ${chalk.dim("(input)")}\n`);
-        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.input))))}\n`);
-        break;
-      case "tool:result":
-        process.stderr.write(`    ${chalk.dim("←")} ${chalk.cyan(event.tool)} ${chalk.dim("(output)")}\n`);
-        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.output))))}\n`);
-        break;
-    }
-  };
-}
+// Verbose tool-detail observer lives in ./verbose-observer.ts so tests can
+// import it without triggering main.ts's top-level CLI parser.
 
 /** Compose multiple observers into one. */
 function composeObservers(...observers: (Observer | undefined)[]): Observer | undefined {

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -77,6 +77,43 @@ function createStreamObserver(): Observer {
   };
 }
 
+// ── Verbose observer (human-readable tool detail) ──────────────────
+/**
+ * Create an observer that prints each tool call's input and output to stderr
+ * inline, in a human-readable format. Useful when debugging a node that's
+ * failing — the default human output only shows step transitions, leaving
+ * "why" invisible. Inputs and outputs are truncated to keep the log readable;
+ * use `--stream` for the full untruncated NDJSON.
+ */
+function createVerboseToolObserver(): Observer {
+  const TRUNCATE = 1200;
+  const truncate = (s: string): string =>
+    s.length > TRUNCATE ? `${s.slice(0, TRUNCATE)}\n      ${chalk.dim(`… [${s.length - TRUNCATE} more chars]`)}` : s;
+  const fmt = (v: unknown): string => {
+    if (v === undefined) return "undefined";
+    if (v === null) return "null";
+    if (typeof v === "string") return v;
+    try {
+      return JSON.stringify(v, null, 2);
+    } catch {
+      return String(v);
+    }
+  };
+  const indent = (s: string): string => s.split("\n").join("\n      ");
+  return (event: ExecutionEvent) => {
+    switch (event.type) {
+      case "tool:call":
+        process.stderr.write(`    ${chalk.dim("→")} ${chalk.cyan(event.tool)} ${chalk.dim("(input)")}\n`);
+        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.input))))}\n`);
+        break;
+      case "tool:result":
+        process.stderr.write(`    ${chalk.dim("←")} ${chalk.cyan(event.tool)} ${chalk.dim("(output)")}\n`);
+        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.output))))}\n`);
+        break;
+    }
+  };
+}
+
 /** Compose multiple observers into one. */
 function composeObservers(...observers: (Observer | undefined)[]): Observer | undefined {
   const valid = observers.filter((o): o is Observer => o != null);
@@ -696,7 +733,7 @@ export function loadWorkflowFile(filePath: string, knownSkills?: Set<string>): W
 
 export async function workflowRunAction(
   file: string,
-  options: Record<string, unknown> & { json?: boolean; stream?: boolean; mermaid?: boolean },
+  options: Record<string, unknown> & { json?: boolean; stream?: boolean; mermaid?: boolean; verbose?: boolean },
 ): Promise<void> {
   // Discover skills first so the loader can flag UNKNOWN_SKILL at parse
   // time. validateWorkflowSkills below still runs for richer category /
@@ -872,6 +909,7 @@ export async function workflowRunAction(
 
   const observer = composeObservers(
     wfProgressObserver,
+    options.verbose ? createVerboseToolObserver() : undefined,
     options.stream ? createStreamObserver() : undefined,
     createCloudStreamObserver(config, wfCloudHandle),
   );
@@ -991,6 +1029,10 @@ workflowCmd
   )
   .option("--json", "Output result as JSON on stdout; suppress progress output")
   .option("--stream", "Stream NDJSON events to stdout (for Studio / automation)")
+  .option(
+    "--verbose",
+    "Print each tool call's input and output inline (human-readable, truncated). Use --stream for full untruncated NDJSON.",
+  )
   .option("--mermaid", "Output a Mermaid diagram with execution state after run")
   .option("--input <json>", "JSON string of input data to pass to the workflow")
   .action(workflowRunAction);

--- a/packages/core/src/cli/verbose-observer.ts
+++ b/packages/core/src/cli/verbose-observer.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+
+import type { ExecutionEvent, Observer } from "../types.js";
+
+const TRUNCATE = 1200;
+
+function truncate(s: string): string {
+  return s.length > TRUNCATE
+    ? `${s.slice(0, TRUNCATE)}\n      ${chalk.dim(`… [${s.length - TRUNCATE} more chars]`)}`
+    : s;
+}
+
+function fmt(v: unknown): string {
+  if (v === undefined) return "undefined";
+  if (v === null) return "null";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function indent(s: string): string {
+  return s.split("\n").join("\n      ");
+}
+
+/**
+ * Create an observer that prints each tool call's input and output to stderr
+ * inline, in a human-readable format. Useful when debugging a node that's
+ * failing — the default human output only shows step transitions, leaving
+ * "why" invisible. Inputs and outputs are truncated to keep the log readable;
+ * use `--stream` for the full untruncated NDJSON.
+ */
+export function createVerboseToolObserver(): Observer {
+  return (event: ExecutionEvent) => {
+    switch (event.type) {
+      case "tool:call":
+        process.stderr.write(`    ${chalk.dim("→")} ${chalk.cyan(event.tool)} ${chalk.dim("(input)")}\n`);
+        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.input))))}\n`);
+        break;
+      case "tool:result":
+        process.stderr.write(`    ${chalk.dim("←")} ${chalk.cyan(event.tool)} ${chalk.dim("(output)")}\n`);
+        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.output))))}\n`);
+        break;
+    }
+  };
+}


### PR DESCRIPTION
## Why

When a workflow node halts or routes unexpectedly, the default CLI output reports `✓ node: success (N tool calls)` and that's it. The actual tool inputs and outputs that drove the routing decision are invisible. Anyone running outside Studio (GitHub Action users, locally without `--stream`) can't see why a node returned the status it did.

Motivating case: a release notes Sweny workflow ([example run](https://github.com/letsoffload/offload/actions/runs/25746309709)) where `validate → notify_halt` fired repeatedly. The Action log only showed the status transitions, not which `checks[]` entries returned `status: fail`. With `--verbose` (or `verbose: true` on the action), the next run would surface that data inline.

## What

- `--verbose` on `sweny workflow run`: prints each `tool:call` (input) and `tool:result` (output) to stderr inline, in a human-readable form. Truncated to ~1200 chars per side; pair with `--stream` if you need the full untruncated payload.
- `verbose: true` GitHub Action input that forwards to the CLI flag. Defaults `false`.
- Action's run step refactored to compose flags into an array so future boolean flags don't bloat the if/else.

## Verification

```
$ sweny workflow run --help
Usage: sweny workflow run [options] <file>
...
  --verbose       Print each tool call's input and output inline
                  (human-readable, truncated). Use --stream for full
                  untruncated NDJSON.
```

- `yarn workspace @sweny-ai/core typecheck`: clean
- `yarn workspace @sweny-ai/core test --run`: 1623 pass, 2 pre-existing failures on `main` (`workflow-yaml.test.ts` snapshot drift, not touched here)
- `yarn lint`: 0 errors, 1665 pre-existing warnings
- Build succeeds; `node dist/cli/main.js workflow run --help` shows the new option

## Test plan

- [ ] Run any workflow locally with `--verbose` and confirm each tool call's input/output appears inline.
- [ ] Run the action with `verbose: true` and confirm the GHA log shows tool detail; with `false`, log should be unchanged.

## Scope

Scoped to `workflow run`. Triage (`sweny triage`) and implement (`sweny implement`) paths have their own observer chains; happy to extend if useful, but kept tight here to limit blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)