### PR TITLE
fix(core): CLI hardening (check timeouts, implement validation parity, config)

### DIFF
--- a/.changeset/cli-hardening.md
+++ b/.changeset/cli-hardening.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/core": patch
+---
+
+CLI hardening: add a 5s timeout to every `sweny check` provider fetch (a hung connect now reports "timed out" instead of hanging), validate `DD_SITE` against a hostname allowlist before URL interpolation, give `sweny implement` credential + integer validation parity with triage (curated "Missing: ..." error, safe `parsePositiveInt` for `--max-implement-turns`), bound-check `--cache-ttl` in `validateInputs`, and warn (naming the file) when a malformed `.sweny.yml` is dropped instead of silently falling back to defaults.

--- a/packages/core/src/cli/__tests__/check.test.ts
+++ b/packages/core/src/cli/__tests__/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { resolveCheckAuthMode, redactUrl, checkAnthropicGateway } from "../check.js";
+import { resolveCheckAuthMode, redactUrl, checkAnthropicGateway, checkDatadog } from "../check.js";
 
 type AuthFields = Parameters<typeof resolveCheckAuthMode>[0];
 
@@ -121,5 +121,65 @@ describe("checkAnthropicGateway", () => {
     const spy = stubFetch(async () => ({ ok: true, status: 200 }));
     await checkAnthropicGateway("https://gw.example.com/", auth({ anthropicApiKey: "k" }), "api-key");
     expect(spy.mock.calls[0][0]).toBe("https://gw.example.com/v1/models");
+  });
+
+  it("passes an AbortSignal so a hung connect cannot hang the check", async () => {
+    const spy = stubFetch(async () => ({ ok: true, status: 200 }));
+    await checkAnthropicGateway("https://gw.example.com", auth({ anthropicApiKey: "k" }), "api-key");
+    expect(spy.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("reports a timeout (not a hang) when the abort signal fires", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const err = new Error("The operation was aborted due to timeout");
+        err.name = "TimeoutError";
+        throw err;
+      }),
+    );
+    const res = await checkAnthropicGateway("https://gw.example.com", auth({ anthropicApiKey: "k" }), "api-key");
+    expect(res.status).toBe("fail");
+    expect(res.detail).toMatch(/timed out/i);
+  });
+});
+
+describe("checkDatadog", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function stubFetch(impl: (url: string, init: any) => Promise<{ ok: boolean; status: number }>) {
+    const spy = vi.fn(impl);
+    vi.stubGlobal("fetch", spy);
+    return spy;
+  }
+
+  it("builds the api.<site> URL and passes an AbortSignal for a valid site", async () => {
+    const spy = stubFetch(async () => ({ ok: true, status: 200 }));
+    const res = await checkDatadog({ apiKey: "a", appKey: "b", site: "datadoghq.eu" });
+    expect(spy.mock.calls[0][0]).toBe("https://api.datadoghq.eu/api/v2/validate");
+    expect(spy.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    expect(res.status).toBe("ok");
+  });
+
+  it("rejects a site with a path/query before building the URL (no fetch)", async () => {
+    const spy = stubFetch(async () => ({ ok: true, status: 200 }));
+    const res = await checkDatadog({ apiKey: "a", appKey: "b", site: "evil.com/x?" });
+    expect(spy).not.toHaveBeenCalled();
+    expect(res.status).toBe("fail");
+    expect(res.detail).toMatch(/Invalid DD_SITE/i);
+  });
+
+  it("reports a timeout when the abort signal fires", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const err = new Error("timed out");
+        err.name = "TimeoutError";
+        throw err;
+      }),
+    );
+    const res = await checkDatadog({ apiKey: "a", appKey: "b" });
+    expect(res.status).toBe("fail");
+    expect(res.detail).toMatch(/timed out/i);
   });
 });

--- a/packages/core/src/cli/__tests__/check.test.ts
+++ b/packages/core/src/cli/__tests__/check.test.ts
@@ -161,13 +161,31 @@ describe("checkDatadog", () => {
     expect(res.status).toBe("ok");
   });
 
-  it("rejects a site with a path/query before building the URL (no fetch)", async () => {
-    const spy = stubFetch(async () => ({ ok: true, status: 200 }));
-    const res = await checkDatadog({ apiKey: "a", appKey: "b", site: "evil.com/x?" });
-    expect(spy).not.toHaveBeenCalled();
-    expect(res.status).toBe("fail");
-    expect(res.detail).toMatch(/Invalid DD_SITE/i);
-  });
+  // Real Datadog sites the allowlist must NOT reject (multi-label hosts,
+  // numeric subdomains, hyphenated gov host). Guards against a future
+  // "tightening" of the regex that breaks legitimate sites.
+  it.each(["datadoghq.com", "datadoghq.eu", "us5.datadoghq.com", "us3.datadoghq.com", "ddog-gov.com"])(
+    "accepts the valid site %s and builds the expected URL",
+    async (site) => {
+      const spy = stubFetch(async () => ({ ok: true, status: 200 }));
+      const res = await checkDatadog({ apiKey: "a", appKey: "b", site });
+      expect(spy.mock.calls[0][0]).toBe(`https://api.${site}/api/v2/validate`);
+      expect(res.status).toBe("ok");
+    },
+  );
+
+  // Dangerous values that smuggle a path/query/host or credentials into the
+  // interpolated URL. All must fail before any fetch.
+  it.each(["evil.com/x?", "datadoghq.com/../../x", "datadoghq.com:9999@evil.com", "datadoghq.com ", "DATADOGHQ.COM"])(
+    "rejects the dangerous site %j before building the URL (no fetch)",
+    async (site) => {
+      const spy = stubFetch(async () => ({ ok: true, status: 200 }));
+      const res = await checkDatadog({ apiKey: "a", appKey: "b", site });
+      expect(spy).not.toHaveBeenCalled();
+      expect(res.status).toBe("fail");
+      expect(res.detail).toMatch(/Invalid DD_SITE/i);
+    },
+  );
 
   it("reports a timeout when the abort signal fires", async () => {
     vi.stubGlobal(

--- a/packages/core/src/cli/check.ts
+++ b/packages/core/src/cli/check.ts
@@ -7,6 +7,12 @@ export interface CheckResult {
 }
 
 /**
+ * Per-check network timeout. A hung connect must not make `sweny check` hang
+ * indefinitely — the whole point of the command is fast diagnostics.
+ */
+const CHECK_TIMEOUT_MS = 5000;
+
+/**
  * Run lightweight connectivity checks for all configured providers.
  * Uses raw fetch — does NOT import provider packages.
  */
@@ -114,6 +120,7 @@ async function checkAnthropic(apiKey: string): Promise<CheckResult> {
   try {
     const res = await fetch("https://api.anthropic.com/v1/models", {
       headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
     });
     if (res.status === 200) {
       return { name, status: "ok", detail: "API key is valid" };
@@ -175,7 +182,7 @@ export async function checkAnthropicGateway(
   }
   try {
     const url = base.replace(/\/+$/, "") + "/v1/models";
-    const res = await fetch(url, { headers });
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(CHECK_TIMEOUT_MS) });
     // Gateways vary on whether /v1/models exists; reachable + non-auth-error is good enough.
     if (res.ok || res.status === 404) {
       return { name, status: "ok", detail: `gateway reachable (${safeBase}), auth mode: ${mode}` };
@@ -189,15 +196,25 @@ export async function checkAnthropicGateway(
   }
 }
 
-async function checkDatadog(creds: Record<string, string>): Promise<CheckResult> {
+export async function checkDatadog(creds: Record<string, string>): Promise<CheckResult> {
   const name = "Observability (datadog)";
   const { apiKey, appKey, site = "datadoghq.com" } = creds;
   if (!apiKey || !appKey) {
     return { name, status: "skip", detail: "DD_API_KEY or DD_APP_KEY not configured" };
   }
+  // `site` (DD_SITE) is interpolated into the request URL — reject anything
+  // outside a hostname allowlist before it can smuggle a path/query/host.
+  if (!/^[a-z0-9.-]+$/.test(site)) {
+    return {
+      name,
+      status: "fail",
+      detail: `Invalid DD_SITE "${site}" — expected a hostname like datadoghq.com or datadoghq.eu`,
+    };
+  }
   try {
     const res = await fetch(`https://api.${site}/api/v2/validate`, {
       headers: { "DD-API-KEY": apiKey, "DD-APPLICATION-KEY": appKey },
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
     });
     if (res.status === 200) {
       return { name, status: "ok", detail: "API key is valid" };
@@ -225,6 +242,7 @@ async function checkSentry(creds: Record<string, string>): Promise<CheckResult> 
   try {
     const res = await fetch("https://sentry.io/api/0/", {
       headers: { Authorization: `Bearer ${authToken}` },
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
     });
     if (res.status === 200) {
       return { name, status: "ok", detail: "Auth token is valid" };
@@ -252,6 +270,7 @@ async function checkLinear(apiKey: string): Promise<CheckResult> {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({ query: "{ viewer { id name } }" }),
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
     });
     if (res.status === 200) {
       const body = (await res.json()) as { data?: { viewer?: { name?: string } }; errors?: unknown[] };
@@ -281,6 +300,7 @@ async function checkGitHub(token: string, name: string): Promise<CheckResult> {
   try {
     const res = await fetch("https://api.github.com/user", {
       headers: { Authorization: `token ${token}`, "User-Agent": "sweny-cli" },
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
     });
     if (res.status === 200) {
       const body = (await res.json()) as { login?: string };
@@ -300,6 +320,12 @@ async function checkGitHub(token: string, name: string): Promise<CheckResult> {
 }
 
 function networkErrorMessage(err: unknown): string {
+  // AbortSignal.timeout fires a DOMException with name "TimeoutError"; an
+  // explicit abort surfaces as "AbortError". Either means we gave up waiting.
+  const errName = err instanceof Error ? err.name : "";
+  if (errName === "TimeoutError" || errName === "AbortError") {
+    return `Connection timed out after ${CHECK_TIMEOUT_MS}ms — host unreachable or too slow`;
+  }
   const msg = err instanceof Error ? err.message : String(err);
   if (/ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(msg)) {
     return `Network error — check your internet connection (${msg})`;

--- a/packages/core/src/cli/config-file.ts
+++ b/packages/core/src/cli/config-file.ts
@@ -58,7 +58,11 @@ export function loadConfigFile(cwd: string = process.cwd()): FileConfig {
   let raw: unknown;
   try {
     raw = parseYaml(content);
-  } catch {
+  } catch (err) {
+    // A malformed config file must not silently fall back to defaults — the
+    // user would get unexpected behavior with no clue their file was dropped.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`⚠  Ignoring malformed config file ${filePath}: ${reason}`);
     return {};
   }
 

--- a/packages/core/src/cli/config.test.ts
+++ b/packages/core/src/cli/config.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { Command } from "commander";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   validateInputs,
   parseCliInputs,
@@ -8,6 +11,7 @@ import {
   registerTriageCommand,
   registerImplementCommand,
 } from "./config.js";
+import { loadConfigFile } from "./config-file.js";
 import type { CliConfig } from "./config.js";
 
 /**
@@ -264,6 +268,47 @@ describe("validateInputs — numeric bounds reject NaN", () => {
     const errors = validateInputs(baseConfig({ maxInvestigateTurns: Infinity }));
     expect(errors.some((e) => e.includes("max-investigate-turns"))).toBe(true);
   });
+
+  it("rejects NaN cache-ttl (malformed --cache-ttl / cache-ttl:)", () => {
+    const errors = validateInputs(baseConfig({ cacheTtl: Number.NaN }));
+    expect(errors.some((e) => e.includes("--cache-ttl"))).toBe(true);
+  });
+
+  it("rejects a zero cache-ttl (below the minimum bound)", () => {
+    const errors = validateInputs(baseConfig({ cacheTtl: 0 }));
+    expect(errors.some((e) => e.includes("--cache-ttl"))).toBe(true);
+  });
+
+  it("accepts a sane cache-ttl", () => {
+    const errors = validateInputs(baseConfig({ cacheTtl: 86400 }));
+    expect(errors.some((e) => e.includes("--cache-ttl"))).toBe(false);
+  });
+});
+
+describe("parseCliInputs — cache-ttl parsing rejects junk", () => {
+  it("rejects a non-numeric --cache-ttl via validateInputs", () => {
+    const config = parseCliInputs({ cacheTtl: "abc" }, {});
+    expect(Number.isNaN(config.cacheTtl)).toBe(true);
+    const errors = validateInputs(config);
+    expect(errors.some((e) => e.includes("--cache-ttl"))).toBe(true);
+  });
+});
+
+describe("validateInputs — implement path credential parity", () => {
+  // The implement action now runs validateInputs(config) before execution.
+  // A claude run with no key/oauth must surface the curated "Missing: ..."
+  // error rather than crashing deep in the executor.
+  it("surfaces the missing ANTHROPIC_API_KEY/OAuth error", () => {
+    const errors = validateInputs(baseConfig({ anthropicApiKey: "", claudeOauthToken: "", repository: "owner/repo" }));
+    expect(errors.some((e) => e.includes("ANTHROPIC_API_KEY") && e.includes("CLAUDE_CODE_OAUTH_TOKEN"))).toBe(true);
+  });
+
+  it("rejects a non-numeric --max-implement-turns (no NaN reaching execution)", () => {
+    const config = parseCliInputs({ maxImplementTurns: "abc" }, {});
+    expect(Number.isNaN(config.maxImplementTurns)).toBe(true);
+    const errors = validateInputs(config);
+    expect(errors.some((e) => e.includes("--max-implement-turns"))).toBe(true);
+  });
 });
 
 describe("parseCliInputs — numeric parsing rejects junk", () => {
@@ -443,5 +488,39 @@ describe("normalizeSwenyAuth", () => {
       if (prev === undefined) delete process.env.SWENY_AUTH;
       else process.env.SWENY_AUTH = prev;
     }
+  });
+});
+
+describe("loadConfigFile — malformed YAML", () => {
+  let dir: string;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("warns (naming the file) and returns {} instead of silently dropping config", () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-cfg-"));
+    const filePath = path.join(dir, ".sweny.yml");
+    // Unbalanced brackets — invalid YAML that parseYaml throws on.
+    fs.writeFileSync(filePath, "time-range: [unterminated\n  bad: : :\n", "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = loadConfigFile(dir);
+
+    expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain(filePath);
+  });
+
+  it("parses a well-formed file without warning", () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "sweny-cfg-"));
+    fs.writeFileSync(path.join(dir, ".sweny.yml"), "time-range: 4h\n", "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = loadConfigFile(dir);
+
+    expect(result["time-range"]).toBe("4h");
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -193,7 +193,7 @@ export function registerTriageCommand(program: Command): Command {
     )
     .option("--bell", "Ring terminal bell on completion", false)
     .option("--cache-dir <path>", "Step cache directory (default: .sweny/cache)")
-    .option("--cache-ttl <seconds>", "Cache TTL in seconds, 0 = infinite (default: 86400)")
+    .option("--cache-ttl <seconds>", "Cache TTL in seconds, 1 to 31536000 (default: 86400)")
     .option("--no-cache", "Disable step cache")
     .option("--output-dir <path>", "Output directory for file providers (default: .sweny/output)")
     .option(

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -616,6 +616,9 @@ export function validateInputs(config: CliConfig): string[] {
   // bounds check let junk through).
   validateIntegerBound(errors, "--max-investigate-turns", config.maxInvestigateTurns, 1, 500);
   validateIntegerBound(errors, "--max-implement-turns", config.maxImplementTurns, 1, 500);
+  // cacheTtl is parsed with parsePositiveInt (junk → NaN); bound it so a
+  // malformed --cache-ttl / cache-ttl: surfaces a field error instead of NaN.
+  validateIntegerBound(errors, "--cache-ttl", config.cacheTtl, 1, 31_536_000);
 
   return errors;
 }

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -42,6 +42,7 @@ import {
   parseCliInputs,
   validateInputs,
   validateWarnings,
+  parsePositiveInt,
 } from "./config.js";
 import type { CliConfig } from "./config.js";
 import {
@@ -526,10 +527,9 @@ implementCmd.action(async (issueId: string, options: Record<string, unknown>) =>
     codingAgentProvider:
       (options.codingAgentProvider as string) || (fileConfig["coding-agent-provider"] as string) || "claude",
     dryRun: Boolean(options.dryRun),
-    maxImplementTurns: parseInt(
-      String(options.maxImplementTurns || (fileConfig["max-implement-turns"] as string) || "40"),
-      10,
-    ),
+    // parsePositiveInt mirrors the triage path: junk → NaN, which
+    // validateInputs rejects via validateIntegerBound below.
+    maxImplementTurns: parsePositiveInt(options.maxImplementTurns ?? (fileConfig["max-implement-turns"] as string), 40),
     baseBranch: (options.baseBranch as string) || (fileConfig["base-branch"] as string) || "main",
     repository: (options.repository as string) || process.env.GITHUB_REPOSITORY || "",
     outputDir:
@@ -538,6 +538,15 @@ implementCmd.action(async (issueId: string, options: Record<string, unknown>) =>
       (fileConfig["output-dir"] as string) ||
       ".sweny/output",
   };
+
+  // Validate (parity with triage): surface the curated "Missing: ..." errors
+  // and reject malformed integer flags before any execution.
+  const implErrors = validateInputs(config);
+  if (implErrors.length > 0) {
+    console.error(formatValidationErrors(implErrors));
+    console.error(c.subtle("\n  Run sweny implement --help for usage information.\n"));
+    process.exit(1);
+  }
 
   const implementSkillDiscovery = configuredSkillsWithDiagnostics(process.env, process.cwd());
   for (const w of implementSkillDiscovery.warnings) {


### PR DESCRIPTION
Implements the five CLI hardening gaps from #216. Scope stays inside `src/cli/` (check.ts, main.ts, config.ts, config-file.ts) plus their tests.

## Changes

1. **check.ts timeouts.** All six provider fetches now pass `signal: AbortSignal.timeout(5000)`. `networkErrorMessage` maps a `TimeoutError`/`AbortError` to a "Connection timed out" detail, so a hung connect surfaces a clear failure instead of hanging the diagnostic command.
2. **Datadog site validation.** `checkDatadog` validates `DD_SITE` against `^[a-z0-9.-]+$` before interpolating it into the request URL. A bad value (e.g. `evil.com/x?`) returns a `fail` with a clear detail and never builds/fetches the URL.
3. **implement validation parity.** The `implement` action now runs `validateInputs(config)` and exits 1 with the curated "Missing: ..." error (mirroring triage), and parses `--max-implement-turns` via `parsePositiveInt` instead of bare `parseInt`, so `abc` is rejected before execution rather than reaching it as `NaN`.
4. **cache-ttl bounds.** `validateInputs` now runs `validateIntegerBound("--cache-ttl", ...)`, so a malformed `--cache-ttl` / `cache-ttl:` is rejected instead of silently becoming `NaN`.
5. **Malformed config warning.** `loadConfigFile` now `console.warn`s (naming the file path) before returning `{}` on a YAML parse error, so a broken `.sweny.yml` is no longer silently dropped.

## Tests

- check.test.ts: AbortSignal is passed; mocked `TimeoutError` surfaces a "timed out" detail; `checkDatadog` rejects a path/query site before fetch and builds the correct `api.<site>` URL for valid sites.
- config.test.ts: `cacheTtl: NaN`/`0` and junk `--cache-ttl` rejected; implement-path missing-credential and `--max-implement-turns abc` rejection; `loadConfigFile` on malformed YAML returns `{}` and calls `console.warn` (spy), well-formed file parses with no warning.

## Verification

- `npm run build --workspace=packages/core` — pass
- `npm run typecheck --workspace=packages/core` — pass
- `npx vitest run config check` — 123 pass
- full `npx vitest run` — 1795 pass, 5 skipped

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)