### PR TITLE
fix(core): --verbose prints result.data, raise truncation to 4000

### DIFF
--- a/.changeset/verbose-data-and-truncation.md
+++ b/.changeset/verbose-data-and-truncation.md
@@ -1,0 +1,20 @@
+---
+"@sweny-ai/core": patch
+---
+
+`--verbose` improvements driven by a real debugging session where the
+existing output was almost-but-not-quite enough.
+
+1. Print `result.data` (the node's structured output) on `node:exit`.
+   Without this, a node returning `{ status: "fail" }` despite every
+   inspected tool call succeeding looks like a paradox. With it, you can
+   see the node emitted the wrong field and root-cause the routing
+   decision.
+2. Raise the default truncation from 1200 to 4000 chars. A 14-item
+   validation checklist JSON exceeds 1200 and the cut hides the bottom
+   summary (`passed`/`failed` totals) which is the most actionable part.
+3. New `SWENY_VERBOSE_TRUNCATE` env var for ad-hoc bumps without a code
+   change.
+
+Both kinds of tools (skill-registered AND Claude Code built-ins) remain
+covered via `result.toolCalls` on `node:exit`.

--- a/packages/core/src/cli/__tests__/verbose-observer.test.ts
+++ b/packages/core/src/cli/__tests__/verbose-observer.test.ts
@@ -23,11 +23,11 @@ describe("createVerboseToolObserver", () => {
     return output().replace(/\x1B\[[0-9;]*m/g, "");
   }
 
-  function nodeExit(node: string, toolCalls: ToolCall[]): ExecutionEvent {
+  function nodeExit(node: string, toolCalls: ToolCall[], data: Record<string, unknown> = {}): ExecutionEvent {
     return {
       type: "node:exit",
       node,
-      result: { status: "success", data: {}, toolCalls },
+      result: { status: "success", data, toolCalls },
     };
   }
 
@@ -83,10 +83,35 @@ describe("createVerboseToolObserver", () => {
     expect(out).toContain("undefined");
   });
 
-  it("is silent for nodes that made no tool calls", () => {
+  it("is silent for nodes with no tool calls and no data", () => {
     const observe = createVerboseToolObserver();
     observe(nodeExit("analyze", []));
     expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints structured output (result.data) on node:exit", () => {
+    const observe = createVerboseToolObserver();
+    observe(nodeExit("validate", [], { status: "fail", checks: [{ name: "x", status: "pass" }], passed: 14 }));
+    const out = plain();
+    expect(out).toContain("validate: output");
+    expect(out).toContain('"status": "fail"');
+    expect(out).toContain('"passed": 14');
+  });
+
+  it("prints both tool calls and structured output when both are present", () => {
+    const observe = createVerboseToolObserver();
+    observe(
+      nodeExit(
+        "validate",
+        [{ tool: "Bash", input: { command: "node script.mjs" }, output: '{"failed":0}', status: "success" }],
+        { status: "pass" },
+      ),
+    );
+    const out = plain();
+    expect(out).toContain("validate: 1 tool call");
+    expect(out).toContain("Bash");
+    expect(out).toContain("validate: output");
+    expect(out).toContain('"status": "pass"');
   });
 
   it("ignores non-node:exit events", () => {

--- a/packages/core/src/cli/verbose-observer.ts
+++ b/packages/core/src/cli/verbose-observer.ts
@@ -1,8 +1,11 @@
 import chalk from "chalk";
 
-import type { ExecutionEvent, Observer, ToolCall } from "../types.js";
+import type { ExecutionEvent, NodeResult, Observer, ToolCall } from "../types.js";
 
-const TRUNCATE = 1200;
+// Default truncation, large enough to fit a 14-item validation checklist JSON
+// without losing the bottom (passed/failed totals). Overridable via env var
+// for ad-hoc debugging when even this isn't enough.
+const TRUNCATE = Number.parseInt(process.env.SWENY_VERBOSE_TRUNCATE ?? "4000", 10) || 4000;
 
 function truncate(s: string): string {
   return s.length > TRUNCATE
@@ -33,33 +36,39 @@ function printCall(call: ToolCall): void {
   process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(call.output))))}\n`);
 }
 
+function printData(node: string, data: NodeResult["data"]): void {
+  if (!data || Object.keys(data).length === 0) return;
+  process.stderr.write(`    ${chalk.bold.dim(`${node}: output`)}\n`);
+  process.stderr.write(`      ${chalk.dim(indent(truncate(fmt(data))))}\n`);
+}
+
 /**
- * Create an observer that prints each tool call's input and output to stderr
- * in a human-readable form. Useful when debugging a node that fails or routes
- * unexpectedly — the default human output only shows step transitions,
- * leaving "why" invisible.
+ * Create an observer that prints, on `node:exit`:
+ *   1. Every tool call's input and output (truncated).
+ *   2. The node's structured output (`result.data`) — the payload that
+ *      conditional edges route on. Without this, "validate → notify_halt"
+ *      with no failing checks looks like a paradox; with it, you can see
+ *      that the node emitted `{ status: "fail" }` and root-cause the wrong
+ *      decision.
  *
- * Emission strategy: print the full call list on `node:exit` rather than per
- * `tool:call`/`tool:result` event. The reason: the executor's tool:call and
- * tool:result events fire only for skill-registered tools, not for the
- * Claude Code subprocess's built-in tools (Bash, Read, Edit, etc.). Those
- * built-in tools — the ones agents actually use most — land in
- * `result.toolCalls` only after the node completes. Walking result.toolCalls
- * on node:exit covers both kinds and avoids partial visibility.
+ * Both kinds of tools are covered (skill-registered AND Claude Code's
+ * built-in Bash/Read/Edit/Write), because `result.toolCalls` is populated
+ * after the node completes regardless of how the call was dispatched.
  *
- * Inputs and outputs are truncated; use `--stream` for full untruncated
- * NDJSON.
+ * Truncation defaults to 4000 chars per side. Override with the
+ * `SWENY_VERBOSE_TRUNCATE` env var for ad-hoc debugging. Use `--stream` for
+ * the full untruncated NDJSON.
  */
 export function createVerboseToolObserver(): Observer {
   return (event: ExecutionEvent) => {
     if (event.type !== "node:exit") return;
     const calls = event.result.toolCalls;
-    if (calls.length === 0) return;
-    process.stderr.write(
-      `    ${chalk.bold.dim(`${event.node}: ${calls.length} tool call${calls.length === 1 ? "" : "s"}`)}\n`,
-    );
-    for (const call of calls) {
-      printCall(call);
+    if (calls.length > 0) {
+      process.stderr.write(
+        `    ${chalk.bold.dim(`${event.node}: ${calls.length} tool call${calls.length === 1 ? "" : "s"}`)}\n`,
+      );
+      for (const call of calls) printCall(call);
     }
+    printData(event.node, event.result.data);
   };
 }


### PR DESCRIPTION
## Why

Followups from the field test of #195. The output is closer to useful but still hides the actionable bits.

**Symptom**: a release-notes workflow halted at \`notify_halt\` after multiple validate↔draft retries. With #195's verbose mode I could finally see Bash tool calls, but:

1. The script's full JSON output was truncated mid-checklist (1200-char cap), hiding the \`{ "passed": 14, "failed": 0 }\` summary at the bottom.
2. The visible checks were all \`pass\`, but validate still routed to \`draft\` (status: fail). Verbose printed tool I/O but not the node's structured output, so the disconnect between "script says pass" and "node emits fail" was invisible.

## What

1. **Print \`result.data\` on \`node:exit\`** alongside tool calls. \`result.data\` is the node's structured output — the payload conditional edges route on. Now you can see "\`validate: output { status: fail, passed: 14, failed: 0 }\`" and know the agent's status decision is the bug, not the script.
2. **Raise default truncation: 1200 → 4000**. Empirically 1200 hides the bottom of typical CLI tool outputs; 4000 fits a 14-item checklist JSON with room.
3. **New \`SWENY_VERBOSE_TRUNCATE\` env var** for ad-hoc bumps without code changes.

## Sample output

\`\`\`
    validate: 1 tool call
    → Bash (input)
      { "command": "node script.mjs ..." }
    ← Bash (output)
      {
        "checks": [ ... 14 items ... ],
        "passed": 14,
        "failed": 0,
        "total": 14
      }
    validate: output
      {
        "status": "fail",
        "checks": [...],
        "quality_retry_count": 2
      }
\`\`\`

The mismatch jumps out immediately.

## Tests

\`yarn vitest run src/cli/__tests__/verbose-observer.test.ts\` → 9 cases, all green. Added:
- data-only emission (no tool calls)
- combined emission (tool calls + data)
- existing 7 cases continue to pass

## Notes

Skill tool calls also benefit since their I/O often crosses 1200 chars too. No semantic change beyond the higher default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)