### PR TITLE
docs(spec): spec + schema conformance follow-ups; github label-failure logging

### DIFF
--- a/packages/core/src/__tests__/inputs.test.ts
+++ b/packages/core/src/__tests__/inputs.test.ts
@@ -132,6 +132,31 @@ describe("validateRuntimeInput", () => {
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.value.foo).toBe("fallback");
   });
+
+  it("treats explicit null on a required field with no default as missing → required error", () => {
+    // Spec contract (workflow.mdx Inputs §Validation rule 1): an explicit
+    // null is symmetric with absence for the required check, just as it is
+    // for the default-fill rule below. Pinning this so the spec/lib
+    // agreement is not implicit.
+    const declared: WorkflowInputs = { token: { type: "string", required: true } };
+    const r = validateRuntimeInput(declared, { token: null });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors).toHaveLength(1);
+      expect(r.errors[0].field).toBe("token");
+      expect(r.errors[0].message).toMatch(/required but not provided/);
+    }
+  });
+
+  it("treats explicit null on an optional field with no default as absent (key omitted from result)", () => {
+    // Symmetric to the null-applies-default case. With no default to
+    // substitute and no required check to fail, null should simply not
+    // surface in the resolved input (matches absence behavior).
+    const declared: WorkflowInputs = { foo: { type: "string" } };
+    const r = validateRuntimeInput(declared, { foo: null });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect("foo" in r.value).toBe(false);
+  });
 });
 
 // ─── workflowInputsZ schema ──────────────────────────────────────

--- a/packages/core/src/__tests__/schema-conformance.test.ts
+++ b/packages/core/src/__tests__/schema-conformance.test.ts
@@ -406,6 +406,37 @@ const fixtures: Fixture[] = [
     expected: true,
   },
 
+  // ── Positive — new fields: inputs + disallowed_tools ─────────────
+  {
+    name: "workflow with a declared inputs block (string + boolean + default)",
+    input: {
+      id: "release-notes",
+      name: "Release Notes",
+      entry: "a",
+      nodes: { a: baseNode() },
+      edges: [],
+      inputs: {
+        since_tag: { type: "string", required: true },
+        draft: { type: "boolean", default: false },
+        labels: { type: "string[]", default: [] },
+      },
+    },
+    expected: true,
+  },
+  {
+    name: "node with disallowed_tools",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: {
+        a: { ...baseNode(), disallowed_tools: ["WebFetch", "WebSearch"] },
+      },
+      edges: [],
+    },
+    expected: true,
+  },
+
   // ── Negative — structural (shared by Zod schema parse + structural check) ──
   // These are rejected by Zod parse, so they should also be rejected by the
   // exported JSON Schema. (Structural checks like SELF_LOOP and UNREACHABLE
@@ -427,6 +458,64 @@ const fixtures: Fixture[] = [
       name: "D",
       entry: "a",
       nodes: "not an object",
+      edges: [],
+    },
+    expected: false,
+  },
+  // ── Negative — new fields ────────────────────────────────────────
+  {
+    // Spec contract (workflow.mdx Inputs: "An InputField MUST NOT declare
+    // both `required: true` and a `default`"). The Zod parser rejected this
+    // from day one; the JSON Schema needs the matching `not` constraint or
+    // editor/CI validators silently pass workflows the runtime will reject.
+    name: "inputs field declaring both required: true and a default",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: baseNode() },
+      edges: [],
+      inputs: {
+        bad: { type: "string", required: true, default: "fallback" },
+      },
+    },
+    expected: false,
+  },
+  {
+    name: "inputs field with required: false plus default (legal: false is the default)",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: baseNode() },
+      edges: [],
+      inputs: {
+        ok: { type: "string", required: false, default: "fallback" },
+      },
+    },
+    expected: true,
+  },
+  {
+    name: "inputs field with unknown type",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: baseNode() },
+      edges: [],
+      inputs: {
+        when: { type: "date" },
+      },
+    },
+    expected: false,
+  },
+  {
+    name: "disallowed_tools with an empty-string entry",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), disallowed_tools: [""] } },
       edges: [],
     },
     expected: false,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -684,6 +684,18 @@ export const workflowJsonSchema = {
             description: "Optional set of allowed values. Validated after the type check.",
           },
         },
+        // The combination `required: true` together with a `default` is incoherent:
+        // a default would either silently satisfy the required check (making it
+        // vestigial) or never fire (making the default dead code). Reject the
+        // combination at JSON-Schema validation time so external validators agree
+        // with the Zod parser. See workflowInputFieldZ.superRefine in inputs.ts.
+        not: {
+          type: "object",
+          required: ["required", "default"],
+          properties: {
+            required: { const: true },
+          },
+        },
       },
     },
     nodes: {

--- a/packages/core/src/skills/github.test.ts
+++ b/packages/core/src/skills/github.test.ts
@@ -1,11 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { github } from "./github.js";
-import type { ToolContext } from "../types.js";
+import type { Logger, ToolContext } from "../types.js";
 
-const ctx = (): ToolContext => ({
+const ctx = (overrides: Partial<ToolContext> = {}): ToolContext => ({
   config: { GITHUB_TOKEN: "test-token" },
   logger: console,
+  ...overrides,
 });
+
+function makeLogger(): Logger & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    info: () => undefined,
+    warn: (msg: string) => warnings.push(msg),
+    error: () => undefined,
+    debug: () => undefined,
+    warnings,
+  };
+}
 
 const createPr = github.tools.find((t) => t.name === "github_create_pr")!;
 
@@ -160,5 +172,42 @@ describe("github_create_pr", () => {
     await expect(createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx())).rejects.toThrow(
       /already exists/i,
     );
+  });
+
+  it("logs a warn when the label POST fails after a successful PR create", async () => {
+    // Closes the silent-failure path called out in the review of PR #189/#193:
+    // a label POST that returns 5xx (or any non-2xx) was caught and swallowed
+    // with zero log signal, so a label-misconfigured run looked indistinguishable
+    // from a successful one. The PR is still considered created (labeling is
+    // best-effort), but operators get a single line in the log naming the
+    // failure so they can investigate without grepping for ghosts.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(201, { number: 7, html_url: "https://github.com/o/r/pull/7" }))
+      .mockResolvedValueOnce(jsonResponse(500, { message: "labels endpoint down" }));
+
+    const logger = makeLogger();
+    const result: any = await createPr.handler(
+      { repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" },
+      ctx({ logger }),
+    );
+
+    // PR creation still considered successful — labels are best-effort.
+    expect(result).toMatchObject({ number: 7 });
+    expect(result.reused).toBeFalsy();
+    // A single warn line names the PR and the failure shape.
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]).toMatch(/label/i);
+    expect(logger.warnings[0]).toMatch(/pull\/7|#7/);
+  });
+
+  it("does not warn when label POST succeeds (no false positives in CI logs)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(201, { number: 12, html_url: "https://github.com/o/r/pull/12" }))
+      .mockResolvedValueOnce(jsonResponse(200, [{ name: "sweny" }, { name: "agent" }]));
+
+    const logger = makeLogger();
+    await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx({ logger }));
+
+    expect(logger.warnings).toHaveLength(0);
   });
 });

--- a/packages/core/src/skills/github.ts
+++ b/packages/core/src/skills/github.ts
@@ -199,8 +199,14 @@ export const github: Skill = {
               body: JSON.stringify({ labels: input.labels ?? ["sweny", "agent"] }),
             });
           }
-        } catch {
-          // Label failure is non-fatal
+        } catch (err) {
+          // Label failure is non-fatal: the PR is already created and labeling
+          // is a best-effort followup. Surface a single warn line naming the
+          // PR + failure so operators can tell a label-misconfigured run from
+          // a clean one. Without this log, a 5xx from /issues/:n/labels was
+          // indistinguishable from success in CI output.
+          const msg = err instanceof Error ? err.message : String(err);
+          ctx.logger?.warn?.(`  github_create_pr: label POST failed for ${pr.html_url ?? `#${pr.number}`} — ${msg}`);
         }
         return reused ? { ...pr, reused: true } : pr;
       },

--- a/spec/public/schemas/workflow.json
+++ b/spec/public/schemas/workflow.json
@@ -291,6 +291,15 @@
             "minItems": 1,
             "description": "Optional set of allowed values. Validated after the type check."
           }
+        },
+        "not": {
+          "type": "object",
+          "required": ["required", "default"],
+          "properties": {
+            "required": {
+              "const": true
+            }
+          }
         }
       }
     },

--- a/spec/src/content/docs/edges.mdx
+++ b/spec/src/content/docs/edges.mdx
@@ -58,6 +58,22 @@ A conforming executor:
 
 When a node has a mix of conditional and unconditional outgoing edges, the unconditional edge serves as a **default path**. The executor presents the conditional edges as choices, with the unconditional edge as a "none of the above" fallback.
 
+### Route-eval view of prior node results
+
+When a prior node declares an [`output`](/nodes#fields) JSON Schema with a non-empty `properties` block, a conforming executor:
+
+- **MUST** scope the routing view of that node's result data to the keys declared in `output.properties`. Non-schema fields (free-form `summary` prose, conversational rationale, debug commentary the model adds alongside the structured payload) MUST NOT reach the route evaluator.
+- **MUST** preserve the `evals` namespace on the routing view when present, so `when` conditions can reference `priorNode.evals.<name>.pass`.
+- **MUST** continue to expose the full prior-node `data` (including any non-schema fields) to **downstream node prompts** via context accumulation. The schema-strict filter is exclusively for route evaluation.
+
+When a prior node has no `output` schema, or the schema declares no `properties` block, the executor MUST expose the full `data` to the route evaluator (back-compatible behavior).
+
+Rationale: a natural-language route evaluator can be swayed by any prose it sees in the context. Declaring an `output` schema is the author's contract for "these are the fields that drive routing"; the runtime treats the schema as authoritative for routing without changing what downstream nodes can read.
+
+### Nested properties
+
+The schema-strict filter is top-level. If a declared property is itself an object (`type: "object"` with nested `properties`), the entire nested value passes through unchanged. The filter does not recurse. Authors who need to hide internal fields of a nested object MUST omit them from the parent object's output, not rely on this filter.
+
 ## Terminal Nodes
 
 A node with zero outgoing edges (after filtering exhausted edges) is a **terminal node**. Execution ends when a terminal node completes.

--- a/spec/src/content/docs/nodes.mdx
+++ b/spec/src/content/docs/nodes.mdx
@@ -7,19 +7,20 @@ A Node represents a single step in a [Workflow](/workflow). Each node contains a
 
 ## Fields
 
-| Field         | Type                             | Required | Default                      | Description                                                                    |
-| ------------- | -------------------------------- | -------- | ---------------------------- | ------------------------------------------------------------------------------ |
-| `name`        | string                           | REQUIRED | —                            | Display name for this node. MUST be non-empty.                                 |
-| `instruction` | [Source](/sources)               | REQUIRED | —                            | Natural language instruction for the AI model. MUST be non-empty.              |
-| `skills`      | string[]                         | OPTIONAL | `[]`                         | Skill IDs this node has access to.                                             |
-| `output`      | JSON Schema object               | OPTIONAL | —                            | Structured output schema for this node's result.                               |
-| `max_turns`   | integer &ge; 1                   | OPTIONAL | implementation&#8209;defined | Maximum AI model turns for this node's execution.                              |
-| `rules`       | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Rules for this node. Additive by default; see [cascade](#cascade-semantics).   |
-| `context`     | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Context for this node. Additive by default; see [cascade](#cascade-semantics). |
-| `eval`        | [Eval](#eval)                    | OPTIONAL | —                            | Named evaluators (value, function, judge) run after the AI finishes the node.  |
-| `eval_policy` | string                           | OPTIONAL | `all_pass`                   | How to aggregate evaluator results. v1 supports `all_pass`.                    |
-| `requires`    | [Requires](#requires)            | OPTIONAL | —                            | Machine-checked pre-conditions evaluated before the AI starts the node.        |
-| `retry`       | [Retry](#retry)                  | OPTIONAL | —                            | Node-local retry on eval failure with optional autonomous reflection.          |
+| Field              | Type                             | Required | Default                      | Description                                                                                                  |
+| ------------------ | -------------------------------- | -------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `name`             | string                           | REQUIRED | —                            | Display name for this node. MUST be non-empty.                                                               |
+| `instruction`      | [Source](/sources)               | REQUIRED | —                            | Natural language instruction for the AI model. MUST be non-empty.                                            |
+| `skills`           | string[]                         | OPTIONAL | `[]`                         | Skill IDs this node has access to.                                                                           |
+| `output`           | JSON Schema object               | OPTIONAL | —                            | Structured output schema for this node's result.                                                             |
+| `max_turns`        | integer &ge; 1                   | OPTIONAL | implementation&#8209;defined | Maximum AI model turns for this node's execution.                                                            |
+| `disallowed_tools` | string[]                         | OPTIONAL | `[]`                         | Built-in agent tools removed from the model context at this node. See [Disallowed Tools](#disallowed-tools). |
+| `rules`            | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Rules for this node. Additive by default; see [cascade](#cascade-semantics).                                 |
+| `context`          | [NodeSources](#nodesources-type) | OPTIONAL | inherited                    | Context for this node. Additive by default; see [cascade](#cascade-semantics).                               |
+| `eval`             | [Eval](#eval)                    | OPTIONAL | —                            | Named evaluators (value, function, judge) run after the AI finishes the node.                                |
+| `eval_policy`      | string                           | OPTIONAL | `all_pass`                   | How to aggregate evaluator results. v1 supports `all_pass`.                                                  |
+| `requires`         | [Requires](#requires)            | OPTIONAL | —                            | Machine-checked pre-conditions evaluated before the AI starts the node.                                      |
+| `retry`            | [Retry](#retry)                  | OPTIONAL | —                            | Node-local retry on eval failure with optional autonomous reflection.                                        |
 
 ## Max Turns Semantics
 
@@ -32,6 +33,32 @@ A conforming executor:
 - When the limit is reached, the executor **SHOULD** capture whatever partial result is available and produce a `NodeResult` with `status: "failed"` and a descriptive error in `data`. The executor **MUST NOT** silently discard the node's work.
 
 Different nodes have vastly different compute needs. A context-gathering node that queries multiple APIs may need many turns, while a summarization node with no tools may need one. Per-node limits give workflow authors fine-grained control over the compute budget.
+
+## Disallowed Tools
+
+The `disallowed_tools` field names built-in agent tools the AI model MUST NOT have access to at this node. Names refer to the agent runtime's built-in tools (e.g. `Bash`, `Read`, `Edit`, `Write`, `WebFetch`, `WebSearch`), not to skill-provided tool names declared in [Skills](/skills).
+
+Typical use: keep an `implement` node focused on the repo by removing `WebFetch` and `WebSearch`, or harden a notification node by removing `Bash` so the agent cannot shell out.
+
+A conforming executor:
+
+- **MUST** prevent the model from invoking any tool listed in `disallowed_tools` for the duration of this node's run.
+- **SHOULD** remove the named tools from the model's context entirely, rather than rejecting calls after the fact, so the model does not waste turns attempting blocked tools.
+- **MUST NOT** apply `disallowed_tools` to skill-provided tools registered via `skills`. Skills are gated by their own declaration (only listed `skills` are available); `disallowed_tools` is exclusively for built-in agent tools.
+- When the field is absent or empty, the executor applies its default tool set with no removals.
+
+```yaml
+implement:
+  name: Implement Fix
+  instruction: Read the issue, write the fix, run tests, commit.
+  skills:
+    - github
+  disallowed_tools:
+    - WebFetch
+    - WebSearch
+```
+
+The exact set of names the runtime recognizes is **implementation-defined** and tracks the agent SDK in use. Workflow authors SHOULD verify a name is honored before relying on it; a typo silently no-ops because there is no built-in tool of that name to remove.
 
 ## Rules & Context
 

--- a/spec/src/content/docs/workflow.mdx
+++ b/spec/src/content/docs/workflow.mdx
@@ -116,7 +116,7 @@ Types are intentionally narrow. If you need richer shapes, model them as a flat 
 
 A conforming runtime MUST enforce:
 
-1. **Required check.** Each declared field with `required: true` MUST be present in the caller's input. (A field with `required: true` cannot also declare a `default`; see [InputField](#inputfield).)
+1. **Required check.** Each declared field with `required: true` MUST be present in the caller's input. A field is "present" when the caller provides a non-`null` value; an explicit `null` (or absence of the key) MUST be treated as missing and surface the same required-field error. (A field with `required: true` cannot also declare a `default`; see [InputField](#inputfield).)
 2. **Type check.** Each declared field's value MUST match its `type`. `number` rejects `NaN` and `±Infinity`. `string[]` requires every element to be a string.
 3. **Enum check.** When `enum` is declared, the value MUST equal one of the listed entries.
 4. **Default fill.** When a field is absent or `null` AND has a `default`, the runtime MUST substitute the default before passing the input to the executor. Because `required` and `default` are mutually exclusive, this rule only applies to optional fields.


### PR DESCRIPTION
## Summary

Two related cleanups, one commit each.

**1. Spec + JSON Schema catch-up for #191, #197, #199.** All three landed code-first, leaving the published spec and exported JSON Schema behind the runtime.
- `nodes.mdx`: Disallowed Tools section + field-table row (#191)
- `edges.mdx`: route-eval schema-strict view of prior node results, incl. nested-property behavior (#197)
- `workflow.mdx`: explicit `null` is symmetric with absence for the required check (#199)
- `schema.ts` / `workflow.json`: `not` constraint rejecting an inputs field declaring both `required: true` and `default`. The Zod parser rejected this from day one; without the matching JSON Schema rule, editor/CI validators silently passed workflows the runtime rejects.
- Conformance + inputs tests pinning all of the above.

**2. `github_create_pr` label-failure logging.** A label POST returning non-2xx after a successful PR create was swallowed with zero log signal. PR creation stays successful (labeling is best-effort), but operators now get one warn line naming the PR and failure.

No explicit changeset added — the CI backstop covers `@sweny-ai/core`; `spec/` is unpublished.

## Test plan

- [x] `npx vitest run` in `packages/core` — 1727 passed, 0 failed
- [x] `npm run typecheck` in `packages/core` — clean
- [x] `workflow.json` validates as JSON
- [ ] Spec site build (`spec/`) green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)