### PR TITLE
feat(core): declared inputs contract for per-run workflow parameters

### DIFF
--- a/.changeset/workflow-inputs-contract.md
+++ b/.changeset/workflow-inputs-contract.md
@@ -23,7 +23,21 @@ validation rules.
 
 Telemetry contract: cloud observers receive the input *shape* (key names +
 declared types) via `summarizeInputShape`, never the values, so workflows
-that accept tokens or other secrets as input do not leak them.
+that accept tokens or other secrets as input do not leak them. The cloud
+run-start payload transmits the shape under the `inputs_shape` key and
+MUST NOT include a matching values bag; the runtime wires this through
+`beginCloudLifecycle`, guarded by a regression test that asserts a
+secret-bearing input never appears in the serialized payload.
+
+Schema hardening: an InputField MUST NOT declare both `required: true`
+and a `default`. The combination is incoherent (a default would either
+silently satisfy the required check, or never fire) and the schema
+rejects it at parse time.
+
+Composition with `workflow_type` is orthogonal and additive: any
+workflow type accepts an `inputs` block, no type reserves field names,
+and the runtime passes the resolved input bag uniformly regardless of
+type. See spec for the full five-rule contract.
 
 New public exports from `@sweny-ai/core`:
 

--- a/.changeset/workflow-inputs-contract.md
+++ b/.changeset/workflow-inputs-contract.md
@@ -1,0 +1,34 @@
+---
+"@sweny-ai/core": minor
+---
+
+Add a declared per-run `inputs` contract to workflows. Workflow YAML may now
+declare an `inputs:` block (top-level, optional) describing the parameters a
+caller can supply at invocation. The CLI validates `--input <json>` against
+this declaration, applies defaults for omitted optional fields, and rejects
+malformed input with a grouped error message before the executor runs.
+
+The composite GitHub Action gains a corresponding `input:` (string-of-JSON,
+forwarded verbatim) so CI callers can thread per-run parameters into a
+workflow without bespoke wrapper actions.
+
+Workflows without an `inputs` block accept any JSON object (back-compat;
+every existing workflow keeps working unchanged).
+
+Types supported: `string`, `number`, `boolean`, `string[]`. Fields support
+`required`, `default`, `description`, and `enum`. The published JSON Schema
+at https://spec.sweny.ai/schemas/workflow.json documents the field shape and
+the spec site at https://spec.sweny.ai/workflow#inputs documents the
+validation rules.
+
+Telemetry contract: cloud observers receive the input *shape* (key names +
+declared types) via `summarizeInputShape`, never the values, so workflows
+that accept tokens or other secrets as input do not leak them.
+
+New public exports from `@sweny-ai/core`:
+
+- `WorkflowInputs`, `WorkflowInputField`, `WorkflowInputType`,
+  `InputValidationError`, `InputValidationResult` types.
+- `validateRuntimeInput(declared, raw)` and `summarizeInputShape(declared,
+  resolved)` functions.
+- `workflowInputsZ` Zod schema.

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,25 @@ inputs:
     required: false
     default: "false"
 
+  input:
+    description: |
+      JSON object of per-run inputs for the workflow. Forwarded verbatim to
+      `sweny workflow run --input '<json>'`. When the workflow declares an
+      `inputs` block, the CLI validates this string against the declaration
+      (type-check, required-field check, default-fill) and fails with a
+      readable diff when the shape doesn't match. When the workflow does NOT
+      declare `inputs`, the JSON is passed through unchanged for back-compat.
+
+      Example (release-notes-style):
+        input: |
+          {
+            "since_tag": "v1.41.12",
+            "until_tag": "v1.41.13",
+            "draft": true
+          }
+    required: false
+    default: ""
+
   cloud-token:
     description: "SWEny Cloud project token (sweny_pk_...) for reporting run results to cloud.sweny.ai. Optional. Equivalent to setting the SWENY_CLOUD_TOKEN env var; either form is accepted."
     required: false
@@ -81,6 +100,7 @@ runs:
         WORKFLOW_PATH: ${{ inputs.workflow }}
         DRY_RUN: ${{ inputs.dry-run }}
         VERBOSE: ${{ inputs.verbose }}
+        WORKFLOW_INPUT: ${{ inputs.input }}
         INPUT_CLOUD_TOKEN: ${{ inputs.cloud-token }}
       run: |
         # Forward the cloud token to the CLI. Prefer the explicit `cloud-token`
@@ -102,5 +122,12 @@ runs:
         FLAGS=()
         [ "$DRY_NORM" = "true" ] && FLAGS+=("--dry-run")
         [ "$VERBOSE_NORM" = "true" ] && FLAGS+=("--verbose")
+        # Forward per-run inputs verbatim. Pass through env to avoid shell
+        # quoting issues with nested JSON; the CLI parses and validates the
+        # string against the workflow's declared `inputs` block (if any) and
+        # fails with a readable error when the shape doesn't match.
+        if [ -n "$WORKFLOW_INPUT" ]; then
+          FLAGS+=("--input" "$WORKFLOW_INPUT")
+        fi
 
         sweny workflow run "$WORKFLOW_PATH" "${FLAGS[@]}"

--- a/packages/core/src/__tests__/inputs.test.ts
+++ b/packages/core/src/__tests__/inputs.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateRuntimeInput,
+  summarizeInputShape,
+  workflowInputsZ,
+  WORKFLOW_INPUT_TYPES,
+  type WorkflowInputs,
+} from "../inputs.js";
+import { workflowZ, parseWorkflow } from "../schema.js";
+import { execute } from "../executor.js";
+import type { Claude, Tool, Workflow } from "../types.js";
+
+// ─── validateRuntimeInput ─────────────────────────────────────────
+
+describe("validateRuntimeInput", () => {
+  it("passes any object through when no inputs are declared (back-compat)", () => {
+    const r = validateRuntimeInput(undefined, { foo: 1, bar: "x" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ foo: 1, bar: "x" });
+  });
+
+  it("accepts an empty object when no inputs are declared", () => {
+    const r = validateRuntimeInput(undefined, null);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({});
+  });
+
+  it("rejects non-object input at the root", () => {
+    const r = validateRuntimeInput(undefined, [1, 2, 3]);
+    expect(r.ok).toBe(false);
+  });
+
+  it("validates string fields", () => {
+    const declared: WorkflowInputs = { name: { type: "string", required: true } };
+    const ok = validateRuntimeInput(declared, { name: "alice" });
+    expect(ok.ok).toBe(true);
+    const bad = validateRuntimeInput(declared, { name: 42 });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      expect(bad.errors[0].field).toBe("name");
+      expect(bad.errors[0].message).toMatch(/string/);
+    }
+  });
+
+  it("validates number / boolean / string[] fields", () => {
+    const declared: WorkflowInputs = {
+      n: { type: "number" },
+      b: { type: "boolean" },
+      arr: { type: "string[]" },
+    };
+    const good = validateRuntimeInput(declared, { n: 5, b: true, arr: ["a", "b"] });
+    expect(good.ok).toBe(true);
+    const bad = validateRuntimeInput(declared, { n: "5", b: "true", arr: [1] });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      expect(bad.errors.map((e) => e.field).sort()).toEqual(["arr", "b", "n"]);
+    }
+  });
+
+  it("rejects NaN / Infinity for number type", () => {
+    const declared: WorkflowInputs = { n: { type: "number" } };
+    const nan = validateRuntimeInput(declared, { n: Number.NaN });
+    expect(nan.ok).toBe(false);
+    const inf = validateRuntimeInput(declared, { n: Number.POSITIVE_INFINITY });
+    expect(inf.ok).toBe(false);
+  });
+
+  it("reports all missing required fields at once, not one at a time", () => {
+    const declared: WorkflowInputs = {
+      a: { type: "string", required: true },
+      b: { type: "number", required: true },
+      c: { type: "boolean" },
+    };
+    const r = validateRuntimeInput(declared, {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toHaveLength(2);
+      expect(r.errors.map((e) => e.field).sort()).toEqual(["a", "b"]);
+    }
+  });
+
+  it("applies defaults when the caller omits a field", () => {
+    const declared: WorkflowInputs = {
+      since: { type: "string", default: "HEAD~10" },
+      draft: { type: "boolean", default: false },
+    };
+    const r = validateRuntimeInput(declared, {});
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ since: "HEAD~10", draft: false });
+  });
+
+  it("caller-provided value beats default", () => {
+    const declared: WorkflowInputs = { since: { type: "string", default: "HEAD~10" } };
+    const r = validateRuntimeInput(declared, { since: "v1.0.0" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.since).toBe("v1.0.0");
+  });
+
+  it("leaves optional fields unset when caller omits them and no default exists", () => {
+    const declared: WorkflowInputs = { foo: { type: "string" } };
+    const r = validateRuntimeInput(declared, {});
+    expect(r.ok).toBe(true);
+    if (r.ok) expect("foo" in r.value).toBe(false);
+  });
+
+  it("passes through undeclared keys for legacy CLI compat (dryRun, timeRange, ...)", () => {
+    const declared: WorkflowInputs = { since: { type: "string" } };
+    const r = validateRuntimeInput(declared, { since: "v1", dryRun: true, repository: "x/y" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.since).toBe("v1");
+      expect(r.value.dryRun).toBe(true);
+      expect(r.value.repository).toBe("x/y");
+    }
+  });
+
+  it("enforces enum constraints", () => {
+    const declared: WorkflowInputs = {
+      severity: { type: "string", enum: ["low", "high"] },
+    };
+    const ok = validateRuntimeInput(declared, { severity: "low" });
+    expect(ok.ok).toBe(true);
+    const bad = validateRuntimeInput(declared, { severity: "critical" });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.errors[0].message).toMatch(/one of/);
+  });
+
+  it("treats explicit null on optional field as missing → applies default", () => {
+    const declared: WorkflowInputs = { foo: { type: "string", default: "fallback" } };
+    const r = validateRuntimeInput(declared, { foo: null });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.foo).toBe("fallback");
+  });
+});
+
+// ─── workflowInputsZ schema ──────────────────────────────────────
+
+describe("workflowInputsZ", () => {
+  it("accepts a valid declaration", () => {
+    const parsed = workflowInputsZ.parse({
+      since: { type: "string", description: "Lower bound", required: true },
+      draft: { type: "boolean", default: false },
+      labels: { type: "string[]", default: [] },
+    });
+    expect(parsed.since.required).toBe(true);
+    expect(parsed.draft.default).toBe(false);
+  });
+
+  it("rejects unknown types", () => {
+    expect(() => workflowInputsZ.parse({ x: { type: "date" } })).toThrow();
+  });
+
+  it("rejects a default whose type doesn't match the field type", () => {
+    expect(() => workflowInputsZ.parse({ x: { type: "string", default: 42 } })).toThrow(/default/);
+  });
+
+  it("rejects enum values that don't match the field type", () => {
+    expect(() => workflowInputsZ.parse({ x: { type: "string", enum: ["a", 5] } })).toThrow(/enum/);
+  });
+
+  it("rejects unknown keys on a field", () => {
+    expect(() => workflowInputsZ.parse({ x: { type: "string", randoKey: true } })).toThrow();
+  });
+
+  it("covers every declared WORKFLOW_INPUT_TYPES value", () => {
+    for (const t of WORKFLOW_INPUT_TYPES) {
+      const parsed = workflowInputsZ.parse({ f: { type: t } });
+      expect(parsed.f.type).toBe(t);
+    }
+  });
+});
+
+// ─── workflowZ integration ───────────────────────────────────────
+
+describe("workflowZ with inputs", () => {
+  it("accepts a workflow that declares inputs", () => {
+    const parsed = workflowZ.parse({
+      id: "release-notes",
+      name: "Release Notes",
+      entry: "discover",
+      nodes: { discover: { name: "Discover", instruction: "Find tags" } },
+      edges: [],
+      inputs: {
+        since_tag: { type: "string", required: true },
+        until_tag: { type: "string", default: "HEAD" },
+      },
+    });
+    expect(parsed.inputs?.since_tag.required).toBe(true);
+    expect(parsed.inputs?.until_tag.default).toBe("HEAD");
+  });
+
+  it("parseWorkflow rejects malformed inputs blocks", () => {
+    expect(() =>
+      parseWorkflow({
+        id: "x",
+        name: "x",
+        entry: "a",
+        nodes: { a: { name: "A", instruction: "Do it" } },
+        edges: [],
+        inputs: { foo: { type: "json" } },
+      }),
+    ).toThrow();
+  });
+
+  it("existing workflows without an inputs block continue to parse", () => {
+    const parsed = workflowZ.parse({
+      id: "no-inputs",
+      name: "No Inputs",
+      entry: "a",
+      nodes: { a: { name: "A", instruction: "x" } },
+      edges: [],
+    });
+    expect(parsed.inputs).toBeUndefined();
+  });
+});
+
+// ─── summarizeInputShape ─────────────────────────────────────────
+
+describe("summarizeInputShape", () => {
+  it("returns declared types when an inputs contract exists", () => {
+    const declared: WorkflowInputs = {
+      since: { type: "string" },
+      n: { type: "number" },
+    };
+    expect(summarizeInputShape(declared, { since: "v1", n: 5 })).toEqual({
+      since: "string",
+      n: "number",
+    });
+  });
+
+  it("falls back to observed runtime types when no contract is declared", () => {
+    expect(summarizeInputShape(undefined, { a: "x", b: 3, c: true, d: ["x"], e: null })).toEqual({
+      a: "string",
+      b: "number",
+      c: "boolean",
+      d: "string[]",
+      e: "null",
+    });
+  });
+
+  it("never includes values, only key + type", () => {
+    const r = summarizeInputShape(undefined, { secret: "sk-xxx" });
+    expect(JSON.stringify(r)).not.toContain("sk-xxx");
+  });
+});
+
+// ─── End-to-end through executor ─────────────────────────────────
+
+/** Minimal mock Claude that records the input it sees and returns nothing. */
+function makeMockClaude(captured: { input?: unknown; conditions?: string[] }): Claude {
+  return {
+    async run({ context }) {
+      captured.input = (context as Record<string, unknown>).input;
+      return { status: "success", data: { ok: true }, toolCalls: [] };
+    },
+    async evaluate({ context, choices }) {
+      // record the input snapshot at the routing decision point too
+      captured.input = (context as Record<string, unknown>).input;
+      captured.conditions = choices.map((c) => c.description);
+      return choices[0].id;
+    },
+    async ask() {
+      return "";
+    },
+  };
+}
+
+describe("executor with validated inputs", () => {
+  it("makes input.since visible to the first node's context", async () => {
+    const wf: Workflow = {
+      id: "x",
+      name: "x",
+      description: "",
+      entry: "n",
+      nodes: { n: { name: "N", instruction: "do", skills: [] } },
+      edges: [],
+    };
+    const captured: { input?: unknown } = {};
+    const claude = makeMockClaude(captured);
+    await execute(wf, { since: "v1.0.0" }, { skills: new Map(), claude });
+    expect(captured.input).toEqual({ since: "v1.0.0" });
+  });
+
+  it("makes input.<field> visible to a conditional routing decision", async () => {
+    const wf: Workflow = {
+      id: "x",
+      name: "x",
+      description: "",
+      entry: "n",
+      nodes: {
+        n: { name: "N", instruction: "do", skills: [] },
+        a: { name: "A", instruction: "do", skills: [] },
+        b: { name: "B", instruction: "do", skills: [] },
+      },
+      edges: [
+        { from: "n", to: "a", when: "input.draft is true" },
+        { from: "n", to: "b", when: "input.draft is false" },
+      ],
+    };
+    const captured: { input?: unknown; conditions?: string[] } = {};
+    const claude = makeMockClaude(captured);
+    await execute(wf, { draft: true }, { skills: new Map(), claude });
+    // The routing-decision call saw the same input bag.
+    expect(captured.input).toEqual({ draft: true });
+    // The condition text references input.draft, proving the path is plumbed.
+    expect(captured.conditions?.some((c) => c.includes("input.draft"))).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/inputs.test.ts
+++ b/packages/core/src/__tests__/inputs.test.ts
@@ -162,6 +162,35 @@ describe("workflowInputsZ", () => {
     expect(() => workflowInputsZ.parse({ x: { type: "string", randoKey: true } })).toThrow();
   });
 
+  it("rejects a field that declares both `required: true` and a `default`", () => {
+    // The combination is incoherent: a default would either satisfy the
+    // required check (making it vestigial) or never fire (making the
+    // default dead code). Reject at parse time so authors fix the YAML.
+    expect(() => workflowInputsZ.parse({ x: { type: "string", required: true, default: "fallback" } })).toThrow(
+      /required.*default|default.*required/i,
+    );
+  });
+
+  it("accepts `required: true` without a `default`", () => {
+    const parsed = workflowInputsZ.parse({ x: { type: "string", required: true } });
+    expect(parsed.x.required).toBe(true);
+    expect(parsed.x.default).toBeUndefined();
+  });
+
+  it("accepts a `default` without `required: true`", () => {
+    const parsed = workflowInputsZ.parse({ x: { type: "string", default: "fallback" } });
+    expect(parsed.x.default).toBe("fallback");
+    expect(parsed.x.required).toBeUndefined();
+  });
+
+  it("accepts `required: false` together with a `default` (false is the optional default)", () => {
+    // Explicit `required: false` is the same as omitting it; the default
+    // is permitted in that case because there's no conflict.
+    const parsed = workflowInputsZ.parse({ x: { type: "string", required: false, default: "x" } });
+    expect(parsed.x.required).toBe(false);
+    expect(parsed.x.default).toBe("x");
+  });
+
   it("covers every declared WORKFLOW_INPUT_TYPES value", () => {
     for (const t of WORKFLOW_INPUT_TYPES) {
       const parsed = workflowInputsZ.parse({ f: { type: t } });

--- a/packages/core/src/__tests__/inputs.test.ts
+++ b/packages/core/src/__tests__/inputs.test.ts
@@ -6,8 +6,9 @@ import {
   WORKFLOW_INPUT_TYPES,
   type WorkflowInputs,
 } from "../inputs.js";
-import { workflowZ, parseWorkflow } from "../schema.js";
+import { workflowZ, parseWorkflow, workflowTypeZ } from "../schema.js";
 import { execute } from "../executor.js";
+import { buildStartRunPayload } from "../cli/cloud-lifecycle.js";
 import type { Claude, Tool, Workflow } from "../types.js";
 
 // ─── validateRuntimeInput ─────────────────────────────────────────
@@ -240,6 +241,109 @@ describe("workflowZ with inputs", () => {
       edges: [],
     });
     expect(parsed.inputs).toBeUndefined();
+  });
+});
+
+// ─── inputs × workflow_type composition ──────────────────────────
+//
+// Pins the contract documented in spec/src/content/docs/workflow.mdx
+// under "Composition with workflow_type":
+//
+//   1. Any workflow type can declare inputs.
+//   2. Inputs are additive, never inferred or replaced by the type.
+//   3. No reserved field names per type.
+//   4. Cloud renderers may display both surfaces; the runtime does not
+//      couple them. The cloud start-run payload carries workflow_type
+//      separately and never reads the declared inputs.
+
+describe("inputs composition with workflow_type", () => {
+  it("every workflow_type value accepts a declared inputs block", () => {
+    // Iterate the canonical enum so adding a new type forces a decision
+    // about whether the additive rule still applies.
+    for (const type of workflowTypeZ.options) {
+      const parsed = workflowZ.parse({
+        id: `wf-${type}`,
+        name: `WF ${type}`,
+        entry: "a",
+        workflow_type: type,
+        nodes: { a: { name: "A", instruction: "x" } },
+        edges: [],
+        inputs: {
+          since_tag: { type: "string", required: true },
+          dry_run: { type: "boolean", default: false },
+        },
+      });
+      expect(parsed.workflow_type).toBe(type);
+      expect(parsed.inputs?.since_tag.required).toBe(true);
+      expect(parsed.inputs?.dry_run.default).toBe(false);
+    }
+  });
+
+  it("pr_review with inputs does not reserve or auto-inject field names", () => {
+    // No input name (pull_request_url, repo, severity, etc.) is reserved
+    // by the pr_review type. Author-declared fields ride alongside,
+    // unchanged.
+    const wf = parseWorkflow({
+      id: "pr-review-with-inputs",
+      name: "PR Review",
+      entry: "review",
+      workflow_type: "pr_review",
+      nodes: { review: { name: "Review", instruction: "Review the diff" } },
+      edges: [],
+      inputs: {
+        pull_request_url: { type: "string", required: true },
+        severity_floor: { type: "string", enum: ["low", "medium", "high"], default: "low" },
+      },
+    });
+    expect(wf.workflow_type).toBe("pr_review");
+    expect(Object.keys(wf.inputs ?? {}).sort()).toEqual(["pull_request_url", "severity_floor"]);
+    // Nothing implicit was injected.
+    expect(Object.keys(wf.inputs ?? {})).not.toContain("pr_url");
+    expect(Object.keys(wf.inputs ?? {})).not.toContain("repository");
+  });
+
+  it("declared inputs validate independently of workflow_type", () => {
+    // Same caller input is validated identically whether the workflow is
+    // typed as pr_review, monitor, or generic. The type does not change
+    // required/default/enum semantics.
+    const declared: WorkflowInputs = {
+      target: { type: "string", required: true },
+      retries: { type: "number", default: 0 },
+    };
+    const callerInput = { target: "v1.0.0" };
+    const r = validateRuntimeInput(declared, callerInput);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ target: "v1.0.0", retries: 0 });
+  });
+
+  it("cloud start-run payload carries workflow_type but never the declared inputs", () => {
+    // The cloud lifecycle ships workflow_type to route the renderer. It
+    // does NOT read or forward the declared inputs (the values would be
+    // sensitive; the shape is exposed elsewhere via summarizeInputShape).
+    const wf: Pick<Workflow, "id" | "workflow_type"> = {
+      id: "release-notes",
+      workflow_type: "content_generation",
+    };
+    const payload = buildStartRunPayload(wf, { runUuid: "abc-123", env: {} });
+    expect(payload.workflow_id).toBe("release-notes");
+    expect(payload.workflow_type).toBe("content_generation");
+    expect(payload).not.toHaveProperty("inputs");
+    expect(payload).not.toHaveProperty("input");
+  });
+
+  it("absent workflow_type still accepts inputs (treated as generic)", () => {
+    const wf = parseWorkflow({
+      id: "no-type-but-inputs",
+      name: "No Type",
+      entry: "a",
+      nodes: { a: { name: "A", instruction: "x" } },
+      edges: [],
+      inputs: {
+        since: { type: "string", default: "HEAD~10" },
+      },
+    });
+    expect(wf.workflow_type).toBeUndefined();
+    expect(wf.inputs?.since.default).toBe("HEAD~10");
   });
 });
 

--- a/packages/core/src/cli/__tests__/cloud-lifecycle.test.ts
+++ b/packages/core/src/cli/__tests__/cloud-lifecycle.test.ts
@@ -102,6 +102,34 @@ describe("buildStartRunPayload", () => {
     const payload = buildStartRunPayload({ id: "x" }, { runUuid: "u" });
     expect(payload.workflow_type).toBe("generic");
   });
+
+  it("omits inputs_shape when neither declared nor resolved inputs are passed", () => {
+    const payload = buildStartRunPayload({ id: "x" }, { runUuid: "u" });
+    expect(payload.inputs_shape).toBeUndefined();
+  });
+
+  it("derives inputs_shape from the declared inputs (no values)", () => {
+    const payload = buildStartRunPayload(
+      { id: "release-notes", workflow_type: "content_generation" },
+      {
+        runUuid: "u",
+        declaredInputs: {
+          since_tag: { type: "string" },
+          draft: { type: "boolean", default: true },
+        },
+        resolvedInputs: { since_tag: "v1.41.0", draft: false },
+      },
+    );
+    expect(payload.inputs_shape).toEqual({ since_tag: "string", draft: "boolean" });
+  });
+
+  it("falls back to observed types when no declaration is provided", () => {
+    const payload = buildStartRunPayload(
+      { id: "x" },
+      { runUuid: "u", resolvedInputs: { repo: "owner/name", dryRun: true } },
+    );
+    expect(payload.inputs_shape).toEqual({ repo: "string", dryRun: "boolean" });
+  });
 });
 
 describe("newRunUuid", () => {
@@ -288,6 +316,37 @@ describe("beginCloudLifecycle / finishCloudLifecycle — CLI wire-up wrapper", (
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body.workflow_id).toBe("monitor-1");
     expect(body.workflow_type).toBe("monitor");
+  });
+
+  it("transmits the input shape but never the values, even when a secret is in the bag", async () => {
+    // Spec contract (workflow.mdx, Telemetry shape): cloud renderers MAY
+    // display the input shape (key → type) but MUST NOT ship the values.
+    // This test fails if the literal secret ever appears in any part of
+    // the cloud payload; the strongest possible regression guard.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ run_id: "r-secret" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const SECRET = "sk-test-secret-do-not-leak";
+    await beginCloudLifecycle(
+      { cloudToken: "tok" },
+      { id: "wf-with-secret", workflow_type: "generic" as const },
+      {
+        declaredInputs: { token: { type: "string" }, draft: { type: "boolean" } },
+        resolvedInputs: { token: SECRET, draft: true },
+      },
+    );
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const rawBody = init.body as string;
+    // Hard guarantee: the literal secret bytes do not appear anywhere in
+    // the serialized payload. No JSON-encoding, no parent key, nothing.
+    expect(rawBody).not.toContain(SECRET);
+    const body = JSON.parse(rawBody) as Record<string, unknown>;
+    expect(body.inputs_shape).toEqual({ token: "string", draft: "boolean" });
+    expect(body.inputs).toBeUndefined();
   });
 
   it("finishCloudLifecycle is a no-op when handle is null", async () => {

--- a/packages/core/src/cli/cloud-lifecycle.ts
+++ b/packages/core/src/cli/cloud-lifecycle.ts
@@ -17,7 +17,8 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { ExecutionEvent, NodeResult, Observer, Workflow } from "../types.js";
+import { summarizeInputShape } from "../inputs.js";
+import type { ExecutionEvent, NodeResult, Observer, Workflow, WorkflowInputs } from "../types.js";
 
 const CLOUD_URL_DEFAULT = "https://cloud.sweny.ai";
 const TIMEOUT_MS = 10_000;
@@ -51,6 +52,17 @@ export interface StartRunInput {
   trigger_metadata?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   run_uuid?: string;
+  /**
+   * Declared input shape for this run: key name → declared (or observed)
+   * type. Values are intentionally NEVER included; per the workflow spec
+   * (Telemetry shape), cloud renderers may display the input contract a
+   * run was invoked with but must not receive the values themselves. A
+   * workflow that takes a token as input therefore never leaks it.
+   *
+   * Omitted when the caller didn't pass an inputs shape (e.g. legacy
+   * call sites pre-dating the inputs contract).
+   */
+  inputs_shape?: Record<string, string>;
 }
 
 export interface StartRunResult {
@@ -130,10 +142,21 @@ export function newRunUuid(): string {
 /**
  * Build a run-start payload from a Workflow + env. Pure function; the caller
  * is responsible for passing it to `startRun()`.
+ *
+ * `inputsShape` (when provided) ships the key-name → declared-type map for
+ * the run. Values are NEVER transmitted; callers compute the shape via
+ * `summarizeInputShape` (or pass the workflow's declared `inputs` block
+ * and resolved input bag and let this helper compute it). See the
+ * Telemetry shape rule in spec/src/content/docs/workflow.mdx.
  */
 export function buildStartRunPayload(
   workflow: Pick<Workflow, "id" | "workflow_type">,
-  options: { runUuid: string; env?: NodeJS.ProcessEnv },
+  options: {
+    runUuid: string;
+    env?: NodeJS.ProcessEnv;
+    declaredInputs?: WorkflowInputs;
+    resolvedInputs?: Record<string, unknown>;
+  },
 ): StartRunInput {
   const env = options.env ?? process.env;
   const trigger_source = detectTriggerSource(env);
@@ -142,7 +165,7 @@ export function buildStartRunPayload(
   if (env.GITHUB_REF) metadata.branch = env.GITHUB_REF.replace(/^refs\/heads\//, "");
   if (env.GITHUB_SHA) metadata.commit_sha = env.GITHUB_SHA;
   if (env.GITHUB_ACTOR) metadata.actor = env.GITHUB_ACTOR;
-  return {
+  const payload: StartRunInput = {
     workflow_id: workflow.id,
     workflow_type: workflow.workflow_type ?? "generic",
     trigger_source,
@@ -150,6 +173,17 @@ export function buildStartRunPayload(
     metadata,
     run_uuid: options.runUuid,
   };
+  // Compute the shape when caller provided either a declaration or a
+  // resolved bag. Omit the key entirely when there's nothing to summarize
+  // so old cloud builds that don't model `inputs_shape` aren't surprised
+  // by an empty object.
+  if (options.declaredInputs || options.resolvedInputs) {
+    const shape = summarizeInputShape(options.declaredInputs, options.resolvedInputs);
+    if (Object.keys(shape).length > 0) {
+      payload.inputs_shape = shape;
+    }
+  }
+  return payload;
 }
 
 /**
@@ -269,10 +303,15 @@ export interface CloudLifecycleHandle {
 export async function beginCloudLifecycle(
   config: { cloudToken?: string; repository?: string },
   workflow: Pick<Workflow, "id" | "workflow_type">,
+  options?: { declaredInputs?: WorkflowInputs; resolvedInputs?: Record<string, unknown> },
 ): Promise<CloudLifecycleHandle | null> {
   if (!config.cloudToken) return null;
   const runUuid = newRunUuid();
-  const payload = buildStartRunPayload(workflow, { runUuid });
+  const payload = buildStartRunPayload(workflow, {
+    runUuid,
+    declaredInputs: options?.declaredInputs,
+    resolvedInputs: options?.resolvedInputs,
+  });
   const reportConfig: CloudReportConfig = {
     cloudToken: config.cloudToken,
     repository: config.repository,

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -421,7 +421,14 @@ triageCmd.action(async (options: Record<string, unknown>) => {
   // node-streaming observer can attach events to the correct runId.
   // Null when the token is unset or startRun fails — cloud reporting
   // must never block the workflow.
-  const cloudHandle = await beginCloudLifecycle(config, triageWorkflow);
+  //
+  // Cloud sees the input *shape* (key names + observed types), never
+  // the values. Per workflow spec Telemetry shape rule, a token in the
+  // bag never leaves the host.
+  const cloudHandle = await beginCloudLifecycle(config, triageWorkflow, {
+    declaredInputs: triageWorkflow.inputs,
+    resolvedInputs: workflowInput,
+  });
   if (cloudHandle?.dashboardUrl) {
     console.log(c.subtle(`  cloud: ${cloudHandle.dashboardUrl}`));
   }
@@ -616,8 +623,11 @@ implementCmd.action(async (issueId: string, options: Record<string, unknown>) =>
 
   // Open cloud lifecycle session BEFORE composing observers so the
   // node-streaming observer can attach to the correct runId. See
-  // triage path for rationale.
-  const implCloudHandle = await beginCloudLifecycle(config, implementWorkflow);
+  // triage path for rationale. Cloud sees the input *shape* only.
+  const implCloudHandle = await beginCloudLifecycle(config, implementWorkflow, {
+    declaredInputs: implementWorkflow.inputs,
+    resolvedInputs: workflowInput,
+  });
   if (implCloudHandle?.dashboardUrl) {
     console.log(c.subtle(`  cloud: ${implCloudHandle.dashboardUrl}`));
   }
@@ -916,8 +926,13 @@ export async function workflowRunAction(
 
   // Open cloud lifecycle session BEFORE composing observers so the
   // node-streaming observer can attach to the correct runId. See
-  // triage path for rationale.
-  const wfCloudHandle = await beginCloudLifecycle(config, workflow);
+  // triage path for rationale. Cloud sees the input *shape* only,
+  // never the values. Enforces the workflow spec Telemetry rule
+  // even when the workflow's declared inputs include secrets.
+  const wfCloudHandle = await beginCloudLifecycle(config, workflow, {
+    declaredInputs: workflow.inputs,
+    resolvedInputs: workflowInput,
+  });
   if (wfCloudHandle?.dashboardUrl && !isJson) {
     console.log(c.subtle(`  cloud: ${wfCloudHandle.dashboardUrl}`));
   }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -20,6 +20,7 @@ import { buildAutoMcpServers, buildSkillMcpServers, buildProviderContext } from 
 import { loadAdditionalContext } from "../templates.js";
 import type { McpAutoConfig } from "../types.js";
 import { loadAndValidateWorkflow } from "../loader.js";
+import { validateRuntimeInput } from "../inputs.js";
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
@@ -840,13 +841,38 @@ export async function workflowRunAction(
   let workflowInput: Record<string, unknown>;
 
   if (options.input && typeof options.input === "string") {
+    let parsed: unknown;
     try {
-      workflowInput = JSON.parse(options.input as string);
+      parsed = JSON.parse(options.input as string);
     } catch {
       console.error(chalk.red("  --input must be valid JSON"));
       process.exit(1);
       return;
     }
+    // Validate against the workflow's declared `inputs` contract (when present).
+    // Workflows without an `inputs` block pass through unchanged.
+    const validated = validateRuntimeInput(workflow.inputs, parsed);
+    if (!validated.ok) {
+      console.error(chalk.red(`\n  --input does not match workflow "${workflow.id}" inputs contract:\n`));
+      for (const err of validated.errors) {
+        console.error(chalk.red(`    ✗ ${err.field}: ${err.message}`));
+      }
+      if (workflow.inputs) {
+        console.error(chalk.dim(`\n  Declared inputs:`));
+        for (const [name, field] of Object.entries(workflow.inputs)) {
+          const flags: string[] = [field.type];
+          if (field.required) flags.push("required");
+          if (field.default !== undefined) flags.push(`default=${JSON.stringify(field.default)}`);
+          console.error(
+            chalk.dim(`    - ${name} (${flags.join(", ")})${field.description ? `: ${field.description}` : ""}`),
+          );
+        }
+      }
+      console.error("");
+      process.exit(1);
+      return;
+    }
+    workflowInput = validated.value;
   } else {
     workflowInput = {
       timeRange: config.timeRange,
@@ -866,6 +892,26 @@ export async function workflowRunAction(
       }),
       context: buildProviderCtx(config, mcpServers),
     };
+
+    // If the workflow declared `inputs`, apply defaults to the config-derived bag.
+    // This lets a CI caller omit --input entirely and still get the documented
+    // defaults filled in (e.g. since_tag/until_tag pulled from a release-notes
+    // workflow's declaration).
+    if (workflow.inputs) {
+      const validated = validateRuntimeInput(workflow.inputs, workflowInput);
+      if (!validated.ok) {
+        console.error(
+          chalk.red(`\n  Workflow "${workflow.id}" declares required inputs not satisfied by default config:\n`),
+        );
+        for (const err of validated.errors) {
+          console.error(chalk.red(`    ✗ ${err.field}: ${err.message}`));
+        }
+        console.error(chalk.dim(`\n  Pass them via --input '{ ... }'.\n`));
+        process.exit(1);
+        return;
+      }
+      workflowInput = validated.value;
+    }
   }
 
   // Open cloud lifecycle session BEFORE composing observers so the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,14 @@ export type {
   ResolvedSource,
   SourceKind,
   SourceResolutionMap,
+  WorkflowInputs,
+  WorkflowInputField,
+  WorkflowInputType,
+  InputValidationError,
+  InputValidationResult,
 } from "./types.js";
+
+export { WORKFLOW_INPUT_TYPES } from "./types.js";
 
 export { consoleLogger } from "./types.js";
 
@@ -90,11 +97,15 @@ export {
   mcpServerConfigZ,
   skillDefinitionZ,
   sourceZ,
+  workflowInputsZ,
   parseWorkflow,
   validateWorkflow,
   workflowJsonSchema,
 } from "./schema.js";
 export type { WorkflowError } from "./schema.js";
+
+// Workflow input validation
+export { validateRuntimeInput, summarizeInputShape } from "./inputs.js";
 
 // MCP auto-injection
 export { buildAutoMcpServers, buildSkillMcpServers, buildProviderContext } from "./mcp.js";

--- a/packages/core/src/inputs.ts
+++ b/packages/core/src/inputs.ts
@@ -23,7 +23,11 @@
  *   4. `default` fills in the value when the caller omits it. The default
  *      is type-checked against the field's `type` at parse time, so
  *      authors can't ship a YAML that injects a string into a number
- *      field at run time.
+ *      field at run time. `required: true` and `default` are mutually
+ *      exclusive: declaring both is incoherent (the default either
+ *      satisfies the required check, making it vestigial, or it doesn't,
+ *      making the default dead code), so the schema rejects the
+ *      combination at parse time.
  *   5. Telemetry redaction: the executor only ever sees the resolved
  *      `input` map. Cloud observers see the *shape* (key names + types)
  *      via `summarizeInputShape`, never the values, so a workflow that
@@ -89,6 +93,19 @@ const workflowInputFieldZ = z
   })
   .strict()
   .superRefine((field, ctx) => {
+    // `required: true` together with a `default` is incoherent: if the
+    // default substitutes for an omitted value, the field is effectively
+    // optional; if the required check fires, the default is dead code.
+    // Reject the combination at parse time so authors fix the YAML
+    // instead of relying on undocumented runtime tie-breaking.
+    if (field.required === true && field.default !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "field cannot declare both `required: true` and `default`; pick one (a default makes the field optional)",
+        path: ["required"],
+      });
+    }
     if (field.default !== undefined) {
       const err = checkValueType(field.default, field.type);
       if (err) {

--- a/packages/core/src/inputs.ts
+++ b/packages/core/src/inputs.ts
@@ -1,0 +1,289 @@
+/**
+ * Workflow inputs — declared per-run parameter contract.
+ *
+ * A workflow YAML may declare a top-level `inputs` block describing the
+ * per-run parameters it accepts. The CLI validates `--input <json>` against
+ * this declaration, applies defaults, and rejects malformed runs at the
+ * boundary so node prompts and conditional routing receive a well-shaped
+ * `input` value.
+ *
+ * Design notes (the contract that matters for downstream consumers):
+ *
+ *   1. The `inputs` block is OPTIONAL. Workflows without one accept any
+ *      JSON object (back-compat with every workflow shipped before this
+ *      change). Author opts in by adding the block.
+ *   2. Types are the JSON-native primitives we can validate without a
+ *      schema engine: `string`, `number`, `boolean`, plus `string[]` for
+ *      multi-value cases (labels, files, etc.). This is intentionally
+ *      narrower than full JSON Schema. Authors who need richer shapes can
+ *      still pass an arbitrary object; declaring it just opts into the
+ *      validator. We can widen later without breaking existing YAML.
+ *   3. `required: true` makes a field mandatory. Missing fields surface a
+ *      single grouped error listing every gap, not one error per call.
+ *   4. `default` fills in the value when the caller omits it. The default
+ *      is type-checked against the field's `type` at parse time, so
+ *      authors can't ship a YAML that injects a string into a number
+ *      field at run time.
+ *   5. Telemetry redaction: the executor only ever sees the resolved
+ *      `input` map. Cloud observers see the *shape* (key names + types)
+ *      via `summarizeInputShape`, never the values, so a workflow that
+ *      takes API tokens as input never leaks them.
+ *
+ * Out of scope on purpose:
+ *   - No templating language (`{{input.foo}}` etc.). Workflow instructions
+ *     are natural-language and the LLM already sees `input` in its context
+ *     map; that path is good enough for v1 and avoids inventing a dialect.
+ *   - No nested object schemas. If a single workflow needs deep input,
+ *     pass a JSON blob through and document it; we can layer schemas in
+ *     later. Most production use cases are flat (since_tag, until_tag,
+ *     dry_run, repo, time_range, etc.).
+ */
+
+import { z } from "zod";
+
+/**
+ * Supported input field types.
+ *
+ * Kept narrow on purpose. See module docstring for rationale.
+ */
+export const WORKFLOW_INPUT_TYPES = ["string", "number", "boolean", "string[]"] as const;
+export type WorkflowInputType = (typeof WORKFLOW_INPUT_TYPES)[number];
+
+/** A single declared input field. */
+export interface WorkflowInputField {
+  /** JSON-native type. See {@link WORKFLOW_INPUT_TYPES}. */
+  type: WorkflowInputType;
+  /** Human-readable description. Surfaced by CLI help and cloud renderers. */
+  description?: string;
+  /** When true, the caller MUST provide a value. */
+  required?: boolean;
+  /**
+   * Default applied when the caller omits the field. Type-checked against
+   * `type` at YAML parse time (a string default on a number field is a
+   * schema error, not a runtime surprise).
+   */
+  default?: unknown;
+  /** Optional set of allowed values. Validated after type-check. */
+  enum?: unknown[];
+}
+
+/** Declared input contract for a workflow. Keys are field names. */
+export type WorkflowInputs = Record<string, WorkflowInputField>;
+
+// ─── Zod schema ─────────────────────────────────────────────────
+
+const workflowInputTypeZ = z.enum(WORKFLOW_INPUT_TYPES);
+
+/**
+ * Per-field validator. Cross-field checks (default matches type, enum
+ * values match type) run in superRefine so all problems on a single field
+ * surface together rather than one-at-a-time.
+ */
+const workflowInputFieldZ = z
+  .object({
+    type: workflowInputTypeZ,
+    description: z.string().optional(),
+    required: z.boolean().optional(),
+    default: z.unknown().optional(),
+    enum: z.array(z.unknown()).min(1).optional(),
+  })
+  .strict()
+  .superRefine((field, ctx) => {
+    if (field.default !== undefined) {
+      const err = checkValueType(field.default, field.type);
+      if (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `default ${err}`,
+          path: ["default"],
+        });
+      }
+    }
+    if (field.enum) {
+      for (let i = 0; i < field.enum.length; i++) {
+        const err = checkValueType(field.enum[i], field.type);
+        if (err) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `enum[${i}] ${err}`,
+            path: ["enum", i],
+          });
+        }
+      }
+    }
+  });
+
+export const workflowInputsZ = z.record(workflowInputFieldZ);
+
+// ─── Validation ─────────────────────────────────────────────────
+
+/** A single validation error against the declared input contract. */
+export interface InputValidationError {
+  field: string;
+  message: string;
+}
+
+/** Tagged result of validating raw runtime input against a declared contract. */
+export type InputValidationResult =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; errors: InputValidationError[] };
+
+/**
+ * Validate the caller's raw input object against the workflow's declared
+ * `inputs` block. Applies defaults for omitted optional fields. Surfaces
+ * every problem in a single response so the CLI prints a useful message
+ * instead of failing on the first error.
+ *
+ * When no `inputs` block is declared, returns the caller's object verbatim
+ * (back-compat: every existing workflow passes through unchanged).
+ */
+export function validateRuntimeInput(declared: WorkflowInputs | undefined, raw: unknown): InputValidationResult {
+  // Back-compat: no declaration → accept anything.
+  if (!declared || Object.keys(declared).length === 0) {
+    if (raw == null) return { ok: true, value: {} };
+    if (typeof raw !== "object" || Array.isArray(raw)) {
+      return { ok: false, errors: [{ field: "(root)", message: "input must be a JSON object" }] };
+    }
+    return { ok: true, value: raw as Record<string, unknown> };
+  }
+
+  if (raw != null && (typeof raw !== "object" || Array.isArray(raw))) {
+    return { ok: false, errors: [{ field: "(root)", message: "input must be a JSON object" }] };
+  }
+  const provided = (raw ?? {}) as Record<string, unknown>;
+
+  const errors: InputValidationError[] = [];
+  const out: Record<string, unknown> = {};
+
+  for (const [name, field] of Object.entries(declared)) {
+    const has = Object.prototype.hasOwnProperty.call(provided, name);
+    let value = has ? provided[name] : undefined;
+
+    if (!has || value === undefined || value === null) {
+      if (field.default !== undefined) {
+        out[name] = field.default;
+        continue;
+      }
+      if (field.required) {
+        errors.push({ field: name, message: "required but not provided" });
+      }
+      // Optional and no default: leave unset. Downstream `priorNode.input.X`
+      // reads will see `undefined`, which JSON-serializes as absent.
+      continue;
+    }
+
+    const typeErr = checkValueType(value, field.type);
+    if (typeErr) {
+      errors.push({ field: name, message: typeErr });
+      continue;
+    }
+
+    if (field.enum && !field.enum.some((v) => deepEqual(v, value))) {
+      errors.push({
+        field: name,
+        message: `must be one of: ${field.enum.map((v) => JSON.stringify(v)).join(", ")}`,
+      });
+      continue;
+    }
+
+    out[name] = value;
+  }
+
+  // Pass through caller-provided keys that aren't in the declaration.
+  // This is intentional: existing CLI flags (timeRange, dryRun, etc.)
+  // and the cascade `rules`/`context` mechanism inject extra keys into
+  // the input bag. The declaration narrows the contract for documented
+  // fields without locking down the whole object.
+  for (const [k, v] of Object.entries(provided)) {
+    if (!Object.prototype.hasOwnProperty.call(declared, k)) {
+      out[k] = v;
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value: out };
+}
+
+/**
+ * Summary of an input bag suitable for telemetry: keys + observed types,
+ * never values. Cloud renderers use this to display the input contract a
+ * run was invoked with, without leaking the values themselves.
+ *
+ * `declared` shapes the output when present (so the summary stays stable
+ * across runs even when the caller omits optional fields). Falls back to
+ * the resolved values' runtime shape when no declaration exists.
+ */
+export function summarizeInputShape(
+  declared: WorkflowInputs | undefined,
+  resolved: Record<string, unknown> | undefined,
+): Record<string, WorkflowInputType | "object" | "null"> {
+  const shape: Record<string, WorkflowInputType | "object" | "null"> = {};
+  if (declared) {
+    for (const [name, field] of Object.entries(declared)) {
+      shape[name] = field.type;
+    }
+    return shape;
+  }
+  if (!resolved) return shape;
+  for (const [name, value] of Object.entries(resolved)) {
+    shape[name] = observedType(value);
+  }
+  return shape;
+}
+
+// ─── Internals ──────────────────────────────────────────────────
+
+function checkValueType(value: unknown, type: WorkflowInputType): string | null {
+  switch (type) {
+    case "string":
+      return typeof value === "string" ? null : `must be a string (got ${observedType(value)})`;
+    case "number":
+      return typeof value === "number" && Number.isFinite(value)
+        ? null
+        : `must be a finite number (got ${observedType(value)})`;
+    case "boolean":
+      return typeof value === "boolean" ? null : `must be a boolean (got ${observedType(value)})`;
+    case "string[]":
+      if (!Array.isArray(value)) return `must be an array of strings (got ${observedType(value)})`;
+      for (let i = 0; i < value.length; i++) {
+        if (typeof value[i] !== "string") {
+          return `must be an array of strings (element ${i} is ${observedType(value[i])})`;
+        }
+      }
+      return null;
+  }
+}
+
+function observedType(value: unknown): WorkflowInputType | "object" | "null" {
+  if (value === null) return "null";
+  if (Array.isArray(value)) {
+    return value.every((v) => typeof v === "string") ? "string[]" : "object";
+  }
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return "object";
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a == null || b == null) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a as Record<string, unknown>);
+    const bk = Object.keys(b as Record<string, unknown>);
+    if (ak.length !== bk.length) return false;
+    return ak.every((k) => deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  }
+  return false;
+}

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -19,7 +19,9 @@ import {
   SKILL_ID_PATTERN,
 } from "./types.js";
 import { sourceZ } from "./sources.js";
+import { workflowInputsZ, WORKFLOW_INPUT_TYPES } from "./inputs.js";
 export { sourceZ };
+export { workflowInputsZ };
 
 // ─── Zod Schemas ─────────────────────────────────────────────────
 
@@ -280,6 +282,7 @@ export const workflowZ = z.object({
   context: z.array(sourceZ).optional(),
   judge_model: z.string().min(1).optional(),
   judge_budget: z.number().int().min(0).optional(),
+  inputs: workflowInputsZ.optional(),
 });
 
 const LEGACY_VERIFY_MESSAGE =
@@ -647,6 +650,40 @@ export const workflowJsonSchema = {
       default: 50,
       description:
         "Soft cap on expected judge calls per workflow run. Executor warns at load time if exceeded; not a hard runtime cap in v1.",
+    },
+    inputs: {
+      type: "object",
+      description:
+        "Declared per-run input contract. Each entry names a parameter the caller may supply via --input. The CLI validates against this declaration, applies defaults for omitted optional fields, and rejects unknown types before the executor runs. Optional; workflows without an inputs block accept any JSON object (back-compat).",
+      additionalProperties: {
+        type: "object",
+        required: ["type"],
+        additionalProperties: false,
+        properties: {
+          type: {
+            type: "string",
+            enum: [...WORKFLOW_INPUT_TYPES],
+            description: "JSON-native type. Use a flat object if you need richer shapes.",
+          },
+          description: {
+            type: "string",
+            description: "Human-readable purpose. Shown in CLI help and cloud renderers.",
+          },
+          required: {
+            type: "boolean",
+            default: false,
+            description: "When true, the caller must provide a value.",
+          },
+          default: {
+            description: "Value applied when the caller omits the field. Type-checked at parse time against 'type'.",
+          },
+          enum: {
+            type: "array",
+            minItems: 1,
+            description: "Optional set of allowed values. Validated after the type check.",
+          },
+        },
+      },
     },
     nodes: {
       type: "object",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,16 @@
 // ─── Source re-exports ──────────────────────────────────────────
 export type { Source, ResolvedSource, SourceKind, SourceResolutionMap } from "./sources.js";
 
+// ─── Workflow input re-exports ──────────────────────────────────
+export type {
+  WorkflowInputs,
+  WorkflowInputField,
+  WorkflowInputType,
+  InputValidationError,
+  InputValidationResult,
+} from "./inputs.js";
+export { WORKFLOW_INPUT_TYPES } from "./inputs.js";
+
 // ─── Skill System ────────────────────────────────────────────────
 //
 // A Skill is a logical group of tools that share configuration.
@@ -339,6 +349,16 @@ export interface Workflow {
   judge_model?: string;
   /** Soft cap on expected judge calls per workflow run. Warning at load time when exceeded. */
   judge_budget?: number;
+  /**
+   * Declared per-run input contract. When present, the CLI validates the
+   * caller-provided `--input` JSON against this declaration, applies defaults
+   * for omitted optional fields, and rejects malformed input before the
+   * executor runs. Workflows without an `inputs` block accept any JSON
+   * object (back-compat).
+   *
+   * See `src/inputs.ts` for the field shape and validation rules.
+   */
+  inputs?: import("./inputs.js").WorkflowInputs;
 }
 
 /**

--- a/spec/public/schemas/workflow.json
+++ b/spec/public/schemas/workflow.json
@@ -261,6 +261,39 @@
       "default": 50,
       "description": "Soft cap on expected judge calls per workflow run. Executor warns at load time if exceeded; not a hard runtime cap in v1."
     },
+    "inputs": {
+      "type": "object",
+      "description": "Declared per-run input contract. Each entry names a parameter the caller may supply via --input. The CLI validates against this declaration, applies defaults for omitted optional fields, and rejects unknown types before the executor runs. Optional; workflows without an inputs block accept any JSON object (back-compat).",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type"],
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["string", "number", "boolean", "string[]"],
+            "description": "JSON-native type. Use a flat object if you need richer shapes."
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable purpose. Shown in CLI help and cloud renderers."
+          },
+          "required": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, the caller must provide a value."
+          },
+          "default": {
+            "description": "Value applied when the caller omits the field. Type-checked at parse time against 'type'."
+          },
+          "enum": {
+            "type": "array",
+            "minItems": 1,
+            "description": "Optional set of allowed values. Validated after the type check."
+          }
+        }
+      }
+    },
     "nodes": {
       "type": "object",
       "additionalProperties": {

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -7,18 +7,19 @@ A Workflow is the top-level document. It defines a directed graph of [Nodes](/no
 
 ## Fields
 
-| Field           | Type                                                             | Required | Default   | Description                                                                                                |
-| --------------- | ---------------------------------------------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------- |
-| `id`            | string                                                           | REQUIRED | —         | Unique identifier for this workflow. MUST be non-empty.                                                    |
-| `name`          | string                                                           | REQUIRED | —         | Human-readable name. MUST be non-empty.                                                                    |
-| `description`   | string                                                           | OPTIONAL | `""`      | Purpose of the workflow.                                                                                   |
-| `entry`         | string                                                           | REQUIRED | —         | Node ID where execution begins. MUST reference a key in `nodes`.                                           |
-| `nodes`         | Record&lt;string, [Node](/nodes)&gt;                             | REQUIRED | —         | Map of node ID to Node definition. Keys are referenced by `entry` and edge `from`/`to` fields.             |
-| `edges`         | [Edge](/edges)[]                                                 | REQUIRED | —         | Directed edges defining execution flow and routing conditions.                                             |
-| `skills`        | Record&lt;string, [SkillDefinition](#skilldefinition-object)&gt; | OPTIONAL | `{}`      | Inline skill definitions scoped to this workflow.                                                          |
-| `rules`         | [Source](/sources)[]                                             | OPTIONAL | `[]`      | Directives prepended to every node's instruction. Organization-wide policies, coding standards.            |
-| `context`       | [Source](/sources)[]                                             | OPTIONAL | `[]`      | Background knowledge prepended to every node's instruction. Architecture docs, playbooks.                  |
-| `workflow_type` | string (enum)                                                    | OPTIONAL | `generic` | Workflow type discriminator. Routes runs to a type-specific renderer. See [Workflow type](#workflow-type). |
+| Field           | Type                                                             | Required | Default   | Description                                                                                                            |
+| --------------- | ---------------------------------------------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `id`            | string                                                           | REQUIRED | —         | Unique identifier for this workflow. MUST be non-empty.                                                                |
+| `name`          | string                                                           | REQUIRED | —         | Human-readable name. MUST be non-empty.                                                                                |
+| `description`   | string                                                           | OPTIONAL | `""`      | Purpose of the workflow.                                                                                               |
+| `entry`         | string                                                           | REQUIRED | —         | Node ID where execution begins. MUST reference a key in `nodes`.                                                       |
+| `nodes`         | Record&lt;string, [Node](/nodes)&gt;                             | REQUIRED | —         | Map of node ID to Node definition. Keys are referenced by `entry` and edge `from`/`to` fields.                         |
+| `edges`         | [Edge](/edges)[]                                                 | REQUIRED | —         | Directed edges defining execution flow and routing conditions.                                                         |
+| `skills`        | Record&lt;string, [SkillDefinition](#skilldefinition-object)&gt; | OPTIONAL | `{}`      | Inline skill definitions scoped to this workflow.                                                                      |
+| `rules`         | [Source](/sources)[]                                             | OPTIONAL | `[]`      | Directives prepended to every node's instruction. Organization-wide policies, coding standards.                        |
+| `context`       | [Source](/sources)[]                                             | OPTIONAL | `[]`      | Background knowledge prepended to every node's instruction. Architecture docs, playbooks.                              |
+| `workflow_type` | string (enum)                                                    | OPTIONAL | `generic` | Workflow type discriminator. Routes runs to a type-specific renderer. See [Workflow type](#workflow-type).             |
+| `inputs`        | Record&lt;string, [InputField](#inputs)&gt;                      | OPTIONAL | —         | Declared per-run input contract. The CLI validates `--input` against this and applies defaults. See [Inputs](#inputs). |
 
 ## Workflow type
 
@@ -86,6 +87,107 @@ When executing a workflow, you may pass runtime input parameters. Two special fi
 - **`context`** — A [Source](/sources) or array of Sources containing background information prepended to every node's instruction. These layer on top of workflow-level and node-level context.
 
 Runtime input rules and context resolve eagerly before any node executes. See [Nodes — Input Augmentation](/nodes#input-augmentation) for the full assembly order.
+
+## Inputs
+
+A workflow MAY declare a top-level `inputs` block describing the per-run parameters it accepts. When present, the CLI validates the caller-supplied `--input <json>` against this declaration before the executor runs, applies defaults for omitted optional fields, and rejects malformed input with a grouped error message.
+
+Workflows without an `inputs` block accept any JSON object (back-compat with every workflow shipped before this feature).
+
+### InputField
+
+Each entry in `inputs` declares one parameter:
+
+| Field         | Type           | Required | Description                                                                               |
+| ------------- | -------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `type`        | string (enum)  | REQUIRED | One of `string`, `number`, `boolean`, `string[]`.                                         |
+| `description` | string         | OPTIONAL | Human-readable purpose. Shown in CLI errors and cloud renderers.                          |
+| `required`    | boolean        | OPTIONAL | When `true`, the caller MUST provide a value. Default: `false`.                           |
+| `default`     | matches `type` | OPTIONAL | Value applied when the caller omits the field. Type-checked at parse time against `type`. |
+| `enum`        | array          | OPTIONAL | Optional set of allowed values. Each entry MUST match the field's `type`.                 |
+
+Types are intentionally narrow. If you need richer shapes, model them as a flat object and let the receiving node parse the field. The contract MAY widen later without breaking existing YAML.
+
+### Validation rules
+
+A conforming runtime MUST enforce:
+
+1. **Required check.** Each declared field with `required: true` MUST be present in the caller's input.
+2. **Type check.** Each declared field's value MUST match its `type`. `number` rejects `NaN` and `±Infinity`. `string[]` requires every element to be a string.
+3. **Enum check.** When `enum` is declared, the value MUST equal one of the listed entries.
+4. **Default fill.** When a field is absent or `null` AND has a `default`, the runtime MUST substitute the default before passing the input to the executor.
+5. **Caller wins.** A caller-provided value MUST take precedence over a declared `default`.
+6. **Undeclared keys pass through.** Keys provided by the caller that aren't declared in `inputs` SHOULD pass through unchanged (so CLI-injected fields like `dryRun` and the runtime `rules`/`context` cascade keep working).
+7. **All errors at once.** A validator MUST surface every missing-required and type-mismatch in a single response, not one error per call.
+
+### Telemetry shape
+
+Cloud renderers and run dashboards MAY display the input _shape_ a run was invoked with (key names plus their declared types), but MUST NOT ship the input values themselves. A workflow that accepts a token or other secret as input never leaks the value to telemetry.
+
+### Example
+
+```yaml
+id: release-notes
+name: Release Notes
+description: Draft release notes for the next tag
+entry: discover
+
+inputs:
+  since_tag:
+    type: string
+    description: Lower bound for the commit range. Default is the previous tag.
+    default: ""
+  until_tag:
+    type: string
+    description: Upper bound for the commit range.
+    default: HEAD
+  draft:
+    type: boolean
+    description: When true, post the notes as a draft instead of publishing.
+    default: true
+  audience:
+    type: string
+    description: Target audience for the notes.
+    enum: [drivers, dispatchers, engineering, all]
+    default: all
+  required_label:
+    type: string
+    required: true
+    description: Issue label to scope the changelog to.
+
+nodes:
+  discover:
+    name: Discover changes
+    instruction: >-
+      Compare commits between input.since_tag and input.until_tag.
+      Scope to PRs labeled input.required_label. Group by area.
+edges: []
+```
+
+### Invocation
+
+CLI:
+
+```bash
+sweny workflow run release-notes.yml \
+  --input '{"since_tag":"v1.41.12","until_tag":"v1.41.13","required_label":"release"}'
+```
+
+GitHub Action (composite):
+
+```yaml
+- uses: swenyai/sweny@v5
+  with:
+    workflow: .sweny/release-notes.yml
+    input: |
+      {
+        "since_tag": "${{ inputs.since_tag }}",
+        "until_tag": "${{ github.ref_name }}",
+        "required_label": "release"
+      }
+```
+
+Workflow authors reference inputs by name in node instructions and edge `when` conditions; the resolved bag is exposed to every node as `input` on the prompt context.
 
 ## Structural Validation
 

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -45,6 +45,8 @@ A conforming consumer:
 
 Marketplace templates published in v1+ are required to declare `workflow_type` so they render correctly out of the box.
 
+`workflow_type` is independent of the [Inputs](#inputs) contract. A workflow of any type MAY declare `inputs`, and the type discriminator does not reserve any field names. The composition rules are spelled out under [Inputs and `workflow_type`](#composition-with-workflow_type).
+
 ### Example
 
 ```yaml
@@ -127,6 +129,18 @@ A conforming runtime MUST enforce:
 Cloud renderers and run dashboards MAY display the input _shape_ a run was invoked with (key names plus their declared types), but MUST NOT ship the input values themselves. A workflow that accepts a token or other secret as input never leaks the value to telemetry.
 
 A conforming runtime that posts run-start telemetry MUST transmit the shape under the payload key `inputs_shape` (key name → declared type, e.g. `{ "since_tag": "string", "draft": "boolean" }`) and MUST NOT include the matching `inputs` (or any equivalent values bag) in the same or any other telemetry payload. Runtimes that do not transmit input data at all trivially satisfy this rule and MAY omit `inputs_shape` entirely.
+
+### Composition with workflow_type
+
+The `inputs` contract and the [`workflow_type`](#workflow-type) discriminator are orthogonal. They do not introspect each other. Concretely:
+
+1. **Any workflow type can declare inputs.** `pr_review`, `e2e_test`, `content_generation`, `monitor`, `data_sync`, and `generic` workflows all accept an `inputs` block. There is no type for which `inputs` is illegal, and no type that requires `inputs`. The validator does not gate `inputs` on `workflow_type`.
+2. **Inputs are purely additive.** Declaring `inputs` does NOT replace, infer, or override anything the type's renderer might display. The author's declared parameters ride alongside the type's standard fields. Cloud renderers compose the two surfaces; they do not choose between them.
+3. **No reserved field names.** No type reserves an input name. A `pr_review` workflow MAY name a field `pull_request_url`, `pr`, `repo`, `severity`, anything. The renderer does not look inside the input bag to populate its own UI; the type's standard fields come from cloud-side trigger metadata (PR URL from the GitHub Action context, e.g.), not from `inputs`. If your workflow needs a value the renderer also displays, it is the author's job to wire it through.
+4. **Renderer scope.** When a typed workflow declares `inputs`, the cloud run dashboard MAY display BOTH the input shape (key names + declared types, never values; see [Telemetry shape](#telemetry-shape)) AND the type's standard fields. The two panes are independent. A renderer MUST NOT fail or warn if a typed workflow declares inputs.
+5. **No runtime coupling.** The executor passes the resolved `input` bag to every node regardless of `workflow_type`. Type-specific cloud renderers do not introspect the `input` bag's contents at runtime; they only see the declared shape via the telemetry surface.
+
+If a future workflow type needs to require named input fields (e.g. a hypothetical `scheduled_report` type that requires a `cadence` field), the spec will name those fields explicitly and the validator will enforce them. As of v1, no type does.
 
 ### Example
 

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -124,6 +124,8 @@ A conforming runtime MUST enforce:
 
 Cloud renderers and run dashboards MAY display the input _shape_ a run was invoked with (key names plus their declared types), but MUST NOT ship the input values themselves. A workflow that accepts a token or other secret as input never leaks the value to telemetry.
 
+A conforming runtime that posts run-start telemetry MUST transmit the shape under the payload key `inputs_shape` (key name → declared type, e.g. `{ "since_tag": "string", "draft": "boolean" }`) and MUST NOT include the matching `inputs` (or any equivalent values bag) in the same or any other telemetry payload. Runtimes that do not transmit input data at all trivially satisfy this rule and MAY omit `inputs_shape` entirely.
+
 ### Example
 
 ```yaml

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -106,16 +106,18 @@ Each entry in `inputs` declares one parameter:
 | `default`     | matches `type` | OPTIONAL | Value applied when the caller omits the field. Type-checked at parse time against `type`. |
 | `enum`        | array          | OPTIONAL | Optional set of allowed values. Each entry MUST match the field's `type`.                 |
 
+An InputField MUST NOT declare both `required: true` and a `default`; the combination is incoherent (a default would either silently satisfy the required check, or never fire) and is rejected at workflow load time. Authors who want the required check to fire MUST omit the `default`. Authors who want a fallback value MUST omit `required: true`.
+
 Types are intentionally narrow. If you need richer shapes, model them as a flat object and let the receiving node parse the field. The contract MAY widen later without breaking existing YAML.
 
 ### Validation rules
 
 A conforming runtime MUST enforce:
 
-1. **Required check.** Each declared field with `required: true` MUST be present in the caller's input.
+1. **Required check.** Each declared field with `required: true` MUST be present in the caller's input. (A field with `required: true` cannot also declare a `default`; see [InputField](#inputfield).)
 2. **Type check.** Each declared field's value MUST match its `type`. `number` rejects `NaN` and `±Infinity`. `string[]` requires every element to be a string.
 3. **Enum check.** When `enum` is declared, the value MUST equal one of the listed entries.
-4. **Default fill.** When a field is absent or `null` AND has a `default`, the runtime MUST substitute the default before passing the input to the executor.
+4. **Default fill.** When a field is absent or `null` AND has a `default`, the runtime MUST substitute the default before passing the input to the executor. Because `required` and `default` are mutually exclusive, this rule only applies to optional fields.
 5. **Caller wins.** A caller-provided value MUST take precedence over a declared `default`.
 6. **Undeclared keys pass through.** Keys provided by the caller that aren't declared in `inputs` SHOULD pass through unchanged (so CLI-injected fields like `dryRun` and the runtime `rules`/`context` cascade keep working).
 7. **All errors at once.** A validator MUST surface every missing-required and type-mismatch in a single response, not one error per call.


### PR DESCRIPTION
## Why

The composite GitHub Action (the generic engine wrapper, post-refactor) has no plumbing for per-run parameters. A workflow whose `discover` node needs `since_tag` / `until_tag` overrides at invocation has no way to receive them from a `workflow_dispatch` event. The CLI already accepts `--input <json>`, but the action wrapper doesn't surface it, and the existing path validates nothing, so a typo in `--input` either flows into the model as garbage or fails inside a node with a useless error.

Building on #194 / #195 / #196 (verbose), #197 (route-eval schema strip), #198 (verbose on triage / implement).

## What

Library-first design, option **(a)** from the survey: workflows declare a typed input contract.

- New top-level optional `inputs:` block on the workflow schema. Each entry declares `type` (`string` | `number` | `boolean` | `string[]`), and optionally `description`, `required`, `default`, `enum`. Field-level defaults and enum members are type-checked at YAML parse time, not at run time.
- New `validateRuntimeInput(declared, raw)` and `summarizeInputShape(declared, resolved)` functions exposed from `@sweny-ai/core`. The CLI's `workflow run --input` calls the validator before the executor runs, applies defaults for omitted optional fields, and surfaces every problem in one grouped error message.
- Composite GHA gains a matching `input:` (string-of-JSON, forwarded verbatim). Handled symmetrically with `dry-run` / `verbose`: pulled in via env and appended to the CLI flag array, no string-vs-object inconsistency.
- Spec doc and the published JSON Schema both document the new contract.

## Decision space considered

- **(a)** Declared inputs block (chosen). Strongest documentation surface, type-safe defaults, validator at the CLI boundary, telemetry-shape-only redaction. Costs the most code.
- **(b)** Pure passthrough. Smallest patch. Rejected because the validator at the boundary is the load-bearing piece — without it `--input` typos still reach the model.
- **(c)** Passthrough now, declared later. Rejected as a half-step; the contract is small enough to land in one PR.

Out of scope on purpose: no `{{input.foo}}` templating, no nested-object schemas. The LLM already sees `input` in its context map; natural-language reference is the existing substrate.

## Back-compat

Workflows without an `inputs` block accept any JSON object, unchanged. Every existing bundled workflow (`triage.yml`, `implement.yml`, `seed-content.yml`, `examples/file-ops.yml`) keeps working with zero edits. The 1640-test baseline grew to 1667.

## Test plan

- [x] `validateRuntimeInput`: declared vs undeclared, type checks for all four types, NaN / Infinity rejection, all-required-errors-at-once, default fill, caller-wins-over-default, optional-leaves-unset, enum, explicit-null-treated-as-missing, undeclared-keys-pass-through.
- [x] `workflowInputsZ`: every declared type accepted, unknown types rejected, type-mismatched defaults rejected, type-mismatched enum members rejected, unknown field keys rejected.
- [x] `workflowZ` integration: workflow with `inputs:` parses; `parseWorkflow` rejects malformed inputs blocks; workflows without `inputs:` continue to parse.
- [x] `summarizeInputShape`: declared shape preferred when present, observed shape on falls back; values never appear in the output.
- [x] End-to-end through `execute()`: input.X reaches the first node's context AND the routing-decision context.
- [x] `yarn workspace @sweny-ai/core typecheck` clean.
- [x] `yarn workspace @sweny-ai/core test --run` 1667 / 1667 passing.
- [x] `yarn workspace @sweny-ai/core build` regenerates `spec/public/schemas/workflow.json` with the new `inputs` block.
- [x] `yarn lint` 0 errors.

## Followups (separate PRs, intentionally out of scope here)

- `swenyai/triage` and `swenyai/e2e` action wrappers: add a matching `input:` forwarder. Same shape as this PR's, plus their own existing flag set.
- Bundled workflows: opt `triage` / `implement` / `seed-content` into a declared `inputs:` block where it replaces CLI flags.
- Cloud telemetry: pipe `summarizeInputShape(workflow.inputs, resolved)` into `beginCloudLifecycle` metadata so the dashboard renders the declared contract per run.