### PR TITLE
feat(core): add linear_list_comments tool to the Linear skill

### DIFF
--- a/.changeset/linear-list-comments.md
+++ b/.changeset/linear-list-comments.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/core": minor
+---
+
+Add `linear_list_comments` to the Linear skill. Returns id, body, author, and timestamp for each comment on an issue, given an issue ID or identifier. The skill previously had no way to read an issue's comments, so any workflow needing comment history (for example, an idempotency check that scans for a sentinel comment before posting) had to fall back to the remote Linear MCP. The new tool is aliased to the Linear MCP `list_comments` tool so verify treats the two as equivalent.

--- a/packages/core/src/skills/linear.test.ts
+++ b/packages/core/src/skills/linear.test.ts
@@ -8,6 +8,7 @@ const ctx = (): ToolContext => ({
 });
 
 const listLabels = linear.tools.find((t) => t.name === "linear_list_labels")!;
+const listComments = linear.tools.find((t) => t.name === "linear_list_comments")!;
 
 function gqlResponse(data: unknown): Response {
   return new Response(JSON.stringify({ data }), {
@@ -63,5 +64,56 @@ describe("linear_list_labels", () => {
 
   it("is exposed as an alias for the Linear MCP list_issue_labels tool", () => {
     expect(linear.mcpAliases?.linear_list_labels).toEqual(["list_issue_labels"]);
+  });
+});
+
+describe("linear_list_comments", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("queries an issue's comments and defaults the limit to 50", async () => {
+    fetchMock.mockResolvedValueOnce(
+      gqlResponse({
+        issue: {
+          comments: {
+            nodes: [{ id: "com_1", body: "first", createdAt: "2026-05-19T00:00:00Z", user: { name: "Nate" } }],
+          },
+        },
+      }),
+    );
+
+    const result: any = await listComments.handler({ issueId: "OFF-1020" }, ctx());
+
+    expect(result.issue.comments.nodes[0]).toMatchObject({ body: "first" });
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.variables).toEqual({ id: "OFF-1020", first: 50 });
+    expect(sent.query).toContain("comments(first: $first)");
+  });
+
+  it("honors an explicit limit", async () => {
+    fetchMock.mockResolvedValueOnce(gqlResponse({ issue: { comments: { nodes: [] } } }));
+
+    await listComments.handler({ issueId: "OFF-1020", limit: 10 }, ctx());
+
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sent.variables).toEqual({ id: "OFF-1020", first: 10 });
+  });
+
+  it("throws when the issue is not found", async () => {
+    fetchMock.mockResolvedValueOnce(gqlResponse({ issue: null }));
+
+    await expect(listComments.handler({ issueId: "OFF-9999" }, ctx())).rejects.toThrow(/no issue "OFF-9999"/);
+  });
+
+  it("is exposed as an alias for the Linear MCP list_comments tool", () => {
+    expect(linear.mcpAliases?.linear_list_comments).toEqual(["list_comments"]);
   });
 });

--- a/packages/core/src/skills/linear.ts
+++ b/packages/core/src/skills/linear.ts
@@ -131,6 +131,37 @@ export const linear: Skill = {
         ),
     },
     {
+      name: "linear_list_comments",
+      description: "List comments on a Linear issue (returns id, body, author, and timestamp for each)",
+      input_schema: {
+        type: "object",
+        properties: {
+          issueId: { type: "string", description: "Linear issue ID (UUID) or identifier (e.g. 'OFF-1020')" },
+          limit: { type: "number", description: "Max comments to return (default: 50)" },
+        },
+        required: ["issueId"],
+      },
+      handler: async (input: { issueId: string; limit?: number }, ctx) => {
+        const data = await linearGql(
+          `query($id: String!, $first: Int) {
+            issue(id: $id) {
+              comments(first: $first) {
+                nodes { id body createdAt user { name } }
+              }
+            }
+          }`,
+          { id: input.issueId, first: input.limit ?? 50 },
+          ctx,
+        );
+        if (!data?.issue) {
+          throw new Error(
+            `[Linear] linear_list_comments found no issue "${input.issueId}". Raw response: ${JSON.stringify(data)}`,
+          );
+        }
+        return data;
+      },
+    },
+    {
       name: "linear_list_teams",
       description: "List Linear teams (needed for teamId when creating issues)",
       input_schema: {
@@ -217,6 +248,7 @@ export const linear: Skill = {
     linear_update_issue: ["save_issue"],
     linear_search_issues: ["list_issues"],
     linear_add_comment: ["save_comment"],
+    linear_list_comments: ["list_comments"],
     linear_list_teams: ["list_teams"],
     linear_list_labels: ["list_issue_labels"],
   },


### PR DESCRIPTION
## What

Adds `linear_list_comments` to the Linear skill.

The skill could create, search, update, and comment on issues, but had no tool to **read** an issue's existing comments. Workflows that need comment history had to fall back to the remote Linear MCP, which makes `skills: [linear]` alone insufficient for that class of workflow.

`linear_list_comments` takes an issue ID or identifier and returns `id`, `body`, author, and `createdAt` per comment (default limit 50). It is aliased to the Linear MCP `list_comments` tool in `mcpAliases`, so `verify` treats the built-in tool and the MCP tool as equivalent.

## Motivation

A release-cleanup workflow (transition Linear issues to a terminal state on a release tag, leave one audit comment per issue) needs to scan an issue's comments for a sentinel before posting, so re-runs stay idempotent. With the current skill that scan is impossible without the remote MCP. This tool closes that gap.

## Changes

- `packages/core/src/skills/linear.ts`: new `linear_list_comments` tool + `mcpAliases` entry.
- `packages/core/src/skills/linear.test.ts`: 4 tests (query shape, default limit, explicit limit, not-found throw, MCP alias).
- `.changeset/linear-list-comments.md`: minor bump for `@sweny-ai/core`.

## Test

```
npx vitest run src/skills/linear.test.ts   # 7 passed
npx tsc --noEmit                            # clean
```