### PR TITLE
fix(core): --verbose now covers built-in tools (Bash, Read, Edit)

### DIFF
--- a/.changeset/verbose-built-in-tools.md
+++ b/.changeset/verbose-built-in-tools.md
@@ -1,0 +1,15 @@
+---
+"@sweny-ai/core": patch
+---
+
+`--verbose` now prints tool calls for the agent's built-in tools (Bash,
+Read, Edit, Write, etc.) in addition to skill-registered tools. Previously
+the verbose observer only fired on `tool:call` / `tool:result` events,
+which are emitted only for skill tools in `executor.ts`. Built-in tools
+come via the Claude Code subprocess stream and land in `result.toolCalls`
+on node:exit, so they never produced events.
+
+Re-emission strategy: print all `result.toolCalls` on `node:exit` rather
+than per-event. This trades liveness for completeness, which is the right
+call for the debugging use case: you want the full picture after the node
+runs, not partial visibility per call.

--- a/packages/core/src/cli/__tests__/verbose-observer.test.ts
+++ b/packages/core/src/cli/__tests__/verbose-observer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { createVerboseToolObserver } from "../verbose-observer.js";
-import type { ExecutionEvent } from "../../types.js";
+import type { ExecutionEvent, ToolCall } from "../../types.js";
 
 describe("createVerboseToolObserver", () => {
   let writeSpy: ReturnType<typeof vi.spyOn>;
@@ -18,48 +18,49 @@ describe("createVerboseToolObserver", () => {
     return writeSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
   }
 
-  // ANSI color codes are noise for assertions — strip them.
+  // ANSI color codes are noise for assertions; strip them.
   function plain(): string {
     return output().replace(/\x1B\[[0-9;]*m/g, "");
   }
 
-  it("prints tool:call input to stderr with the tool name", () => {
-    const observe = createVerboseToolObserver();
-    const event: ExecutionEvent = {
-      type: "tool:call",
-      node: "draft",
-      tool: "Bash",
-      input: { command: "ls -la" },
+  function nodeExit(node: string, toolCalls: ToolCall[]): ExecutionEvent {
+    return {
+      type: "node:exit",
+      node,
+      result: { status: "success", data: {}, toolCalls },
     };
-    observe(event);
+  }
+
+  it("prints each tool call's input and output on node:exit", () => {
+    const observe = createVerboseToolObserver();
+    observe(
+      nodeExit("draft", [
+        { tool: "Bash", input: { command: "ls -la" }, output: "file1\nfile2\n", status: "success" },
+        { tool: "Read", input: { path: "/etc/hosts" }, output: "127.0.0.1 localhost", status: "success" },
+      ]),
+    );
     const out = plain();
+    expect(out).toContain("draft: 2 tool calls");
     expect(out).toContain("Bash");
-    expect(out).toContain("(input)");
     expect(out).toContain('"command": "ls -la"');
+    expect(out).toContain("file1");
+    expect(out).toContain("Read");
+    expect(out).toContain("/etc/hosts");
   });
 
-  it("prints tool:result output to stderr with the tool name", () => {
+  it("flags error outputs distinctly", () => {
     const observe = createVerboseToolObserver();
-    const event: ExecutionEvent = {
-      type: "tool:result",
-      node: "draft",
-      tool: "Read",
-      output: "file contents here",
-    };
-    observe(event);
-    const out = plain();
-    expect(out).toContain("Read");
-    expect(out).toContain("(output)");
-    expect(out).toContain("file contents here");
+    observe(
+      nodeExit("guardrails", [{ tool: "Bash", input: { command: "bad" }, output: { error: "boom" }, status: "error" }]),
+    );
+    expect(plain()).toContain("(output, error)");
   });
 
   it("truncates long payloads and reports how many chars were dropped", () => {
     const observe = createVerboseToolObserver();
     const long = "x".repeat(5_000);
-    observe({ type: "tool:result", node: "draft", tool: "Read", output: long });
+    observe(nodeExit("draft", [{ tool: "Read", input: { path: "/big" }, output: long, status: "success" }]));
     const out = plain();
-    // Truncation note format: "[3800 more chars]" — exact number isn't load-bearing,
-    // but the suffix should be present and the full 5000 chars should not.
     expect(out).toMatch(/\[\d+ more chars\]/);
     expect(out.length).toBeLessThan(long.length);
   });
@@ -70,28 +71,31 @@ describe("createVerboseToolObserver", () => {
     const circular: Cyc = { name: "loop" };
     circular.self = circular;
 
-    expect(() => observe({ type: "tool:call", node: "draft", tool: "X", input: circular })).not.toThrow();
-    expect(() => observe({ type: "tool:result", node: "draft", tool: "X", output: circular })).not.toThrow();
-
-    // Should fall back to a string representation, not blow up the stream.
+    expect(() => observe(nodeExit("draft", [{ tool: "X", input: circular, output: circular }]))).not.toThrow();
     expect(plain()).toContain("X");
   });
 
   it("renders null and undefined as readable tokens", () => {
     const observe = createVerboseToolObserver();
-    observe({ type: "tool:call", node: "draft", tool: "X", input: null });
-    observe({ type: "tool:result", node: "draft", tool: "X", output: undefined });
+    observe(nodeExit("draft", [{ tool: "X", input: null, output: undefined }]));
     const out = plain();
     expect(out).toContain("null");
     expect(out).toContain("undefined");
   });
 
-  it("ignores non-tool events", () => {
+  it("is silent for nodes that made no tool calls", () => {
+    const observe = createVerboseToolObserver();
+    observe(nodeExit("analyze", []));
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-node:exit events", () => {
     const observe = createVerboseToolObserver();
     observe({ type: "node:enter", node: "draft", instruction: "do a thing" });
-    observe({ type: "node:exit", node: "draft", result: { status: "success", data: {}, toolCalls: [] } });
     observe({ type: "workflow:start", workflow: "wf" });
     observe({ type: "workflow:end", results: {} });
+    observe({ type: "tool:call", node: "draft", tool: "Read", input: {} });
+    observe({ type: "tool:result", node: "draft", tool: "Read", output: "x" });
     expect(writeSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/cli/verbose-observer.ts
+++ b/packages/core/src/cli/verbose-observer.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 
-import type { ExecutionEvent, Observer } from "../types.js";
+import type { ExecutionEvent, Observer, ToolCall } from "../types.js";
 
 const TRUNCATE = 1200;
 
@@ -25,24 +25,41 @@ function indent(s: string): string {
   return s.split("\n").join("\n      ");
 }
 
+function printCall(call: ToolCall): void {
+  process.stderr.write(`    ${chalk.dim("→")} ${chalk.cyan(call.tool)} ${chalk.dim("(input)")}\n`);
+  process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(call.input))))}\n`);
+  const status = call.status === "error" ? chalk.red("(output, error)") : chalk.dim("(output)");
+  process.stderr.write(`    ${chalk.dim("←")} ${chalk.cyan(call.tool)} ${status}\n`);
+  process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(call.output))))}\n`);
+}
+
 /**
  * Create an observer that prints each tool call's input and output to stderr
- * inline, in a human-readable format. Useful when debugging a node that's
- * failing — the default human output only shows step transitions, leaving
- * "why" invisible. Inputs and outputs are truncated to keep the log readable;
- * use `--stream` for the full untruncated NDJSON.
+ * in a human-readable form. Useful when debugging a node that fails or routes
+ * unexpectedly — the default human output only shows step transitions,
+ * leaving "why" invisible.
+ *
+ * Emission strategy: print the full call list on `node:exit` rather than per
+ * `tool:call`/`tool:result` event. The reason: the executor's tool:call and
+ * tool:result events fire only for skill-registered tools, not for the
+ * Claude Code subprocess's built-in tools (Bash, Read, Edit, etc.). Those
+ * built-in tools — the ones agents actually use most — land in
+ * `result.toolCalls` only after the node completes. Walking result.toolCalls
+ * on node:exit covers both kinds and avoids partial visibility.
+ *
+ * Inputs and outputs are truncated; use `--stream` for full untruncated
+ * NDJSON.
  */
 export function createVerboseToolObserver(): Observer {
   return (event: ExecutionEvent) => {
-    switch (event.type) {
-      case "tool:call":
-        process.stderr.write(`    ${chalk.dim("→")} ${chalk.cyan(event.tool)} ${chalk.dim("(input)")}\n`);
-        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.input))))}\n`);
-        break;
-      case "tool:result":
-        process.stderr.write(`    ${chalk.dim("←")} ${chalk.cyan(event.tool)} ${chalk.dim("(output)")}\n`);
-        process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(event.output))))}\n`);
-        break;
+    if (event.type !== "node:exit") return;
+    const calls = event.result.toolCalls;
+    if (calls.length === 0) return;
+    process.stderr.write(
+      `    ${chalk.bold.dim(`${event.node}: ${calls.length} tool call${calls.length === 1 ? "" : "s"}`)}\n`,
+    );
+    for (const call of calls) {
+      printCall(call);
     }
   };
 }


### PR DESCRIPTION
## Why

In #194 the verbose observer fired on \`tool:call\` / \`tool:result\` events. Turns out the executor only emits those events for **skill-registered tools** (Linear, GitHub, Slack, etc. via \`trackedTools\` in \`executor.ts\`). The agent's **built-in tools** (Bash, Read, Edit, Write, etc.) come from the Claude Code subprocess stream and only land in \`result.toolCalls\` on \`node:exit\` — no per-call events are emitted.

Net effect: \`--verbose\` was silent in the most common case. First field test: [offload run](https://github.com/letsoffload/offload/actions/runs/25758054347) where the validate node's Bash invocation of a checklist script was exactly what we wanted to see, and verbose produced zero output.

## What

Switch the verbose observer to emit on \`node:exit\` by walking \`result.toolCalls\`. Covers every kind of tool the agent invoked. Trade-off: live-during-node visibility for end-of-node completeness. For the debugging use case (figuring out why a node failed or routed unexpectedly) completeness wins — partial visibility was worse than not-yet-implemented because it hid the gap.

\`\`\`
draft: 7 tool calls
    → Bash (input)
      { "command": "cat apps/user-docs/content/release-notes/_meta.js" }
    ← Bash (output)
      export default { … }
    → Bash (input)
      { "command": "node apps/user-docs/scripts/quality-checklist.mjs …" }
    ← Bash (output)
      { "checks": [ … ], "failed": 3 }
    …
\`\`\`

## Tests

Updated \`verbose-observer.test.ts\` (7 cases, all green):
- emits per node:exit
- flags \`status: \"error\"\` outputs distinctly
- truncation behavior
- circular-reference safety
- null / undefined formatting
- silent when no tool calls
- silent for non-node:exit events (including stray tool:call / tool:result)

## Notes

If someone genuinely wants live-during-node tool visibility we can add it later by plumbing the observer into \`claude.ts\`'s stream handler. That's a larger change; not needed for the debugging use case this flag was built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)