### PR TITLE
fix(core): route evaluator should fail loud on declared-but-missing output fields

### DIFF
--- a/.changeset/route-eval-missing-field-loud.md
+++ b/.changeset/route-eval-missing-field-loud.md
@@ -1,0 +1,20 @@
+---
+"@sweny-ai/core": patch
+---
+
+Fix route evaluator silently treating declared-but-missing output fields as
+matchable. When a source node declared `output.properties.foo` but the agent
+omitted `foo` from its emitted JSON, the route eval view dropped the key
+entirely. A natural-language edge condition like `foo is 0 or foo is undefined`
+then ghost-matched on the structurally-absent field, taking the wrong branch.
+
+The view is now contract-shaped: every declared property appears in the route
+eval context, with explicit `null` when the agent did not emit it. A new
+`node:warning` execution event surfaces the missing-field set so observers and
+log streams see the contract violation. The evaluate prompt now instructs the
+model to treat `null` as "declared but unknown", not as any specific value.
+
+Additionally, when the source schema declares a property in its `required`
+array and the agent omits it, the node is now failed post-run with a clear
+error, so routing follows the failure path instead of guessing against a
+half-built data view.

--- a/packages/core/src/__tests__/claude.test.ts
+++ b/packages/core/src/__tests__/claude.test.ts
@@ -935,6 +935,19 @@ describe("buildEvaluatePrompt", () => {
     expect(prompt.trim().endsWith("Respond with ONLY the choice ID, nothing else.")).toBe(true);
   });
 
+  it("instructs the model to treat explicit null as 'declared but unknown', not as 0/false/undefined/etc.", async () => {
+    const { buildEvaluatePrompt } = await import("../claude.js");
+    // The executor fills declared-but-missing output properties with
+    // explicit null. Without this rule, the LLM evaluator can match
+    // a null value against a literal-zero or "is undefined" condition
+    // and take the wrong branch. See executor.ts buildRouteEvalEntry
+    // and the offload release-notes field bug.
+    const prompt = buildEvaluatePrompt("Q?", {}, [{ id: "a", description: "x" }]);
+    expect(prompt.toLowerCase()).toContain("null");
+    expect(prompt).toMatch(/declared.*did NOT emit a value/i);
+    expect(prompt.toLowerCase()).toMatch(/do not match.*is 0/);
+  });
+
   it("handles empty context and empty choice list without throwing", async () => {
     const { buildEvaluatePrompt } = await import("../claude.js");
     // Edge case: defensive. The executor never calls evaluate() with zero

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -2592,6 +2592,292 @@ describe("route evaluator: schema-strict view of prior data", () => {
   });
 });
 
+// ─── Route evaluator: declared-but-missing field handling ────────
+//
+// Second-order field bug from the offload release-notes workflow.
+//
+// A draft node declared `output.properties.quality_retry_count` (optional,
+// not in `required`). The agent omitted the field on the first pass. The
+// schema-strict filter (PR #197) correctly stripped non-schema noise from
+// the route eval view, but it ALSO quietly dropped declared-but-missing
+// keys via `if (k in obj)` in pickKeys. The route view ended up with no
+// quality_retry_count key at all.
+//
+// The edge condition `quality_retry_count is 0 OR is undefined` then
+// matched on "undefined" because the field was structurally absent from
+// the context, and the workflow took the wrong branch.
+//
+// Two failure modes, one root cause:
+//   1. Declared optional + omitted by agent → key missing → "is undefined"
+//      ghost-match.
+//   2. Declared required + omitted by agent → silent failure with the
+//      same routing impact, no signal to the operator.
+//
+// Fix: declared properties are part of the routing contract. They must
+// appear in the route eval view, with explicit `null` when the agent did
+// not emit them. Required-but-missing fields are a stronger contract
+// violation and fail the node loudly.
+
+describe("route evaluator: declared-but-missing field handling", () => {
+  it("surfaces declared optional fields as explicit null when the agent omits them", async () => {
+    // Exact downstream shape: draft node declared quality_retry_count as
+    // an optional property; agent omitted it; edge condition references
+    // it. The route view must include the key (with null) so the LLM
+    // evaluator cannot ghost-match "is undefined".
+    const workflow: Workflow = {
+      id: "declared-missing-null",
+      name: "Declared Missing Null",
+      description: "",
+      entry: "draft",
+      nodes: {
+        draft: {
+          name: "Draft",
+          instruction: "Draft",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+              quality_retry_count: { type: "number" },
+            },
+            required: ["status"], // quality_retry_count is optional
+          },
+        },
+        publish: { name: "Publish", instruction: "Publish", skills: [] },
+        retry: { name: "Retry", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "draft", to: "publish", when: "quality_retry_count is 0 or undefined" },
+        { from: "draft", to: "retry", when: "quality_retry_count is greater than 0" },
+      ],
+    };
+
+    let routeContext: Record<string, unknown> = {};
+    const claude: any = {
+      async run() {
+        return {
+          // Agent emits status but omits the optional quality_retry_count.
+          status: "success",
+          data: { status: "ok" },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        routeContext = opts.context;
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(workflow, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const draftView = routeContext.draft as Record<string, unknown>;
+    expect(draftView).toBeDefined();
+    expect(draftView).toHaveProperty("status", "ok");
+    // The key MUST be present. An absent key is the bug.
+    expect(draftView).toHaveProperty("quality_retry_count");
+    expect(draftView.quality_retry_count).toBeNull();
+  });
+
+  it("emits a node:warning observer event when a declared field is missing from emitted data", async () => {
+    // Loud signal: log streams and observers see the contract violation
+    // even when it's only an optional field. Without this, downstream
+    // tooling has no way to surface a misbehaving agent.
+    const workflow: Workflow = {
+      id: "declared-missing-warning",
+      name: "Declared Missing Warning",
+      description: "",
+      entry: "draft",
+      nodes: {
+        draft: {
+          name: "Draft",
+          instruction: "Draft",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+              quality_retry_count: { type: "number" },
+            },
+            required: ["status"],
+          },
+        },
+        publish: { name: "Publish", instruction: "Publish", skills: [] },
+        retry: { name: "Retry", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "draft", to: "publish", when: "quality_retry_count is 0 or undefined" },
+        { from: "draft", to: "retry", when: "quality_retry_count is greater than 0" },
+      ],
+    };
+
+    const events: ExecutionEvent[] = [];
+    const claude: any = {
+      async run() {
+        return { status: "success", data: { status: "ok" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    await execute(
+      workflow,
+      {},
+      {
+        skills: createSkillMap([]),
+        claude,
+        config: {},
+        observer: (e) => events.push(e),
+      },
+    );
+
+    const warnings = events.filter((e) => e.type === "node:warning") as Array<
+      ExecutionEvent & { type: "node:warning" }
+    >;
+    expect(warnings.length).toBeGreaterThan(0);
+    const w = warnings.find((x) => x.node === "draft");
+    expect(w).toBeDefined();
+    expect(w!.fields).toContain("quality_retry_count");
+  });
+
+  it("fails the node when a required declared field is missing from emitted data", async () => {
+    // Loudest signal: the schema's required array is the workflow author's
+    // contract. If the agent skips a required field, the node is failed
+    // post-run. Routing then follows the failure path instead of guessing
+    // against a half-built data view.
+    const workflow: Workflow = {
+      id: "declared-required-missing",
+      name: "Declared Required Missing",
+      description: "",
+      entry: "draft",
+      nodes: {
+        draft: {
+          name: "Draft",
+          instruction: "Draft",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+              quality_retry_count: { type: "number" },
+            },
+            required: ["status", "quality_retry_count"], // both required
+          },
+        },
+        publish: { name: "Publish", instruction: "Publish", skills: [] },
+        retry: { name: "Retry", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "draft", to: "publish", when: "quality_retry_count is 0" },
+        { from: "draft", to: "retry", when: "quality_retry_count is greater than 0" },
+      ],
+    };
+
+    const claude: any = {
+      async run() {
+        // Agent emits status but omits the required quality_retry_count.
+        return { status: "success", data: { status: "ok" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    const { results, trace } = await execute(
+      workflow,
+      {},
+      {
+        skills: createSkillMap([]),
+        claude,
+        config: {},
+      },
+    );
+
+    // The node ran but failed contract validation. routing keeps going
+    // through advanceFromNode, but the trace records a failed step.
+    const draftResult = results.get("draft");
+    expect(draftResult).toBeDefined();
+    expect(draftResult!.status).toBe("failed");
+    expect(String(draftResult!.data?.error ?? "")).toContain("quality_retry_count");
+
+    const draftStep = trace.steps.find((s) => s.node === "draft");
+    expect(draftStep?.status).toBe("failed");
+  });
+
+  it("does not warn or fail when every declared property is emitted", async () => {
+    // Negative control. The happy path is silent: no warning event, no
+    // failed step, no behavior change vs PR #197.
+    const workflow: Workflow = {
+      id: "declared-all-present",
+      name: "Declared All Present",
+      description: "",
+      entry: "draft",
+      nodes: {
+        draft: {
+          name: "Draft",
+          instruction: "Draft",
+          skills: [],
+          output: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+              quality_retry_count: { type: "number" },
+            },
+            required: ["status", "quality_retry_count"],
+          },
+        },
+        publish: { name: "Publish", instruction: "Publish", skills: [] },
+        retry: { name: "Retry", instruction: "Retry", skills: [] },
+      },
+      edges: [
+        { from: "draft", to: "publish", when: "quality_retry_count is 0" },
+        { from: "draft", to: "retry", when: "quality_retry_count is greater than 0" },
+      ],
+    };
+
+    const events: ExecutionEvent[] = [];
+    const claude: any = {
+      async run() {
+        return {
+          status: "success",
+          data: { status: "ok", quality_retry_count: 0 },
+          toolCalls: [],
+        };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+      async ask() {
+        return "";
+      },
+    };
+
+    const { results } = await execute(
+      workflow,
+      {},
+      {
+        skills: createSkillMap([]),
+        claude,
+        config: {},
+        observer: (e) => events.push(e),
+      },
+    );
+
+    const warnings = events.filter((e) => e.type === "node:warning");
+    expect(warnings).toEqual([]);
+    expect(results.get("draft")?.status).toBe("success");
+  });
+});
+
 // ─── Bundled workflows: routing contract invariants ──────────────
 //
 // Enforce the audit claim in PR #197 with a test: every conditional-edge

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -428,6 +428,7 @@ export function buildEvaluatePrompt(
     `1. Read each choice's condition literally and match against the structured fields in the context (e.g. status, counts, enum values, boolean flags).`,
     `2. Ignore prose narrative fields ("summary", free-form rationale, conversational commentary). They are not the contract.`,
     `3. When a field's value contradicts what a prose field claims, trust the field's value.`,
+    `4. A field whose value is explicitly null means the source node DECLARED that field but did NOT emit a value. Treat null as "unknown" and do NOT match it against any specific value (do not match "is 0", "is N", "is true", "is false", or "is undefined" against a null field). Prefer a default/fallback edge when the field needed for a decision is null.`,
     `\nRespond with ONLY the choice ID, nothing else.`,
   ].join("\n");
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -274,6 +274,28 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
       // Retry only triggers on eval failure. Bail on tool/API errors.
       if (result.status !== "success") break;
 
+      // Required-field gate: if the source node's declared output schema
+      // marks fields as `required`, those fields are the routing contract.
+      // An agent that omits a required field has violated the contract; we
+      // fail the node loudly rather than letting routing guess against a
+      // half-built data view. See the offload release-notes field bug:
+      // an optional quality_retry_count was declared in the schema but
+      // omitted by the agent, the route view silently dropped the key,
+      // and an "is 0 OR is undefined" condition ghost-matched.
+      //
+      // We only check declared `required` fields, not full JSON Schema
+      // validation. Type mismatches, formats, additionalProperties, etc.
+      // stay the workflow author's problem and don't have the same
+      // routing-correctness blast radius.
+      const missingRequired = findMissingRequiredFields(result.data, node.output);
+      if (missingRequired.length > 0) {
+        const msg = `output schema violation: required field(s) missing from emitted data: ${missingRequired.join(", ")}`;
+        result.status = "failed";
+        result.data = { ...(result.data ?? {}), error: msg };
+        logger.warn(`  ${msg}`, { node: currentId });
+        break;
+      }
+
       const evalResults = await evaluateAll(node.eval, result, {
         aliases: toolAliases,
         claude,
@@ -475,21 +497,50 @@ function buildPriorNodeContext(result: NodeResult): Record<string, unknown> {
  * `data` including any prose `summary`, so workflows that consume the
  * narrative in subsequent steps keep working.
  */
-function buildRouteEvalEntry(result: NodeResult, sourceNode: Node | undefined): Record<string, unknown> {
+function buildRouteEvalEntry(
+  result: NodeResult,
+  sourceNode: Node | undefined,
+): { view: Record<string, unknown>; missing: string[] } {
   const fullData = (result.data ?? {}) as Record<string, unknown>;
   const declaredProps = getDeclaredOutputProperties(sourceNode?.output);
 
-  const dataView: Record<string, unknown> = declaredProps ? pickKeys(fullData, declaredProps) : fullData;
+  // When the source node declared an `output.properties` block, the routing
+  // view is contract-shaped: every declared property is present in the
+  // view, with an explicit `null` when the agent did not emit it. The
+  // alternative (silently dropping the key) lets the LLM evaluator
+  // ghost-match conditions like "is 0", "is N", or "is undefined" against
+  // a structurally-absent field. That was the offload release-notes field
+  // bug: an optional `quality_retry_count` declared in the schema but
+  // omitted by the agent, evaluated against a condition like
+  // `quality_retry_count is 0 OR is undefined`, took the wrong branch.
+  //
+  // Returning `missing` separately lets the caller emit a loud warning so
+  // operators see the contract violation in the log stream.
+  let dataView: Record<string, unknown>;
+  const missing: string[] = [];
+  if (declaredProps) {
+    dataView = {};
+    for (const k of declaredProps) {
+      if (k in fullData) {
+        dataView[k] = fullData[k];
+      } else {
+        dataView[k] = null;
+        missing.push(k);
+      }
+    }
+  } else {
+    dataView = fullData;
+  }
 
   const evals = result.evals ?? [];
-  if (evals.length === 0) return dataView;
+  if (evals.length === 0) return { view: dataView, missing };
 
   const evalsByName: Record<string, unknown> = {};
   for (const e of evals) {
     evalsByName[e.name] = e;
   }
   // Spread evals first so a data-side `evals` key shadows it (back-compat).
-  return { evals: evalsByName, ...dataView };
+  return { view: { evals: evalsByName, ...dataView }, missing };
 }
 
 /**
@@ -510,12 +561,32 @@ function getDeclaredOutputProperties(output: JSONSchema | undefined): Set<string
   return new Set(keys);
 }
 
-function pickKeys(obj: Record<string, unknown>, keys: Set<string>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const k of keys) {
-    if (k in obj) out[k] = obj[k];
-  }
-  return out;
+/**
+ * Return the declared `required` field names for a node's output schema,
+ * or an empty array when no required block is declared. Tolerant of
+ * malformed schemas (mirrors getDeclaredOutputProperties).
+ */
+function getDeclaredRequiredFields(output: JSONSchema | undefined): string[] {
+  if (!output || typeof output !== "object") return [];
+  const required = (output as Record<string, unknown>).required;
+  if (!Array.isArray(required)) return [];
+  return required.filter((r): r is string => typeof r === "string");
+}
+
+/**
+ * Validate a node's emitted data against the declared output schema's
+ * required fields. Returns the list of required-but-missing field names.
+ *
+ * This is intentionally narrow: we do NOT do full JSON Schema validation.
+ * The routing impact comes from required fields being absent, so that's
+ * what we check. Type mismatches, format violations, additionalProperties
+ * etc. stay the workflow author's problem.
+ */
+function findMissingRequiredFields(data: unknown, output: JSONSchema | undefined): string[] {
+  const required = getDeclaredRequiredFields(output);
+  if (required.length === 0) return [];
+  const obj = (data ?? {}) as Record<string, unknown>;
+  return required.filter((k) => !(k in obj));
 }
 
 function nodeSourcesToArray(ns: NodeSources | undefined): { sources: Source[]; only: boolean } {
@@ -757,10 +828,32 @@ async function resolveNext(
   // always-injected `summary` prose from the reference Claude client) can
   // sway the natural-language route evaluator and override the actual
   // structured result. See `buildRouteEvalEntry` for the full rationale.
-  const context: Record<string, unknown> = {
-    input,
-    ...Object.fromEntries([...results.entries()].map(([k, v]) => [k, buildRouteEvalEntry(v, workflow.nodes[k])])),
-  };
+  const context: Record<string, unknown> = { input };
+  for (const [k, v] of results.entries()) {
+    const { view, missing } = buildRouteEvalEntry(v, workflow.nodes[k]);
+    context[k] = view;
+    if (missing.length > 0) {
+      // Loud signal for the operator. The view itself already replaces the
+      // missing keys with explicit `null`, so the LLM evaluator cannot
+      // ghost-match "is N" or "is undefined" against a structurally-absent
+      // field. The warning surfaces the contract violation in the log
+      // stream and to observer-based telemetry.
+      logger?.warn(`  route eval: source node '${k}' declared properties not in emitted data: ${missing.join(", ")}`, {
+        node: k,
+        fields: missing,
+      });
+      safeObserve(
+        observer,
+        {
+          type: "node:warning",
+          node: k,
+          reason: `declared output properties missing from emitted data; routing view filled them with null`,
+          fields: missing,
+        },
+        logger,
+      );
+    }
+  }
 
   const choices = conditionalEdges.map((e) => ({
     id: e.to,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -426,6 +426,18 @@ export type ExecutionEvent =
   | { type: "node:exit"; node: string; result: NodeResult }
   | { type: "node:progress"; node: string; message: string }
   | { type: "node:retry"; node: string; attempt: number; reason: string; preamble: string }
+  /**
+   * Non-fatal contract violation surfaced during node execution. Currently
+   * emitted when a source node declares output properties that the agent
+   * did not emit. The route eval view fills the missing keys with `null`
+   * so the LLM evaluator can't ghost-match conditions like "is undefined"
+   * or "is 0", but the operator still wants a loud signal in the log
+   * stream.
+   *
+   * `fields` lists the declared property names that were missing from the
+   * emitted data. `reason` is a short human-readable summary.
+   */
+  | { type: "node:warning"; node: string; reason: string; fields: string[] }
   | { type: "route"; from: string; to: string; reason: string }
   | { type: "workflow:end"; results: Record<string, NodeResult> };
 


### PR DESCRIPTION
## Summary

When a source node declared `output.properties.foo` but the agent omitted `foo` from its emitted JSON, the route eval view silently dropped the key. A natural-language edge condition like `foo is 0 OR foo is undefined` then ghost-matched on the structurally-absent field, taking the wrong branch on every retry.

This is the second-order field bug downstream from PR #197 (which fixed the prose-pollution side of the route view). The downstream symptom looked like the workflow was caching judge output across retries; it wasn't, the routing just never returned to judge because draft kept routing to the wrong successor.

## Fix

Three changes in `executor.ts` + `claude.ts`:

1. **`buildRouteEvalEntry` produces a contract-shaped view.** Every declared output property appears in the route eval context, with explicit `null` when the agent did not emit it. The LLM evaluator cannot ghost-match conditions against a structurally-absent field.
2. **New `node:warning` execution event.** Surfaces the missing-field set on every routing decision so observers and log streams see the contract violation. Loud signal without breaking the run.
3. **Required-but-missing fields fail the node post-run.** When the schema's `required` array names a property and the agent omits it, the node is marked `failed` with a clear error. Routing then follows the failure branch instead of guessing against a half-built data view.

`buildEvaluatePrompt` adds rule 4 telling the model to treat `null` as "declared but unknown": do not match against `is 0`, `is N`, `is true`, `is false`, or `is undefined`. Prefer a default/fallback edge when the field needed for a decision is null.

## Tests

5 new regression tests:

- `executor.test.ts > route evaluator: declared-but-missing field handling`
  - surfaces declared optional fields as explicit null when the agent omits them
  - emits a `node:warning` observer event when a declared field is missing from emitted data
  - fails the node when a required declared field is missing from emitted data
  - does not warn or fail when every declared property is emitted (negative control)
- `claude.test.ts > buildEvaluatePrompt`
  - instructs the model to treat explicit null as 'declared but unknown'

The first three fail when the fix is reverted; the others pin the invariant.

Full suite: 1712 tests pass.

## Downstream context

A consumer workflow (offload release-notes) hit this in a draft/judge retry loop. The downstream patch moved `quality_retry_count` to `required` and dropped the `OR is undefined` clause from the edge condition. That fixed the symptom. This upstream fix prevents the bug class for any future workflow author.

Reviewers may not have access to the downstream repo; everything they need is in this PR.

## Test plan

- [x] `npm test` in `packages/core` passes (1712/1712)
- [x] `npm run typecheck` clean
- [x] `npm run build` produces the expected dist
- [x] New tests fail before the fix and pass after (verified locally by reverting `executor.ts`)