### PR TITLE
feat(core): --verbose on `sweny triage` and `sweny implement`

### DIFF
--- a/.changeset/verbose-triage-implement.md
+++ b/.changeset/verbose-triage-implement.md
@@ -1,0 +1,19 @@
+---
+"@sweny-ai/core": minor
+---
+
+`--verbose` now works on `sweny triage` and `sweny implement` in addition to
+`sweny workflow run`. Same human-readable tool detail output, same observer,
+same trade-offs (truncated to 4000 chars per side; use `--stream` for the
+full untruncated NDJSON; `SWENY_VERBOSE_TRUNCATE` env var to bump the
+truncation).
+
+Motivation: PRs #194/#195/#196 wired verbose into the generic
+`workflow run` command, but `sweny triage` and `sweny implement` go through
+their own observer composition in `cli/main.ts` and didn't pick it up. The
+swenyai/triage GitHub Action wraps `sweny triage`; without this change, a
+triage run that halts or routes unexpectedly produces the same opaque log
+that prompted the verbose work in the first place.
+
+Tests: parseCliInputs gains three cases pinning the `verbose` field
+plumbing (default false, true when set, defensive boolean coercion).

--- a/packages/core/src/cli/__tests__/report-cloud.test.ts
+++ b/packages/core/src/cli/__tests__/report-cloud.test.ts
@@ -78,6 +78,7 @@ describe("reportToCloud", () => {
       repositoryOwner: "",
       json: false,
       stream: false,
+      verbose: false,
       bell: false,
       cacheDir: "",
       cacheTtl: 0,

--- a/packages/core/src/cli/config.test.ts
+++ b/packages/core/src/cli/config.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { validateInputs, parseCliInputs, parsePositiveInt } from "./config.js";
+import { Command } from "commander";
+import {
+  validateInputs,
+  parseCliInputs,
+  parsePositiveInt,
+  registerTriageCommand,
+  registerImplementCommand,
+} from "./config.js";
 import type { CliConfig } from "./config.js";
 
 /**
@@ -329,5 +336,75 @@ describe("parseCliInputs — verbose flag", () => {
     expect(parseCliInputs({ verbose: 1 as unknown as boolean }).verbose).toBe(true);
     expect(parseCliInputs({ verbose: "" as unknown as boolean }).verbose).toBe(false);
     expect(parseCliInputs({ verbose: undefined }).verbose).toBe(false);
+  });
+});
+
+describe("verbose flag — registered on every long-running subcommand", () => {
+  // Public CLI contract. The swenyai/triage and swenyai/e2e GitHub Actions
+  // both append `--verbose` to the underlying CLI call when their `verbose`
+  // input is set. If the flag silently disappears from either subcommand,
+  // every consumer of those actions stops getting tool-call detail in CI
+  // logs the next time they bump their @sweny-ai/core version. The bug is
+  // invisible until someone tries to debug a halt. Lock the contract here.
+  //
+  // Approach: instantiate commander, register each command, and walk the
+  // registered options. Cheaper than scraping `--help` output and resilient
+  // to commander's formatting changes across versions.
+  function optionLongs(cmd: ReturnType<Command["command"]>): string[] {
+    return cmd.options.map((o) => o.long ?? "").filter(Boolean);
+  }
+
+  function findSubcommand(program: Command, name: string): Command {
+    const cmd = program.commands.find((c) => c.name() === name);
+    if (!cmd) throw new Error(`subcommand '${name}' not found in test fixture`);
+    return cmd;
+  }
+
+  it("triage exposes --verbose", () => {
+    const program = new Command();
+    registerTriageCommand(program);
+    const triage = findSubcommand(program, "triage");
+    expect(optionLongs(triage)).toContain("--verbose");
+  });
+
+  it("implement exposes --verbose", () => {
+    const program = new Command();
+    registerImplementCommand(program);
+    const implement = findSubcommand(program, "implement");
+    expect(optionLongs(implement)).toContain("--verbose");
+  });
+
+  it("triage's --verbose description tells users this is human-readable, truncated, and points at --stream for full output", () => {
+    // The wording is part of the public help. Users grep `sweny triage --help`
+    // for "verbose"; the description has to make the trade-off obvious so
+    // they reach for `--stream` when they need full NDJSON.
+    const program = new Command();
+    registerTriageCommand(program);
+    const verbose = findSubcommand(program, "triage").options.find((o) => o.long === "--verbose");
+    expect(verbose).toBeDefined();
+    expect(verbose!.description).toMatch(/human-readable/i);
+    expect(verbose!.description).toMatch(/truncated/i);
+    expect(verbose!.description).toMatch(/--stream/);
+  });
+
+  it("implement's --verbose description matches the triage wording (single source of truth)", () => {
+    // The two subcommands share the verbose semantics; their descriptions
+    // should be identical so users don't have to learn two trade-offs.
+    const program = new Command();
+    registerTriageCommand(program);
+    registerImplementCommand(program);
+    const triageDesc = findSubcommand(program, "triage").options.find((o) => o.long === "--verbose")?.description;
+    const implementDesc = findSubcommand(program, "implement").options.find((o) => o.long === "--verbose")?.description;
+    expect(triageDesc).toBe(implementDesc);
+  });
+
+  it("both subcommands default --verbose to false (no opt-out needed for callers that don't pass the flag)", () => {
+    const program = new Command();
+    registerTriageCommand(program);
+    registerImplementCommand(program);
+    for (const name of ["triage", "implement"]) {
+      const opt = findSubcommand(program, name).options.find((o) => o.long === "--verbose");
+      expect(opt?.defaultValue, `${name} --verbose default`).toBe(false);
+    }
   });
 });

--- a/packages/core/src/cli/config.test.ts
+++ b/packages/core/src/cli/config.test.ts
@@ -59,6 +59,7 @@ function baseConfig(overrides: Partial<CliConfig> = {}): CliConfig {
     repositoryOwner: "",
     json: false,
     stream: false,
+    verbose: false,
     bell: false,
     cacheDir: ".sweny/cache",
     cacheTtl: 86400,
@@ -304,5 +305,29 @@ describe("parseCliInputs — cloud token", () => {
     } finally {
       if (original !== undefined) process.env.SWENY_CLOUD_TOKEN = original;
     }
+  });
+});
+
+describe("parseCliInputs — verbose flag", () => {
+  // The verbose flag is registered on three CLI surfaces (triage, implement,
+  // workflow run). parseCliInputs is the shared gateway that turns commander's
+  // option bag into the config the executor uses to wire the verbose tool
+  // observer. Pin the wiring so a future refactor doesn't silently drop it.
+  it("defaults to false when the flag is omitted", () => {
+    const config = parseCliInputs({});
+    expect(config.verbose).toBe(false);
+  });
+
+  it("reads --verbose when passed", () => {
+    const config = parseCliInputs({ verbose: true });
+    expect(config.verbose).toBe(true);
+  });
+
+  it("coerces any truthy commander value to boolean (no implicit any leak)", () => {
+    // commander represents repeated --verbose or .option(..., false) differently
+    // across versions. The plumbing must coerce to a clean boolean.
+    expect(parseCliInputs({ verbose: 1 as unknown as boolean }).verbose).toBe(true);
+    expect(parseCliInputs({ verbose: "" as unknown as boolean }).verbose).toBe(false);
+    expect(parseCliInputs({ verbose: undefined }).verbose).toBe(false);
   });
 });

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -81,6 +81,12 @@ export interface CliConfig {
   // CLI-specific
   json: boolean;
   stream: boolean;
+  /**
+   * When true, print each tool call's input and output inline (human-readable,
+   * truncated). Adds a verbose tool observer alongside the spinner/progress
+   * observer. Use `stream` if you need full untruncated NDJSON instead.
+   */
+  verbose: boolean;
   bell: boolean;
 
   // Cache
@@ -175,6 +181,11 @@ export function registerTriageCommand(program: Command): Command {
     .option("--gitlab-base-url <url>", "GitLab base URL (default: https://gitlab.com)")
     .option("--json", "Output results as JSON", false)
     .option("--stream", "Stream NDJSON events to stdout (for Studio / automation)", false)
+    .option(
+      "--verbose",
+      "Print each tool call's input and output inline (human-readable, truncated). Use --stream for full untruncated NDJSON.",
+      false,
+    )
     .option("--bell", "Ring terminal bell on completion", false)
     .option("--cache-dir <path>", "Step cache directory (default: .sweny/cache)")
     .option("--cache-ttl <seconds>", "Cache TTL in seconds, 0 = infinite (default: 86400)")
@@ -309,6 +320,7 @@ export function parseCliInputs(options: Record<string, unknown>, fileConfig: Fil
     // Per-invocation flags: CLI only
     json: Boolean(options.json),
     stream: Boolean(options.stream),
+    verbose: Boolean(options.verbose),
     bell: Boolean(options.bell),
 
     cacheDir: (options.cacheDir as string) || env.SWENY_CACHE_DIR || f("cache-dir") || ".sweny/cache",
@@ -825,6 +837,11 @@ export function registerImplementCommand(program: Command): Command {
     )
     .option("--additional-instructions <text>", "Extra instructions for the coding agent")
     .option("--stream", "Stream NDJSON events to stdout (for Studio / automation)", false)
+    .option(
+      "--verbose",
+      "Print each tool call's input and output inline (human-readable, truncated). Use --stream for full untruncated NDJSON.",
+      false,
+    )
     .option("--offline", "Skip URL Sources and fail fast if any are referenced", false);
 }
 

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -427,6 +427,7 @@ triageCmd.action(async (options: Record<string, unknown>) => {
 
   const observer = composeObservers(
     progressObserver,
+    config.verbose ? createVerboseToolObserver() : undefined,
     config.stream ? createStreamObserver() : undefined,
     createCloudStreamObserver(config, cloudHandle),
   );
@@ -622,6 +623,7 @@ implementCmd.action(async (issueId: string, options: Record<string, unknown>) =>
 
   const observer = composeObservers(
     implProgressObserver,
+    config.verbose ? createVerboseToolObserver() : undefined,
     Boolean(options.stream) ? createStreamObserver() : undefined,
     createCloudStreamObserver(config, implCloudHandle),
   );


### PR DESCRIPTION
## Why

PRs #194 / #195 / #196 wired \`--verbose\` into \`sweny workflow run\` (and the GitHub Action wrapper). \`sweny triage\` and \`sweny implement\` go through their own observer composition in \`cli/main.ts\` and didn't pick it up. The swenyai/triage GitHub Action wraps \`sweny triage\`; without this change, a triage halt produces the same opaque \`✓ node: success (N tool calls)\` log that drove the original verbose work.

Field context: same release-notes investigation that produced #197. We could see what was happening inside \`sweny workflow run\` but not inside \`sweny triage\` or \`sweny implement\` because they didn't expose the flag.

## What

- \`cli/config.ts\` registers \`--verbose\` on both triage and implement.
- Threads \`verbose: boolean\` through \`CliConfig\` and \`parseCliInputs()\`.
- \`cli/main.ts\` adds \`createVerboseToolObserver()\` to the observer composition in both subcommand paths, alongside the existing \`--stream\` observer.

Same output strategy as \`workflow run\`: tool I/O printed on \`node:exit\`, truncated to 4000 chars per side, override with \`SWENY_VERBOSE_TRUNCATE\`. Covers both skill tools and the agent's built-in Bash/Read/Edit/Write.

## Tests

- 3 new cases in \`config.test.ts\` pin the plumbing: default false, true when passed, defensive boolean coercion (commander's option bag can deliver \`1\`, \`""\`, \`undefined\` across versions).
- Existing fixtures (\`report-cloud.test.ts\`, \`config.test.ts\`) updated for the new required field.
- \`yarn workspace @sweny-ai/core test --run\` → 1640 passing.
- \`yarn workspace @sweny-ai/core typecheck\` → clean.

## Verification

\`\`\`
$ sweny triage --help | grep verbose
  --verbose                               Print each tool call's input and output inline (human-readable, truncated). Use --stream for full untruncated NDJSON. (default: false)

$ sweny implement --help | grep verbose
  --verbose                             Print each tool call's input and output inline (human-readable, truncated). Use --stream for full untruncated NDJSON. (default: false)
\`\`\`

## Followups (other PRs)

- \`swenyai/triage/action.yml\` should expose a \`verbose\` input that forwards to \`sweny triage --verbose\`. Will open after this lands and republishes.
- \`swenyai/e2e/action.yml\` already runs \`sweny workflow run\`; needs the same \`verbose: true\` wrapper that's on the main \`swenyai/sweny\` action. Will open separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)