### PR TITLE
fix(core): scope route eval to declared output schema fields

### DIFF
--- a/.changeset/route-eval-schema-strict.md
+++ b/.changeset/route-eval-schema-strict.md
@@ -1,0 +1,33 @@
+---
+"@sweny-ai/core": patch
+---
+
+Stop non-schema fields from biasing natural-language route decisions.
+
+The LLM route evaluator was seeing every key on a prior node's `result.data`,
+including prose narrative fields (the always-injected `summary` from the
+reference Claude client, free-form rationale, internal commentary). On at
+least one production run, a node correctly emitted `status: "pass"` but
+also added a `summary` mentioning retries, and the evaluator pattern-matched
+the retry mention to flip the routing decision. The workflow halted at a
+notify_halt node despite every actual check passing.
+
+Field run: https://github.com/letsoffload/offload/actions/runs/25775301135
+
+Fix. When a node declares an `output` schema with a `properties` block, the
+route-evaluator's view of that node's data is now restricted to those
+declared properties. The declared schema is the routing contract; non-schema
+fields stay out of the decision. Nodes without an `output` schema keep the
+prior behavior (full data view).
+
+The downstream node prompt is untouched. `run()` still sees the full prior
+`data` including prose narrative, so workflows that consume narrative in
+later steps keep working.
+
+Belt-and-suspenders: the `evaluate()` prompt now explicitly instructs the
+model to match conditions against structured fields and ignore prose
+fields. This helps in the no-schema fallback case.
+
+All bundled workflows audited; every conditional-edge source node already
+declared an `output` schema with the routing fields as declared properties.
+Zero behavior change for triage, implement, seed-content.

--- a/packages/core/src/__tests__/claude.test.ts
+++ b/packages/core/src/__tests__/claude.test.ts
@@ -885,3 +885,62 @@ describe("summarizeToolError", () => {
     expect(summarizeToolError(42)).toBe("42");
   });
 });
+
+// ─── buildEvaluatePrompt: route eval prompt body ─────────────────
+//
+// The routing brittleness fix has two halves. The structural half lives
+// in executor.ts (schema-strict filtering of the prior-data view). The
+// belt-and-suspenders half is the evaluate() prompt body, which the LLM
+// route evaluator sees on every routing decision. Without these tests,
+// the prompt rules could be deleted by accident and every routing test
+// in executor.test.ts would still pass (they stub `claude.evaluate` and
+// never exercise the prompt body).
+
+describe("buildEvaluatePrompt", () => {
+  it("includes the user question, context JSON, and choice list", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    const prompt = buildEvaluatePrompt("Which condition is true?", { validate: { status: "pass" } }, [
+      { id: "publish", description: "status is pass" },
+      { id: "retry", description: "status is fail" },
+    ]);
+    expect(prompt).toContain("Which condition is true?");
+    expect(prompt).toContain('"status": "pass"');
+    expect(prompt).toContain('- "publish": status is pass');
+    expect(prompt).toContain('- "retry": status is fail');
+  });
+
+  it("instructs the model to match against structured fields, not prose", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    const prompt = buildEvaluatePrompt("Q?", {}, [{ id: "a", description: "x" }]);
+    // The exact wording is part of the routing contract. If you change it,
+    // bump this assertion deliberately and explain why in the diff.
+    expect(prompt).toMatch(/match.*against the structured fields/i);
+    expect(prompt).toMatch(/ignore prose narrative fields/i);
+    expect(prompt).toMatch(/trust the field'?s value/i);
+  });
+
+  it("calls out 'summary' specifically so the model recognizes the common pollution case", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    // The reference ClaudeClient.run() always injects `summary: response`
+    // alongside parsed output. Naming `summary` in the rules anchors the
+    // model on the actual field that drove the field-run regression
+    // (https://github.com/letsoffload/offload/actions/runs/25775301135).
+    const prompt = buildEvaluatePrompt("Q?", {}, [{ id: "a", description: "x" }]);
+    expect(prompt).toContain('"summary"');
+  });
+
+  it("ends with a terminal directive to return only the choice ID", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    const prompt = buildEvaluatePrompt("Q?", {}, [{ id: "a", description: "x" }]);
+    expect(prompt.trim().endsWith("Respond with ONLY the choice ID, nothing else.")).toBe(true);
+  });
+
+  it("handles empty context and empty choice list without throwing", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    // Edge case: defensive. The executor never calls evaluate() with zero
+    // choices in practice (resolveNext short-circuits when there's a
+    // single outbound edge), but the pure builder shouldn't crash either.
+    expect(() => buildEvaluatePrompt("Q?", {}, [])).not.toThrow();
+    expect(() => buildEvaluatePrompt("Q?", { a: 1 }, [])).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -2327,4 +2327,252 @@ describe("route evaluator: schema-strict view of prior data", () => {
     const openView = routeContext.open as Record<string, unknown>;
     expect(openView).toHaveProperty("freeform", "all good here");
   });
+
+  it("passes nested object values through unchanged (top-level routing contract only)", async () => {
+    // The strict filter is top-level only. If a declared property is itself
+    // an object, its inner fields ride along. This is by design: the
+    // routing contract is "the keys I declared", not "deep schema
+    // validation". Pin the behavior so a future refactor doesn't silently
+    // start deep-filtering and break workflows that route on nested data.
+    const workflow: Workflow = {
+      id: "nested-passthrough",
+      name: "Nested Passthrough",
+      description: "",
+      entry: "decide",
+      nodes: {
+        decide: {
+          name: "Decide",
+          instruction: "Decide",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              outcome: { type: "object" },
+              status: { type: "string" },
+            },
+          },
+        },
+        a: { name: "A", instruction: "A", skills: [] },
+        b: { name: "B", instruction: "B", skills: [] },
+      },
+      edges: [
+        { from: "decide", to: "a", when: "outcome.kind is approved" },
+        { from: "decide", to: "b", when: "outcome.kind is rejected" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: {
+            outcome: { kind: "approved", reviewer: "alice", notes: "free-form prose buried here" },
+            status: "ok",
+            stripped_top_level: "should not appear in routing view",
+          },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const decideView = routeContext.decide as Record<string, unknown>;
+    expect(decideView).toHaveProperty("outcome");
+    expect(decideView).toHaveProperty("status", "ok");
+    expect(decideView).not.toHaveProperty("stripped_top_level");
+    // Nested fields under a declared property pass through intact.
+    const outcome = decideView.outcome as Record<string, unknown>;
+    expect(outcome).toHaveProperty("kind", "approved");
+    expect(outcome).toHaveProperty("reviewer", "alice");
+    expect(outcome).toHaveProperty("notes");
+  });
+
+  it("filters by `properties` keys regardless of whether they appear in `required`", async () => {
+    // `required` and `properties` are independent in JSON Schema. The
+    // routing contract uses `properties` keys (the field exists in the
+    // schema, even if optional). An optional-but-emitted field is
+    // present; an undeclared field is absent.
+    const workflow: Workflow = {
+      id: "required-vs-properties",
+      name: "Required vs Properties",
+      description: "",
+      entry: "check",
+      nodes: {
+        check: {
+          name: "Check",
+          instruction: "Check",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+              note: { type: "string" },
+            },
+            required: ["status"], // note is optional
+          },
+        },
+        done: { name: "Done", instruction: "Done", skills: [] },
+        skip: { name: "Skip", instruction: "Skip", skills: [] },
+      },
+      // Two conditional edges so resolveNext actually calls evaluate()
+      // and we can inspect the route context.
+      edges: [
+        { from: "check", to: "done", when: "status is ok" },
+        { from: "check", to: "skip", when: "status is not ok" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: {
+            status: "ok",
+            note: "optional field, present", // declared as optional, emitted
+            extra: "undeclared, should be filtered out",
+          },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const checkView = routeContext.check as Record<string, unknown>;
+    expect(checkView).toHaveProperty("status", "ok");
+    expect(checkView).toHaveProperty("note", "optional field, present");
+    expect(checkView).not.toHaveProperty("extra");
+  });
+
+  it("applies the routing-view filter per source node, not globally", async () => {
+    // Two prior nodes, each with its own output schema. When a later node
+    // fans out conditional edges, each prior must be filtered using THAT
+    // node's declared properties, not the union or any other node's schema.
+    const workflow: Workflow = {
+      id: "per-source-filtering",
+      name: "Per-Source Filtering",
+      description: "",
+      entry: "first",
+      nodes: {
+        first: {
+          name: "First",
+          instruction: "First",
+          skills: [],
+          output: { type: "object", properties: { a_status: { type: "string" } } },
+        },
+        second: {
+          name: "Second",
+          instruction: "Second",
+          skills: [],
+          output: { type: "object", properties: { b_count: { type: "number" } } },
+        },
+        a: { name: "A", instruction: "A", skills: [] },
+        b: { name: "B", instruction: "B", skills: [] },
+      },
+      edges: [
+        { from: "first", to: "second" },
+        { from: "second", to: "a", when: "b_count > 0" },
+        { from: "second", to: "b", when: "b_count is 0" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run(opts: any) {
+        if (opts.instruction.includes("First")) {
+          return {
+            status: "success",
+            data: { a_status: "ok", a_extra_prose: "should be filtered" },
+            toolCalls: [],
+          };
+        }
+        return {
+          status: "success",
+          data: { b_count: 3, b_extra_prose: "also filtered" },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const firstView = routeContext.first as Record<string, unknown>;
+    const secondView = routeContext.second as Record<string, unknown>;
+    expect(firstView).toEqual({ a_status: "ok" });
+    expect(secondView).toEqual({ b_count: 3 });
+  });
+});
+
+// ─── Bundled workflows: routing contract invariants ──────────────
+//
+// Enforce the audit claim in PR #197 with a test: every conditional-edge
+// source node in the bundled workflows must declare an `output` schema
+// with a non-empty `properties` block, so the routing decision is driven
+// by an explicit contract rather than whatever the agent improvises.
+//
+// Without this test the audit is only as good as the moment it was done.
+// A future workflow author who adds a conditional edge but forgets the
+// output schema would silently fall back to the full-data routing view
+// and resurrect the field-bug class.
+
+describe("bundled workflows: routing contract invariants", () => {
+  it("every conditional-edge source node declares an output schema with properties", async () => {
+    const { triageWorkflow, implementWorkflow, seedContentWorkflow } = await import("../workflows/index.js");
+    const workflows: Array<[string, Workflow]> = [
+      ["triage", triageWorkflow],
+      ["implement", implementWorkflow],
+      ["seed-content", seedContentWorkflow],
+    ];
+
+    const violations: string[] = [];
+
+    for (const [name, wf] of workflows) {
+      const conditionalSources = new Set<string>();
+      for (const edge of wf.edges) {
+        if (edge.when) conditionalSources.add(edge.from);
+      }
+      for (const src of conditionalSources) {
+        const node = wf.nodes[src];
+        if (!node) {
+          violations.push(`${name}: edge references undefined node '${src}'`);
+          continue;
+        }
+        const out = (node as { output?: Record<string, unknown> }).output;
+        if (!out || typeof out !== "object") {
+          violations.push(`${name}: conditional-edge source '${src}' has no output schema`);
+          continue;
+        }
+        const props = out.properties as Record<string, unknown> | undefined;
+        if (!props || typeof props !== "object" || Object.keys(props).length === 0) {
+          violations.push(`${name}: conditional-edge source '${src}' output schema has no properties block`);
+        }
+      }
+    }
+
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
 });

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -2028,3 +2028,303 @@ describe("executor", () => {
     });
   });
 });
+
+// ─── Route evaluator: schema-strict view of prior data ───────────
+//
+// Regression suite for the routing brittleness fix.
+//
+// Field run: https://github.com/letsoffload/offload/actions/runs/25775301135.
+// A `validate` node declared an output schema with
+// `{ status: "pass" | "fail", quality_retry_count, checks }`. The agent
+// emitted `status: "pass"` correctly AND added a non-schema `summary` prose
+// field like "the quality_retry_count from the draft node's context is 1".
+// The route evaluator pattern-matched the retry mention in `summary` and
+// chose the fail/retry edge across multiple iterations, halting the run
+// at notify_halt despite every actual check passing.
+//
+// Fix (see executor.ts buildRouteEvalEntry): when a node has an `output`
+// schema with declared properties, the route-evaluator's view of that
+// node's data is restricted to those declared properties. The downstream
+// node's `run()` context is untouched, so workflows that consume prose
+// narrative in later steps keep working.
+
+describe("route evaluator: schema-strict view of prior data", () => {
+  it("filters route-eval context to declared output properties when the prior node has an output schema", async () => {
+    // The exact field-run shape: status:"pass" is the routing field, but
+    // an unrelated prose field mentions retries.
+    const workflow: Workflow = {
+      id: "schema-strict-routing",
+      name: "Schema-Strict Routing",
+      description: "",
+      entry: "validate",
+      nodes: {
+        validate: {
+          name: "Validate",
+          instruction: "Validate the draft",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string", enum: ["pass", "fail"] },
+              quality_retry_count: { type: "number" },
+            },
+            required: ["status"],
+          },
+        },
+        publish: { name: "Publish", instruction: "Publish", skills: [] },
+        retry_draft: { name: "Retry Draft", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "validate", to: "publish", when: "status is pass" },
+        { from: "validate", to: "retry_draft", when: "status is fail" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: {
+            status: "pass",
+            quality_retry_count: 1,
+            // Non-schema fields. Before the fix, the prose summary leaked
+            // into the route evaluator and biased the decision.
+            summary: "The quality_retry_count from the draft node's context is 1, draft retries occurred.",
+            internal_notes: "had to retry the draft once before passing",
+          },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        // Pick the first choice whose description literally mentions "pass".
+        // This simulates a disciplined evaluator that follows the prompt
+        // rules. The fix is independent of this behavior; the assertions
+        // below pin the structural property.
+        const m = opts.choices.find((c: any) => /\bpass\b/i.test(c.description));
+        return (m ?? opts.choices[0]).id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    const { results } = await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    // Workflow took the pass branch and never executed retry_draft.
+    expect(results.has("publish")).toBe(true);
+    expect(results.has("retry_draft")).toBe(false);
+
+    // The validate entry in the route eval context only contains declared
+    // properties. The non-schema `summary` and `internal_notes` fields
+    // that triggered the field bug are absent.
+    const validateView = routeContext.validate as Record<string, unknown>;
+    expect(validateView).toBeDefined();
+    expect(validateView).toHaveProperty("status", "pass");
+    expect(validateView).toHaveProperty("quality_retry_count", 1);
+    expect(validateView).not.toHaveProperty("summary");
+    expect(validateView).not.toHaveProperty("internal_notes");
+  });
+
+  it("keeps the full prior data visible to downstream node run() (not just routing)", async () => {
+    // Workflows can rely on prose narrative fields for downstream node
+    // prompts even when those fields are not declared in the output
+    // schema. The fix is scoped to routing; run() must keep seeing
+    // everything.
+    const workflow: Workflow = {
+      id: "downstream-keeps-prose",
+      name: "Downstream Keeps Prose",
+      description: "",
+      entry: "first",
+      nodes: {
+        first: {
+          name: "First",
+          instruction: "First",
+          skills: [],
+          output: { type: "object", properties: { status: { type: "string" } } },
+        },
+        second: { name: "Second", instruction: "Second", skills: [] },
+      },
+      edges: [{ from: "first", to: "second" }],
+    };
+
+    let secondRunContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run(opts: any) {
+        // The first node returns prose alongside the declared field. The
+        // second node's run() context must still see both.
+        if (opts.instruction.includes("First")) {
+          return {
+            status: "success",
+            data: { status: "ok", summary: "free-text narrative for the next step" },
+            toolCalls: [],
+          };
+        }
+        secondRunContext = opts.context;
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const firstView = secondRunContext.first as Record<string, unknown>;
+    expect(firstView).toHaveProperty("status", "ok");
+    expect(firstView).toHaveProperty("summary", "free-text narrative for the next step");
+  });
+
+  it("preserves current behavior when the prior node has no output schema", async () => {
+    // Back-compat: a node without `output` exposes its full data to the
+    // route evaluator exactly as before.
+    const workflow: Workflow = {
+      id: "no-schema-back-compat",
+      name: "No Schema Back-Compat",
+      description: "",
+      entry: "decide",
+      nodes: {
+        decide: { name: "Decide", instruction: "Decide", skills: [] },
+        a: { name: "A", instruction: "A", skills: [] },
+        b: { name: "B", instruction: "B", skills: [] },
+      },
+      edges: [
+        { from: "decide", to: "a", when: "choose A" },
+        { from: "decide", to: "b", when: "choose B" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: { freeform_decision: "go A", commentary: "nothing structured here" },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const decideView = routeContext.decide as Record<string, unknown>;
+    expect(decideView).toHaveProperty("freeform_decision", "go A");
+    expect(decideView).toHaveProperty("commentary");
+  });
+
+  it("preserves evals on the routing view even under schema-strict filtering", async () => {
+    // priorNode.evals.<name>.pass is part of the public spec contract for
+    // routing. The strict filter must not strip it.
+    const workflow: Workflow = {
+      id: "evals-survive-strict",
+      name: "Evals Survive Strict",
+      description: "",
+      entry: "check",
+      nodes: {
+        check: {
+          name: "Check",
+          instruction: "Check",
+          skills: [],
+          output: { type: "object", properties: { status: { type: "string" } } },
+          eval: [
+            {
+              name: "well_formed",
+              kind: "value",
+              rule: { output_required: ["status"] },
+            },
+          ],
+        },
+        pass_path: { name: "Pass", instruction: "Pass", skills: [] },
+        fail_path: { name: "Fail", instruction: "Fail", skills: [] },
+      },
+      edges: [
+        { from: "check", to: "pass_path", when: "check.evals.well_formed.pass is true" },
+        { from: "check", to: "fail_path", when: "check.evals.well_formed.pass is false" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: { status: "ok", noise: "should be filtered" },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const checkView = routeContext.check as Record<string, unknown>;
+    expect(checkView).toHaveProperty("status", "ok");
+    expect(checkView).not.toHaveProperty("noise");
+    expect(checkView).toHaveProperty("evals");
+    const evals = checkView.evals as Record<string, unknown>;
+    expect(evals).toHaveProperty("well_formed");
+    expect((evals.well_formed as any).pass).toBe(true);
+  });
+
+  it("falls back to full data when output schema has no properties block (e.g. boolean or empty schema)", async () => {
+    // `output: { type: "object" }` is a valid but non-restrictive schema.
+    // The author has not declared a contract, so the fallback matches the
+    // no-schema case.
+    const workflow: Workflow = {
+      id: "no-properties",
+      name: "No Properties",
+      description: "",
+      entry: "open",
+      nodes: {
+        open: {
+          name: "Open",
+          instruction: "Open",
+          skills: [],
+          output: { type: "object" }, // no properties block
+        },
+        done: { name: "Done", instruction: "Done", skills: [] },
+        retry: { name: "Retry", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "open", to: "done", when: "all good" },
+        { from: "open", to: "retry", when: "any issue" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return { status: "success", data: { freeform: "all good here" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const openView = routeContext.open as Record<string, unknown>;
+    expect(openView).toHaveProperty("freeform", "all good here");
+  });
+});

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -254,10 +254,21 @@ export class ClaudeClient implements Claude {
     const { question, context, choices } = opts;
     const choiceList = choices.map((c) => `- "${c.id}": ${c.description}`).join("\n");
 
+    // The evaluator is doing one job: pick the choice whose condition the
+    // context literally satisfies. Prose narrative fields ("summary",
+    // "rationale", anything the model emitted as commentary) are NOT the
+    // contract. The structured fields are. The executor already filters
+    // declared `output` properties for routing (see buildRouteEvalEntry),
+    // and this prompt rule makes the model lean the same way when an
+    // output schema was not declared.
     const prompt = [
       question,
       `\nContext:\n\`\`\`json\n${JSON.stringify(context, null, 2)}\n\`\`\``,
       `\nChoices:\n${choiceList}`,
+      `\nEvaluation rules:`,
+      `1. Read each choice's condition literally and match against the structured fields in the context (e.g. status, counts, enum values, boolean flags).`,
+      `2. Ignore prose narrative fields ("summary", free-form rationale, conversational commentary). They are not the contract.`,
+      `3. When a field's value contradicts what a prose field claims, trust the field's value.`,
       `\nRespond with ONLY the choice ID, nothing else.`,
     ].join("\n");
 

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -252,25 +252,7 @@ export class ClaudeClient implements Claude {
     choices: { id: string; description: string }[];
   }): Promise<string> {
     const { question, context, choices } = opts;
-    const choiceList = choices.map((c) => `- "${c.id}": ${c.description}`).join("\n");
-
-    // The evaluator is doing one job: pick the choice whose condition the
-    // context literally satisfies. Prose narrative fields ("summary",
-    // "rationale", anything the model emitted as commentary) are NOT the
-    // contract. The structured fields are. The executor already filters
-    // declared `output` properties for routing (see buildRouteEvalEntry),
-    // and this prompt rule makes the model lean the same way when an
-    // output schema was not declared.
-    const prompt = [
-      question,
-      `\nContext:\n\`\`\`json\n${JSON.stringify(context, null, 2)}\n\`\`\``,
-      `\nChoices:\n${choiceList}`,
-      `\nEvaluation rules:`,
-      `1. Read each choice's condition literally and match against the structured fields in the context (e.g. status, counts, enum values, boolean flags).`,
-      `2. Ignore prose narrative fields ("summary", free-form rationale, conversational commentary). They are not the contract.`,
-      `3. When a field's value contradicts what a prose field claims, trust the field's value.`,
-      `\nRespond with ONLY the choice ID, nothing else.`,
-    ].join("\n");
+    const prompt = buildEvaluatePrompt(question, context, choices);
 
     const env = this.buildEnv();
 
@@ -414,6 +396,40 @@ function coreToolToSdkTool(coreTool: Tool, defaultCtx: ToolContext) {
  * `"42"`) from a tool that returned the string "42" (wrapper also sends
  * `"42"`). Preserving the string is safer than guessing.
  */
+/**
+ * Build the prompt used by `ClaudeClient.evaluate()` to pick a routing edge.
+ *
+ * Extracted as a pure function so the prompt body can be unit tested without
+ * spinning up an SDK query. The body is part of the routing contract: workflow
+ * authors and downstream maintainers rely on the model leaning on structured
+ * fields rather than prose narrative when picking an edge, especially in the
+ * fallback case where a source node did not declare an `output` schema (the
+ * executor's schema-strict filter only kicks in when a schema is present;
+ * see `buildRouteEvalEntry` in executor.ts).
+ *
+ * Any change to this prompt should keep:
+ *   - The three "Evaluation rules" pointing the model at structured fields
+ *     and away from prose narrative.
+ *   - A terminal directive to return ONLY the choice ID.
+ */
+export function buildEvaluatePrompt(
+  question: string,
+  context: Record<string, unknown>,
+  choices: { id: string; description: string }[],
+): string {
+  const choiceList = choices.map((c) => `- "${c.id}": ${c.description}`).join("\n");
+  return [
+    question,
+    `\nContext:\n\`\`\`json\n${JSON.stringify(context, null, 2)}\n\`\`\``,
+    `\nChoices:\n${choiceList}`,
+    `\nEvaluation rules:`,
+    `1. Read each choice's condition literally and match against the structured fields in the context (e.g. status, counts, enum values, boolean flags).`,
+    `2. Ignore prose narrative fields ("summary", free-form rationale, conversational commentary). They are not the contract.`,
+    `3. When a field's value contradicts what a prose field claims, trust the field's value.`,
+    `\nRespond with ONLY the choice ID, nothing else.`,
+  ].join("\n");
+}
+
 export function parseToolResultContent(content: unknown): unknown {
   if (typeof content !== "string") return content;
   const trimmed = content.trim();

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -29,6 +29,7 @@ import type {
   ExecutionEvent,
   ExecutionTrace,
   ExecutionResult,
+  JSONSchema,
   Source,
   ResolvedSource,
 } from "./types.js";
@@ -448,6 +449,74 @@ function buildPriorNodeContext(result: NodeResult): Record<string, unknown> {
   return { evals: evalsByName, ...data };
 }
 
+/**
+ * Build the prior-node entry shown to the LLM route evaluator.
+ *
+ * Differs from `buildPriorNodeContext` (which feeds downstream node `run()`
+ * calls) in one way: when the source node declared an `output` schema with
+ * a `properties` block, the data view is restricted to those declared
+ * properties. The `evals` namespace is always preserved when present.
+ *
+ * Why this exists. The route evaluator is a natural-language model. Anything
+ * it sees in the context can sway the decision, including prose narrative
+ * fields like the always-injected `summary` from the reference Claude
+ * client (claude.ts: `data: { summary: response, ...parsed }`). Real-world
+ * symptom: a node correctly emits `status: "pass"` but also adds a
+ * conversational `summary` like "the quality_retry_count is 1", and the
+ * evaluator pattern-matches the retry mention to flip the routing decision.
+ *
+ * The fix is to treat the `output` schema as the routing contract. If the
+ * author declared which fields matter, only those reach the route
+ * evaluator. When no schema is declared we fall back to the full data
+ * (back-compat for workflows without structured outputs).
+ *
+ * The downstream node prompt is untouched: nodes still see the full prior
+ * `data` including any prose `summary`, so workflows that consume the
+ * narrative in subsequent steps keep working.
+ */
+function buildRouteEvalEntry(result: NodeResult, sourceNode: Node | undefined): Record<string, unknown> {
+  const fullData = (result.data ?? {}) as Record<string, unknown>;
+  const declaredProps = getDeclaredOutputProperties(sourceNode?.output);
+
+  const dataView: Record<string, unknown> = declaredProps ? pickKeys(fullData, declaredProps) : fullData;
+
+  const evals = result.evals ?? [];
+  if (evals.length === 0) return dataView;
+
+  const evalsByName: Record<string, unknown> = {};
+  for (const e of evals) {
+    evalsByName[e.name] = e;
+  }
+  // Spread evals first so a data-side `evals` key shadows it (back-compat).
+  return { evals: evalsByName, ...dataView };
+}
+
+/**
+ * Return the declared output property names for a node, or null when the
+ * node has no `output` schema or its schema does not declare a `properties`
+ * block. Null signals "no contract" and routing falls back to the full
+ * data view.
+ *
+ * Tolerant of malformed schemas because `output` is `JSONSchema =
+ * Record<string, unknown>` and is not parsed further by the executor.
+ */
+function getDeclaredOutputProperties(output: JSONSchema | undefined): Set<string> | null {
+  if (!output || typeof output !== "object") return null;
+  const props = (output as Record<string, unknown>).properties;
+  if (!props || typeof props !== "object") return null;
+  const keys = Object.keys(props as Record<string, unknown>);
+  if (keys.length === 0) return null;
+  return new Set(keys);
+}
+
+function pickKeys(obj: Record<string, unknown>, keys: Set<string>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (k in obj) out[k] = obj[k];
+  }
+  return out;
+}
+
 function nodeSourcesToArray(ns: NodeSources | undefined): { sources: Source[]; only: boolean } {
   if (!ns) return { sources: [], only: false };
   if (Array.isArray(ns)) return { sources: ns, only: false };
@@ -680,9 +749,16 @@ async function resolveNext(
   // Claude evaluates which condition matches. Include input so conditions
   // can reference workflow-level flags like dryRun, and expose evals so
   // routing edges can read `priorNode.evals.X.pass`.
+  //
+  // Crucial difference from the run() context: when a prior node declared
+  // an `output` schema, the routing view of its data is restricted to the
+  // declared properties. Without this, non-schema fields (notably the
+  // always-injected `summary` prose from the reference Claude client) can
+  // sway the natural-language route evaluator and override the actual
+  // structured result. See `buildRouteEvalEntry` for the full rationale.
   const context: Record<string, unknown> = {
     input,
-    ...Object.fromEntries([...results.entries()].map(([k, v]) => [k, buildPriorNodeContext(v)])),
+    ...Object.fromEntries([...results.entries()].map(([k, v]) => [k, buildRouteEvalEntry(v, workflow.nodes[k])])),
   };
 
   const choices = conditionalEdges.map((e) => ({


### PR DESCRIPTION
## Why

The LLM route evaluator decides which edge to follow by reading the
accumulated context, which includes every prior node's `result.data`.
The reference `ClaudeClient.run()` builds `data` as
`{ summary: response, ...tryParseJSON(response) }`. The always-injected
prose `summary` (and any other non-schema fields a node emits) leaks into
the routing decision.

Real production run: a `validate` node with output schema
`{ status: "pass" | "fail", quality_retry_count, checks }` emitted
`status: "pass"` correctly and ALSO added `summary: "the
quality_retry_count from the draft node's context is 1, draft retries
occurred"`. The natural-language evaluator pattern-matched the retry
mention and chose the fail/retry edge across multiple iterations,
halting the workflow at `notify_halt` despite every actual check
passing.

Field run: https://github.com/letsoffload/offload/actions/runs/25775301135

Builds on PRs #194, #195, #196 (the `--verbose` series). Those gave us
the visibility to see the contradiction in real time: the structured
output said `pass`, the prose said `retry`, and the routing followed
the prose.

## What

When the source node of a routing decision has an `output` schema with
a `properties` block, the route-evaluator's view of that node's `data`
is filtered to those declared properties (plus the `evals` namespace,
which is part of the public spec contract for routing). Non-declared
fields stay out of the routing decision.

The downstream node `run()` context is untouched. Nodes still see the
full prior data including any prose, so workflows that consume the
narrative in later instructions keep working. Only routing is
narrowed.

Nodes without an `output` schema keep the prior full-data view. No
back-compat hazard for unstructured workflows.

Also strengthens the `evaluate()` prompt with explicit instructions to
match conditions against structured fields and ignore prose. Helps in
the no-schema fallback case.

### Decision space considered

The brief asked for a principled, surveyed answer rather than the first
patch that compiles:

1. **Schema strip on the routing view**. Picked. Surgical, default-on,
   uses an existing author signal (the declared `output` schema) as the
   routing contract. Aligns with how spec authors already think about
   the data shape.
2. Deterministic edge predicate language. Possible follow-up, but a
   bigger surface area, and would compete with the natural-language
   routing that sweny advertises as a feature.
3. Prompt-only hardening. Included as belt-and-suspenders but does
   not by itself eliminate the brittleness.
4. Workflow-level opt-in strict mode. Rejected as overkill for the
   bundled-workflow audit (every conditional-source node already
   declares output properties matching the routing fields).
5. Combination. Picked (1 + 3).

The bundled workflows were audited end-to-end. `triage.yml`,
`implement.yml`, `seed-content.yml`: every node that fans out
conditional edges already declares `output.properties` with the
routing field as a declared property. The fix is a behavior preserve
for them.

## How to verify

```bash
yarn workspace @sweny-ai/core test --run
yarn workspace @sweny-ai/core typecheck
```

- Tests: 1639 passing (1634 baseline + 5 new). When the routing fix
  is reverted, 2 of the new tests fail and pin the exact bug.
- Audit notes are in the changeset and the `buildRouteEvalEntry`
  docblock.

## Follow-ups

- The reference `ClaudeClient.run()` always injects `summary: response`
  alongside the parsed output. That is the actual upstream cause of
  the prose pollution. Worth considering dropping it when an output
  schema is declared, but that is a separate behavior change and may
  affect workflows that consume `summary` downstream. Not in this PR.
- The spec page `edges.mdx` could note the declared-property routing
  contract explicitly. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)