### PR TITLE
refactor(cli): collapse e2e namespace into `sweny new` + `sweny workflow run`

### DIFF
--- a/.changeset/collapse-e2e-namespace.md
+++ b/.changeset/collapse-e2e-namespace.md
@@ -1,0 +1,10 @@
+---
+"@sweny-ai/core": minor
+---
+
+Collapse the `sweny e2e` command namespace into the single entry points. `sweny new` is now the one door for workflow creation, and `sweny workflow run` is the one door for running.
+
+- `sweny e2e init` → `sweny new e2e` (jumps straight into the e2e wizard; the interactive `sweny new` picker still offers it too).
+- `sweny e2e run` → `sweny workflow run`. With no file argument, `sweny workflow run` now batch-runs every workflow in `.sweny/e2e/`, lists them, and asks for confirmation first. Pass `--yes` (`-y`) to skip the prompt in CI, and `--timeout <ms>` for the per-workflow batch timeout.
+
+The public `swenyai/e2e` action is unaffected: it already invokes `sweny workflow run <file>` with an explicit file.

--- a/packages/core/src/cli/e2e.test.ts
+++ b/packages/core/src/cli/e2e.test.ts
@@ -9,6 +9,7 @@ import {
   buildFlowNodes,
   buildFlowWorkflow,
   buildE2eEnvTemplate,
+  batchRunDecision,
 } from "./e2e.js";
 import type { FlowConfig, FlowType, E2eSelections } from "./e2e.js";
 import type { Workflow } from "../types.js";
@@ -786,5 +787,22 @@ describe("runE2eInit — skipIntro option", () => {
     await expect(runE2eInit({ skipIntro: true })).rejects.toThrow("__abort_test__");
     expect(introSpy).not.toHaveBeenCalled();
     expect(logStepSpy).toHaveBeenCalledWith("Setting up end-to-end browser testing");
+  });
+});
+
+describe("batchRunDecision — no-file `sweny workflow run` batch gate", () => {
+  it("runs without prompting when --yes is passed (CI)", () => {
+    expect(batchRunDecision({ yes: true, isTTY: true })).toBe("run");
+    expect(batchRunDecision({ yes: true, isTTY: false })).toBe("run");
+  });
+
+  it("prompts for confirmation in an interactive shell", () => {
+    expect(batchRunDecision({ yes: false, isTTY: true })).toBe("confirm");
+    expect(batchRunDecision({ isTTY: true })).toBe("confirm");
+  });
+
+  it("refuses to batch-run non-interactively without --yes", () => {
+    expect(batchRunDecision({ yes: false, isTTY: false })).toBe("refuse-noninteractive");
+    expect(batchRunDecision({ isTTY: false })).toBe("refuse-noninteractive");
   });
 });

--- a/packages/core/src/cli/e2e.ts
+++ b/packages/core/src/cli/e2e.ts
@@ -1,5 +1,5 @@
 /**
- * sweny e2e — Generate and run agent-driven end-to-end browser tests.
+ * sweny e2e (now `sweny new e2e` + `sweny workflow run`) — generate and run agent-driven end-to-end browser tests.
  *
  * Pure functions for workflow generation + thin @clack/prompts interactive layer.
  * Tests cover the pure functions; the interactive wizard is thin glue.
@@ -594,7 +594,7 @@ const CLEANUP_ENV_VARS: Record<string, Array<{ key: string; hint?: string }>> = 
 export function buildE2eEnvTemplate(selections: E2eSelections): string {
   const lines: string[] = [];
   lines.push("# E2E Testing — SWEny");
-  lines.push("# Fill in values, then run: sweny e2e run");
+  lines.push("# Fill in values, then run: sweny workflow run");
   lines.push("");
 
   lines.push(`E2E_BASE_URL=${selections.baseUrl}`);
@@ -869,9 +869,9 @@ export async function runE2eInit(options: E2eInitOptions = {}): Promise<void> {
   console.log(chalk.dim("  1. Fill in your .env values"));
   if (selections.flows.some((f) => AUTH_REQUIRED_FLOWS.includes(f.type) || f.type === "login")) {
     console.log(chalk.dim("  2. Set E2E_EMAIL and E2E_PASSWORD to a test account"));
-    console.log(chalk.dim(`  3. Run: ${chalk.cyan("sweny e2e run")}\n`));
+    console.log(chalk.dim(`  3. Run: ${chalk.cyan("sweny workflow run")}\n`));
   } else {
-    console.log(chalk.dim(`  2. Run: ${chalk.cyan("sweny e2e run")}\n`));
+    console.log(chalk.dim(`  2. Run: ${chalk.cyan("sweny workflow run")}\n`));
   }
 }
 
@@ -892,6 +892,21 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 export interface E2eRunOptions {
   file?: string;
   timeout?: number;
+  /** Skip the batch confirmation prompt (CI). Only applies to no-file batch runs. */
+  yes?: boolean;
+}
+
+/**
+ * Policy for a no-file batch run. Pure so it can be unit-tested without
+ * touching the filesystem, stdin, or the engine.
+ * - `yes` → run without asking (CI).
+ * - non-interactive without `yes` → refuse (don't fire every workflow by accident).
+ * - interactive → ask for confirmation.
+ */
+export function batchRunDecision(opts: { yes?: boolean; isTTY: boolean }): "run" | "confirm" | "refuse-noninteractive" {
+  if (opts.yes) return "run";
+  if (!opts.isTTY) return "refuse-noninteractive";
+  return "confirm";
 }
 
 /**
@@ -914,7 +929,7 @@ export async function runE2eRun(options: E2eRunOptions): Promise<void> {
     const e2eDir = path.join(cwd, ".sweny", "e2e");
     if (!fs.existsSync(e2eDir)) {
       console.error(chalk.red("  No .sweny/e2e/ directory found."));
-      console.error(chalk.dim("  Run 'sweny e2e init' to set up e2e testing."));
+      console.error(chalk.dim("  Run 'sweny new e2e' to set up e2e testing."));
       process.exit(1);
     }
     files = fs
@@ -924,8 +939,30 @@ export async function runE2eRun(options: E2eRunOptions): Promise<void> {
       .map((f) => path.join(e2eDir, f));
     if (files.length === 0) {
       console.error(chalk.red("  No workflow files found in .sweny/e2e/"));
-      console.error(chalk.dim("  Run 'sweny e2e init' to set up e2e testing."));
+      console.error(chalk.dim("  Run 'sweny new e2e' to set up e2e testing."));
       process.exit(1);
+    }
+
+    // Batch run (no explicit file): list what will run and confirm, so an
+    // accidental `sweny workflow run` doesn't fire every e2e workflow.
+    // --yes bypasses for CI.
+    const decision = batchRunDecision({ yes: options.yes, isTTY: process.stdin.isTTY ?? false });
+    if (decision !== "run") {
+      console.log(chalk.bold(`\n  About to run ${files.length} e2e workflow(s) from .sweny/e2e/:`));
+      for (const f of files) console.log(chalk.dim(`    • ${path.basename(f)}`));
+      console.log("");
+
+      if (decision === "refuse-noninteractive") {
+        console.error(chalk.red("  Refusing to batch-run without confirmation in a non-interactive shell."));
+        console.error(chalk.dim("  Re-run with --yes to proceed (or pass a specific file)."));
+        process.exit(1);
+      }
+
+      const ok = await p.confirm({ message: `Run all ${files.length} e2e workflow(s)?` });
+      if (p.isCancel(ok) || !ok) {
+        p.cancel("Cancelled.");
+        process.exit(0);
+      }
     }
   }
 

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -110,20 +110,6 @@ program
     await runNew(id ? { marketplaceId: id } : undefined);
   });
 
-// ── sweny e2e ────────────────────────────────────────────────────────
-const e2eCmd = program.command("e2e").description("End-to-end browser testing");
-
-e2eCmd
-  .command("run [file]")
-  .description("Run e2e workflow files from .sweny/e2e/")
-  .option("--timeout <ms>", "Timeout per workflow in milliseconds (default: 900000 = 15 min)")
-  .action(async (file: string | undefined, options: { timeout?: string }) => {
-    await runE2eRun({
-      file,
-      timeout: options.timeout ? parseInt(options.timeout, 10) : undefined,
-    });
-  });
-
 // ── sweny check ───────────────────────────────────────────────────────
 program
   .command("check")
@@ -712,9 +698,27 @@ export function loadWorkflowFile(filePath: string, knownSkills?: Set<string>): W
 }
 
 export async function workflowRunAction(
-  file: string,
-  options: Record<string, unknown> & { json?: boolean; stream?: boolean; mermaid?: boolean; verbose?: boolean },
+  file: string | undefined,
+  options: Record<string, unknown> & {
+    json?: boolean;
+    stream?: boolean;
+    mermaid?: boolean;
+    verbose?: boolean;
+    timeout?: string;
+    yes?: boolean;
+  },
 ): Promise<void> {
+  // No file given → batch-run the e2e workflows in .sweny/e2e/. This is the
+  // home for what used to be `sweny e2e run`; it lists what will run and
+  // confirms first (bypass with --yes).
+  if (!file) {
+    await runE2eRun({
+      timeout: options.timeout ? parseInt(options.timeout, 10) : undefined,
+      yes: Boolean(options.yes),
+    });
+    return;
+  }
+
   // Discover skills first so the loader can flag UNKNOWN_SKILL at parse
   // time. validateWorkflowSkills below still runs for richer category /
   // env-var diagnostics, but the loader's structural check fires earlier
@@ -1047,8 +1051,12 @@ workflowCmd
   .action(workflowValidateAction);
 
 workflowCmd
-  .command("run <file>")
-  .description("Run a workflow from a YAML or JSON file")
+  .command("run [file]")
+  .description(
+    "Run a workflow from a YAML or JSON file. With no file, batch-runs every workflow in .sweny/e2e/ (lists and confirms first; use --yes to skip the prompt).",
+  )
+  .option("--timeout <ms>", "Per-workflow timeout in ms for batch runs (default: 900000 = 15 min)")
+  .option("-y, --yes", "Skip the batch confirmation prompt (for CI)")
   .option(
     "--dry-run",
     "Execute until the first conditional routing decision, then stop (no side effects past that point). NOTE: behavior changed in this release — previously --dry-run only printed the node list. For that behavior use --list-nodes.",

--- a/packages/core/src/cli/new.ts
+++ b/packages/core/src/cli/new.ts
@@ -533,6 +533,14 @@ function cancel(): never {
 export async function runNew(options?: { marketplaceId?: string; skipIntro?: boolean }): Promise<void> {
   const cwd = process.cwd();
 
+  // ── E2E shortcut: `sweny new e2e` jumps straight into the e2e wizard ──
+  // `new` is the single entry for all workflow creation; this is a named
+  // shortcut into the same flow the interactive picker reaches via "__e2e".
+  if (options?.marketplaceId === "e2e") {
+    await runE2eInit({ skipIntro: options.skipIntro });
+    return;
+  }
+
   // ── Marketplace install fast path ───────────────────────────────────
   if (options?.marketplaceId) {
     const { installMarketplaceWorkflow } = await import("./marketplace.js");

--- a/packages/plugin/skills/e2e-run/SKILL.md
+++ b/packages/plugin/skills/e2e-run/SKILL.md
@@ -11,26 +11,26 @@ argument-hint: "[file] [--timeout <ms>]"
 
 Run agent-driven browser end-to-end tests. Executes workflow files from `.sweny/e2e/`.
 
-**Prerequisites:** E2E workflows must exist in `.sweny/e2e/`. Run `/sweny:e2e-init` first if the directory is empty.
+**Prerequisites:** E2E workflows must exist in `.sweny/e2e/`. Run `/sweny:new` (and pick "End-to-end browser testing", i.e. `sweny new e2e`) first if the directory is empty.
 
 ## Usage
 
-Run all E2E tests:
+Run all E2E tests. `--yes` skips the batch confirmation prompt, which is required here since this runs non-interactively:
 
 ```bash
-sweny e2e run
+sweny workflow run --yes
 ```
 
-Run a specific test file:
+Run a specific test file (no prompt — the file is explicit):
 
 ```bash
-sweny e2e run $ARGUMENTS
+sweny workflow run $ARGUMENTS
 ```
 
 With a custom timeout (default is 15 minutes per workflow):
 
 ```bash
-sweny e2e run --timeout 300000
+sweny workflow run --yes --timeout 300000
 ```
 
 ## What to expect

--- a/packages/web/src/content/docs/cli/commands.md
+++ b/packages/web/src/content/docs/cli/commands.md
@@ -7,10 +7,12 @@ The `sweny` binary is provided by the `@sweny-ai/core` package. All commands aut
 
 ## sweny new
 
-Create a new SWEny workflow. Interactive picker offering templates, AI-generated workflows, end-to-end browser testing, or a blank start.
+Create a new SWEny workflow. Interactive picker offering templates, AI-generated workflows, end-to-end browser testing, or a blank start. `sweny new` is the single entry for all workflow creation.
 
 ```bash
-sweny new
+sweny new          # interactive picker
+sweny new e2e      # jump straight into the end-to-end browser-testing wizard
+sweny new <id>     # install a published workflow from the marketplace (swenyai/workflows)
 ```
 
 In a fresh repo, walks you through provider inference, credential collection, and writes `.sweny.yml` + `.env` + `.sweny/workflows/<id>.yml`. In a repo that already has `.sweny.yml`, adds the new workflow non-destructively — existing config is preserved and `.env` is append-only.
@@ -219,10 +221,11 @@ sweny workflow validate broken.yml
 
 ### sweny workflow run
 
-Execute a custom workflow file.
+Execute a workflow file. With no file argument, batch-runs every workflow in `.sweny/e2e/` (this is where end-to-end tests run, having replaced the old `sweny e2e run`).
 
 ```bash
-sweny workflow run <file> [options]
+sweny workflow run <file> [options]   # run one workflow
+sweny workflow run [options]          # batch-run all .sweny/e2e/*.yml
 ```
 
 | Option | Description | Default |
@@ -231,8 +234,10 @@ sweny workflow run <file> [options]
 | `--json` | Output result as JSON to stdout; suppress progress rendering | `false` |
 | `--stream` | Stream NDJSON events to stdout (for Studio / automation) | `false` |
 | `--mermaid` | Print a Mermaid diagram with per-node execution state after the run finishes | `false` |
+| `--timeout <ms>` | Per-workflow timeout for batch (no-file) runs | `900000` (15 min) |
+| `-y, --yes` | Skip the batch confirmation prompt (use in CI) | `false` |
 
-Loads the workflow definition, validates its schema, then executes it with the same DAG renderer and skill infrastructure as the built-in `triage` and `implement` commands. Provider settings from `.sweny.yml` and `.env` apply.
+With a file, loads the definition, validates its schema, then executes it with the same DAG renderer and skill infrastructure as the built-in `triage` and `implement` commands. With no file, it lists every `.sweny/e2e/*.yml` workflow, asks you to confirm (skip with `--yes`), runs them sequentially with template variables (`{base_url}`, `{run_id}`, ...) resolved, and exits `0` if all pass, `1` if any fail. Provider settings from `.sweny.yml` and `.env` apply.
 
 ### sweny workflow diagram
 
@@ -343,34 +348,14 @@ sweny workflow list [options]
 
 Prints each configured skill's ID, category, and description. For the full picture (built-in plus custom, configured plus unconfigured), use [`sweny skill list`](#sweny-skill-list) instead.
 
-## sweny e2e
+## End-to-end browser testing
 
-Generate and run AI-driven end-to-end browser tests. See the [E2E Testing guide](/cli/e2e/) for the full walkthrough.
+E2E testing has no dedicated namespace — it uses the two commands above:
 
-### sweny e2e init
+- **Scaffold** with [`sweny new e2e`](#sweny-new) — the wizard generates `.sweny/e2e/<flow-name>.yml` files and appends env vars to `.env`.
+- **Run** with [`sweny workflow run`](#sweny-workflow-run) — no file argument batch-runs every workflow in `.sweny/e2e/`.
 
-Interactive wizard that generates workflow YAML files for testing your web app's flows.
-
-```bash
-sweny e2e init
-```
-
-Walks you through selecting flow types (registration, login, purchase, onboarding, upgrade, cancellation, custom), configuring per-flow details (URL paths, form fields, success criteria), setting the base URL, and optionally enabling cleanup. Outputs `.sweny/e2e/<flow-name>.yml` files and appends env vars to `.env`.
-
-### sweny e2e run
-
-Execute e2e workflow files.
-
-```bash
-sweny e2e run [file] [options]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `[file]` | Run a specific workflow file | All `.sweny/e2e/*.yml` |
-| `--timeout <ms>` | Timeout per workflow in milliseconds | `900000` (15 min) |
-
-Without a file argument, runs all `.yml` files in `.sweny/e2e/` sequentially. Loads `.env`, resolves template variables (`{base_url}`, `{test_email}`, `{run_id}`, etc.), and executes each workflow. Exits `0` if all pass, `1` if any fail.
+See the [E2E Testing guide](/cli/e2e/) for the full walkthrough.
 
 ## sweny skill
 

--- a/packages/web/src/content/docs/cli/e2e.md
+++ b/packages/web/src/content/docs/cli/e2e.md
@@ -7,8 +7,8 @@ SWEny E2E generates workflow-based browser tests from a quick interactive wizard
 
 ## How it works
 
-1. `sweny e2e init` — interactive wizard asks about your app's flows (registration, login, purchase, etc.) and generates workflow YAML files
-2. `sweny e2e run` — loads the generated workflows, resolves template variables, and executes them with an AI agent driving `agent-browser`
+1. `sweny new e2e` — interactive wizard asks about your app's flows (registration, login, purchase, etc.) and generates workflow YAML files
+2. `sweny workflow run` — loads the generated workflows, resolves template variables, and executes them with an AI agent driving `agent-browser`
 
 Each generated workflow is a self-contained DAG:
 
@@ -22,17 +22,17 @@ The setup node installs and starts the browser daemon. Test nodes contain natura
 
 ```bash
 # 1. Run the wizard
-sweny e2e init
+sweny new e2e
 
 # 2. Fill in any .env values (base URL, cleanup credentials)
 
-# 3. Run all tests
-sweny e2e run
+# 3. Run all tests (lists them and asks to confirm first)
+sweny workflow run
 ```
 
 ## The wizard
 
-`sweny e2e init` walks you through 7 screens:
+`sweny new e2e` walks you through 7 screens:
 
 **Flow types** — pick which flows to test:
 
@@ -75,14 +75,16 @@ The naming convention `e2e-*@yourapp.test` makes cleanup safe — anything match
 ## Running tests
 
 ```bash
-# Run all .sweny/e2e/*.yml files sequentially
-sweny e2e run
+# Run all .sweny/e2e/*.yml files sequentially.
+# Lists them and asks to confirm first; --yes skips the prompt (use in CI).
+sweny workflow run
+sweny workflow run --yes
 
-# Run a specific workflow
-sweny e2e run registration.yml
+# Run a specific workflow (no prompt — the file is explicit)
+sweny workflow run .sweny/e2e/registration.yml
 
-# Custom timeout (default: 15 minutes per workflow)
-sweny e2e run --timeout 300000
+# Custom timeout for batch runs (default: 15 minutes per workflow)
+sweny workflow run --timeout 300000 --yes
 ```
 
 Output:
@@ -173,6 +175,6 @@ edges:
 
 ## What's next
 
-- [Commands Reference](/cli/commands/) — full flag reference for `sweny e2e`
+- [Commands Reference](/cli/commands/) — full flag reference for `sweny new` and `sweny workflow run`
 - [Custom Workflows](/workflows/custom/) — build non-E2E workflows from natural language
 - [GitHub Action](/action/) — run E2E workflows in CI

--- a/packages/web/src/content/docs/cli/examples.md
+++ b/packages/web/src/content/docs/cli/examples.md
@@ -421,7 +421,7 @@ Generate AI-driven end-to-end tests for any web app. No Playwright scripts — t
 ### Set up e2e tests with the wizard
 
 ```bash
-sweny e2e init
+sweny new e2e
 ```
 
 The wizard asks which flows to test (registration, login, purchase, onboarding, upgrade, cancellation, custom), per-flow details, and whether to auto-cleanup test data. It generates workflow YAML files in `.sweny/e2e/`.
@@ -429,21 +429,22 @@ The wizard asks which flows to test (registration, login, purchase, onboarding, 
 ### Run all e2e tests
 
 ```bash
-sweny e2e run
+sweny workflow run          # lists the workflows and asks to confirm
+sweny workflow run --yes    # skip the prompt (CI)
 ```
 
-Executes every `.yml` in `.sweny/e2e/` sequentially. Auto-generates test credentials (`e2e-{timestamp}@yourapp.test`), resolves template variables, and reports pass/fail per workflow.
+With no file, executes every `.yml` in `.sweny/e2e/` sequentially. Auto-generates test credentials (`e2e-{timestamp}@yourapp.test`), resolves template variables, and reports pass/fail per workflow.
 
 ### Run a specific test
 
 ```bash
-sweny e2e run registration.yml
+sweny workflow run .sweny/e2e/registration.yml
 ```
 
 ### Custom timeout for slow flows
 
 ```bash
-sweny e2e run --timeout 600000   # 10 minutes per workflow
+sweny workflow run --timeout 600000 --yes   # 10 minutes per workflow
 ```
 
 ### Test with a staging environment
@@ -456,7 +457,7 @@ E2E_PASSWORD=secret
 ```
 
 ```bash
-sweny e2e run
+sweny workflow run --yes
 ```
 
 **[Full E2E guide](/cli/e2e/)** — wizard details, template variables, cleanup backends, and generated workflow structure.

--- a/packages/web/src/content/docs/getting-started/quick-start.md
+++ b/packages/web/src/content/docs/getting-started/quick-start.md
@@ -66,8 +66,8 @@ sweny implement ENG-123         # fix a tracked issue and open a PR
 Or generate AI-driven browser tests for any web app:
 
 ```bash
-sweny e2e init                  # wizard generates test workflows
-sweny e2e run                   # AI agent drives a real browser
+sweny new e2e                   # wizard generates test workflows
+sweny workflow run              # AI agent drives a real browser
 ```
 
 **[Full CLI guide](/cli/)** — commands, configuration, and real-world examples. **[E2E testing guide](/cli/e2e/)** — browser test generation and execution.

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -105,8 +105,8 @@ Or [build your own](/workflows/custom/) from a single sentence with `sweny workf
 Generate AI-driven end-to-end tests for any web app — no test scripts to write:
 
 ```bash
-sweny e2e init     # wizard asks about your flows → generates workflow YAML
-sweny e2e run      # AI agent drives a real browser to test your app
+sweny new e2e        # wizard asks about your flows → generates workflow YAML
+sweny workflow run   # AI agent drives a real browser to test your app
 ```
 
 The wizard supports 7 flow types — registration, login, purchase, onboarding, upgrade, cancellation, and custom. Each generates a self-contained workflow with auto-generated test credentials and optional cleanup. [Get started with E2E testing](/cli/e2e/)


### PR DESCRIPTION
## What

`sweny new` is the single entry for workflow creation; `sweny workflow run` is the single entry for running. Removes the standalone `sweny e2e` namespace, which had drifted: `sweny e2e init` was documented in ~8 places but never actually registered, and `sweny e2e run` duplicated what `workflow run` should own.

## Changes

- `sweny e2e init` → **`sweny new e2e`** — named shortcut that jumps straight into the e2e wizard (`runNew` delegates when the arg is `e2e`). The interactive `sweny new` picker still offers it.
- `sweny e2e run` → **`sweny workflow run`** — with no file argument, batch-runs every `.sweny/e2e/*.yml`, **lists them and asks to confirm first**. `-y/--yes` skips the prompt (required for CI; non-interactive without it refuses and exits 1). `--timeout <ms>` sets the per-workflow batch timeout.
- Batch policy extracted into `batchRunDecision` (pure, unit-tested: run / confirm / refuse-noninteractive).
- Swept all stale references: docs (commands, e2e guide, examples, index, quick-start), the `e2e-run` plugin skill (now passes `--yes` since it runs non-interactively), and live CLI output strings.

## Safety

The public `swenyai/e2e` GitHub Action is unaffected — it already calls `sweny workflow run <file>` with an explicit file, so it never hits the batch/confirm path.

## Tests

Full core suite: 1739 passed / 5 skipped. New `batchRunDecision` coverage. Non-interactive batch refusal verified to exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)