### PR TITLE
fix(core): executor termination safety + eval-gate correctness

### DIFF
--- a/.changeset/executor-termination-safety.md
+++ b/.changeset/executor-termination-safety.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/core": minor
+---
+
+Executor termination safety and eval-gate correctness. Adds a workflow-level `max_steps` execute option (default 200) that throws a clear "step budget exceeded" error instead of hanging on an unbounded cycle (a back-edge with no `max_iterations` or a route that keeps looping); per-edge `max_iterations` behavior is unchanged. An invalid route target with no default edge now ends the branch loudly (returns null and emits a terminal `route` event) rather than silently jumping to the first out-edge, and the `route` event no longer reports `reason: "default"` when no default edge exists. A missing required output field now flows through the same retry path as eval failures, so a node with `retry` configured can self-heal a one-off omission. `output_required` now FAILS on an empty wildcard expansion in "all" mode (e.g. `findings[*].severity` when `findings` is `[]`) instead of vacuously passing. `resolveConfig` honors `options.env` and falls back to `process.env`, matching Source resolution.

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { tmpdir } from "node:os";
 
 import { execute } from "../executor.js";
-import type { Workflow, ExecutionEvent } from "../types.js";
+import type { Workflow, ExecutionEvent, Skill } from "../types.js";
 import { MockClaude, createFileSkill } from "../testing.js";
 import { createSkillMap } from "../skills/index.js";
 
@@ -602,7 +602,7 @@ describe("executor", () => {
     expect(results.has("b")).toBe(false);
   });
 
-  it("validates route choice falls back on invalid Claude response", async () => {
+  it("terminates loudly on an invalid route target when no default edge exists", async () => {
     // Create a claude mock that returns an invalid route
     const badRouteClaude: any = {
       async run() {
@@ -613,6 +613,10 @@ describe("executor", () => {
       },
     };
 
+    const events: ExecutionEvent[] = [];
+    // branchingWorkflow has only conditional edges (high/low), no default
+    // unconditional edge. A garbage route target must NOT silently jump to
+    // outEdges[0] (which could be a loop-back); it ends the branch loudly.
     const { results } = await execute(
       branchingWorkflow,
       {},
@@ -620,11 +624,21 @@ describe("executor", () => {
         skills: createSkillMap([]),
         claude: badRouteClaude,
         config: {},
+        observer: (e) => events.push(e),
       },
     );
 
-    // Should still complete — falls back to first valid edge target
-    expect(results.size).toBe(2);
+    // Only the entry node ran; routing terminated instead of guessing an edge.
+    expect(results.size).toBe(1);
+    expect(results.has("check")).toBe(true);
+
+    // The route event reports a terminal stop with an explicit reason, never
+    // reason: "default" (there is no default edge).
+    const routeEvents = events.filter((e) => e.type === "route");
+    const last = routeEvents[routeEvents.length - 1] as Extract<ExecutionEvent, { type: "route" }>;
+    expect(last.to).toBe("(end)");
+    expect(last.reason).toMatch(/invalid route target/);
+    expect(routeEvents.every((e) => (e as { reason?: string }).reason !== "default")).toBe(true);
   });
 
   describe("node.verify", () => {
@@ -2984,5 +2998,223 @@ describe("bundled workflows: routing contract invariants", () => {
     }
 
     expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+// ─── Termination safety + eval-gate correctness (issue #212) ───────
+
+describe("executor termination safety", () => {
+  it("an unconditional self-loop with no max_iterations hits the step budget and throws", async () => {
+    // a → a forever (single unconditional edge, no max_iterations).
+    const selfLoop: Workflow = {
+      id: "self-loop",
+      name: "Self loop",
+      description: "a loops to itself with no bound",
+      entry: "a",
+      nodes: {
+        a: { name: "A", instruction: "Do A", skills: [] },
+      },
+      edges: [{ from: "a", to: "a" }],
+    };
+
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+
+    await expect(
+      execute(selfLoop, {}, { skills: createSkillMap([]), claude, config: {}, max_steps: 10 }),
+    ).rejects.toThrow(/step budget exceeded/);
+  });
+
+  it("a routed loop with no max_iterations hits the step budget and throws", async () => {
+    // a → b → a (conditional, no max_iterations); evaluator always loops back.
+    const routedLoop: Workflow = {
+      id: "routed-loop",
+      name: "Routed loop",
+      description: "a → b → a forever",
+      entry: "a",
+      nodes: {
+        a: { name: "A", instruction: "Step A", skills: [] },
+        b: { name: "B", instruction: "Step B", skills: [] },
+        done: { name: "Done", instruction: "Finish", skills: [] },
+      },
+      edges: [
+        { from: "a", to: "b" },
+        { from: "b", to: "a", when: "loop back" },
+        { from: "b", to: "done", when: "finish" },
+      ],
+    };
+
+    const loopClaude: any = {
+      async run() {
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        // Always choose the loop-back edge.
+        return opts.choices.find((c: any) => c.id === "a")?.id ?? opts.choices[0].id;
+      },
+    };
+
+    await expect(
+      execute(routedLoop, {}, { skills: createSkillMap([]), claude: loopClaude, config: {}, max_steps: 12 }),
+    ).rejects.toThrow(/step budget exceeded/);
+  });
+
+  it("a bounded workflow runs to completion under the default step budget", async () => {
+    const claude = new MockClaude({
+      workflow: skilllessWorkflow,
+      responses: { a: { data: {} }, b: { data: {} }, c: { data: {} } },
+    });
+    const { results } = await execute(skilllessWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
+    expect(results.size).toBe(3);
+  });
+});
+
+describe("resolveConfig env threading", () => {
+  it("reads skill config from options.env, not just process.env", async () => {
+    // A skill that declares one config field bound to an env var.
+    const skill: Skill = {
+      id: "demo",
+      name: "Demo",
+      description: "demo skill",
+      category: "general",
+      config: { demo_token: { env: "DEMO_TOKEN", required: true, description: "demo token" } },
+      tools: [],
+      // Instruction-only skill: valid with no tools, so the node passes the
+      // runtime skill guard. The point of the test is resolveConfig env reads.
+      instruction: "demo context",
+    };
+
+    const oneNode: Workflow = {
+      id: "cfg",
+      name: "Cfg",
+      description: "single node using a config-bearing skill",
+      entry: "a",
+      nodes: { a: { name: "A", instruction: "Do A", skills: ["demo"] } },
+      edges: [],
+    };
+
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+
+    // The value is ONLY present in options.env, never in process.env.
+    expect(process.env.DEMO_TOKEN).toBeUndefined();
+    const { results } = await execute(
+      oneNode,
+      {},
+      { skills: createSkillMap([skill]), claude, config: {}, env: { DEMO_TOKEN: "from-options-env" } },
+    );
+    expect(results.get("a")?.status).toBe("success");
+  });
+
+  it("throws for a required config field absent from options.env", async () => {
+    const skill: Skill = {
+      id: "demo2",
+      name: "Demo2",
+      description: "demo skill",
+      category: "general",
+      config: { demo_token: { env: "DEMO_TOKEN_MISSING", required: true, description: "demo token" } },
+      tools: [],
+    };
+    const oneNode: Workflow = {
+      id: "cfg2",
+      name: "Cfg2",
+      description: "single node",
+      entry: "a",
+      nodes: { a: { name: "A", instruction: "Do A", skills: ["demo2"] } },
+      edges: [],
+    };
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+    await expect(
+      execute(oneNode, {}, { skills: createSkillMap([skill]), claude, config: {}, env: {} }),
+    ).rejects.toThrow(/Missing required config/);
+  });
+});
+
+describe("missing-required-field retry", () => {
+  const schemaNode: Workflow = {
+    id: "required-retry",
+    name: "Required retry",
+    description: "single node with a required output field + retry",
+    entry: "a",
+    nodes: {
+      a: {
+        name: "A",
+        instruction: "Emit a severity",
+        skills: [],
+        output: { type: "object", properties: { severity: { type: "string" } }, required: ["severity"] },
+        retry: { max: 1 },
+      },
+    },
+    edges: [],
+  };
+
+  it("re-attempts on a missing required field when retry is configured, and self-heals", async () => {
+    let attempt = 0;
+    const healingClaude: any = {
+      async run() {
+        attempt++;
+        // First attempt omits the required `severity`; second attempt includes it.
+        return attempt === 1
+          ? { status: "success", data: { other: 1 }, toolCalls: [] }
+          : { status: "success", data: { severity: "high" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+
+    const { results } = await execute(
+      schemaNode,
+      {},
+      { skills: createSkillMap([]), claude: healingClaude, config: {} },
+    );
+    expect(attempt).toBe(2);
+    expect(results.get("a")?.status).toBe("success");
+    expect(results.get("a")?.data.severity).toBe("high");
+  });
+
+  it("hard-fails after exhausting retries when the required field stays missing", async () => {
+    let attempt = 0;
+    const stubborn: any = {
+      async run() {
+        attempt++;
+        return { status: "success", data: { other: 1 }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+
+    const { results } = await execute(schemaNode, {}, { skills: createSkillMap([]), claude: stubborn, config: {} });
+    // initial + 1 retry = 2 attempts
+    expect(attempt).toBe(2);
+    expect(results.get("a")?.status).toBe("failed");
+    expect(String(results.get("a")?.data.error)).toMatch(/required field\(s\) missing/);
+  });
+
+  it("hard-fails without retry config (no retry path)", async () => {
+    const noRetryNode: Workflow = {
+      ...schemaNode,
+      id: "required-no-retry",
+      nodes: {
+        a: {
+          name: "A",
+          instruction: "Emit a severity",
+          skills: [],
+          output: { type: "object", properties: { severity: { type: "string" } }, required: ["severity"] },
+        },
+      },
+    };
+    let attempt = 0;
+    const claude: any = {
+      async run() {
+        attempt++;
+        return { status: "success", data: { other: 1 }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    const { results } = await execute(noRetryNode, {}, { skills: createSkillMap([]), claude, config: {} });
+    expect(attempt).toBe(1);
+    expect(results.get("a")?.status).toBe("failed");
   });
 });

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3066,6 +3066,55 @@ describe("executor termination safety", () => {
     const { results } = await execute(skilllessWorkflow, {}, { skills: createSkillMap([]), claude, config: {} });
     expect(results.size).toBe(3);
   });
+
+  it("eval retries do NOT count toward the step budget (only node visits do)", async () => {
+    // A single terminal node whose eval fails on every attempt, with a large
+    // retry budget. Retries re-run claude inside the node; they are bounded by
+    // retry.max and must NOT consume the workflow-level step budget, which
+    // counts node visits (cycle protection). With max_steps: 1 the node is
+    // visited exactly once, so the 1+10 attempts here must complete without
+    // tripping the budget. This pins the deliberate design: retries have their
+    // own bound (retry.max), the step cap guards cycles.
+    const node: Workflow = {
+      id: "retry-no-step",
+      name: "Retry no step",
+      description: "single terminal node that retries hard",
+      entry: "a",
+      nodes: {
+        a: {
+          name: "A",
+          instruction: "Emit ok",
+          skills: [],
+          eval: [{ name: "never", kind: "value", rule: { output_required: ["ok"] } }],
+          retry: { max: 10 },
+        },
+      },
+      edges: [],
+    };
+
+    let runs = 0;
+    const failingClaude: any = {
+      async run() {
+        runs++;
+        // Never emits `ok`, so the value eval fails every attempt.
+        return { status: "success", data: { other: 1 }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+
+    // max_steps: 1 allows a single node visit. If retries counted toward
+    // the budget, the 11 attempts would throw "step budget exceeded".
+    const { results } = await execute(
+      node,
+      {},
+      { skills: createSkillMap([]), claude: failingClaude, config: {}, max_steps: 1 },
+    );
+    // initial + 10 retries, all within one node visit
+    expect(runs).toBe(11);
+    expect(results.get("a")?.status).toBe("failed");
+  });
 });
 
 describe("resolveConfig env threading", () => {

--- a/packages/core/src/__tests__/requires.test.ts
+++ b/packages/core/src/__tests__/requires.test.ts
@@ -51,6 +51,17 @@ describe("evaluateRequires", () => {
     expect(evaluateRequires(requires, ctx)).toBeNull();
   });
 
+  it("fails on an empty wildcard expansion in default (all) mode (issue #212)", () => {
+    // `requires` shares checkOutputRequired with value evals. An empty
+    // `findings` array must NOT vacuously satisfy a required wildcard path.
+    const requires: NodeRequires = {
+      output_required: ["scan.findings[*].severity"],
+    };
+    const err = evaluateRequires(requires, { input: {}, scan: { findings: [] } });
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/no elements/);
+  });
+
   it("reports output_matches failure with operator description", () => {
     const requires: NodeRequires = {
       output_matches: [{ path: "triage.recommendation", equals: "implement" }],

--- a/packages/core/src/eval/__tests__/value.test.ts
+++ b/packages/core/src/eval/__tests__/value.test.ts
@@ -27,8 +27,9 @@ describe("checkOutputRequired", () => {
     expect(checkOutputRequired(["findings[*].severity"], data)).toBeNull();
   });
 
-  it("with default (all) wildcard over empty array, vacuously passes", () => {
-    expect(checkOutputRequired(["findings[*].severity"], { findings: [] })).toBeNull();
+  it("with default (all) wildcard over empty array, fails (no elements is a structurally-absent required output)", () => {
+    const err = checkOutputRequired(["findings[*].severity"], { findings: [] });
+    expect(err).toMatch(/output_required.*'findings\[\*\]\.severity'.*no elements/);
   });
 
   it("with `any` wildcard, passes when at least one element has non-null path", () => {

--- a/packages/core/src/eval/value.ts
+++ b/packages/core/src/eval/value.ts
@@ -117,7 +117,17 @@ export function checkOutputRequired(paths: string[], data: unknown): string | nu
       continue;
     }
     if (r.mode === "all") {
-      if (r.values.length > 0 && !r.values.every((v) => v !== null && v !== undefined)) {
+      // An empty wildcard expansion (e.g. `findings[*].severity` when
+      // `findings` is `[]`) resolves to zero values. That is a
+      // structurally-absent required output, not a satisfied gate: treat it
+      // as a failure rather than vacuously passing. A non-wildcard path always
+      // yields exactly one value, so this branch only ever sees an empty array
+      // for an empty wildcard expansion. Same class as the route-eval
+      // `missing` warning: a required field that is absent must not green-light
+      // the gate.
+      if (r.values.length === 0) {
+        failures.push(`'${path}' resolved to no elements (empty wildcard expansion)`);
+      } else if (!r.values.every((v) => v !== null && v !== undefined)) {
         failures.push(`'${path}' resolved to null/undefined value(s)`);
       }
     } else {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -32,10 +32,12 @@ import type {
   JSONSchema,
   Source,
   ResolvedSource,
+  EvalResult,
 } from "./types.js";
 import { consoleLogger } from "./types.js";
 import { resolveSources } from "./source-resolver.js";
 import { evaluateAll, aggregateEval } from "./eval/index.js";
+import type { AggregateOutcome } from "./eval/index.js";
 import { evaluateRequires } from "./requires.js";
 import { buildRetryPreamble } from "./retry.js";
 import { resolveExecutionModel } from "./model.js";
@@ -60,7 +62,24 @@ export interface ExecuteOptions {
   fetchAuth?: Record<string, string>;
   /** When true, URL Sources throw instead of fetching */
   offline?: boolean;
+  /**
+   * Workflow-level hard cap on total node executions (the number of times the
+   * main loop visits a node). Guards against unbounded cycles, e.g. a back-edge
+   * with no `max_iterations` or an LLM route evaluator that keeps choosing the
+   * loop-back edge. Defaults to {@link DEFAULT_MAX_STEPS}. When exceeded the
+   * executor throws a clear "step budget exceeded" error rather than hanging.
+   * Per-edge `max_iterations` behavior is unchanged.
+   */
+  max_steps?: number;
 }
+
+/**
+ * Default workflow-level step budget. Counts total node executions across the
+ * whole run (loop iterations included). Generous enough for legitimate deep
+ * workflows with controlled cycles, tight enough to terminate a runaway loop
+ * before it burns meaningful model spend.
+ */
+export const DEFAULT_MAX_STEPS = 200;
 
 /**
  * Execute a workflow from entry to completion.
@@ -77,11 +96,13 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
   // The caller's skill map takes precedence — inline skills only fill gaps.
   const skills = mergeInlineSkills(options.skills, workflow.skills);
 
-  const config = resolveConfig(skills, options.config);
+  const config = resolveConfig(skills, options.config, options.env ?? process.env);
   const logger = options.logger ?? consoleLogger;
   const results = new Map<string, NodeResult>();
   const edgeCounts = new Map<string, number>(); // "from→to" → times followed
   const nodeRunCounts = new Map<string, number>(); // node → times executed
+  const maxSteps = options.max_steps ?? DEFAULT_MAX_STEPS;
+  let stepCount = 0; // total node executions across the run (loop iterations included)
   const trace: ExecutionTrace = { steps: [], edges: [], sources: {} };
 
   validate(workflow, skills);
@@ -142,6 +163,20 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
   while (currentId) {
     const node = workflow.nodes[currentId];
     if (!node) throw new Error(`Unknown node: "${currentId}"`);
+
+    // Workflow-level hard cap. Per-edge max_iterations bounds individual
+    // back-edges, but a self-loop (or LLM route) with no max_iterations is
+    // otherwise unbounded. This budget terminates the run loudly instead of
+    // hanging CI / the action and burning model spend.
+    stepCount++;
+    if (stepCount > maxSteps) {
+      throw new Error(
+        `step budget exceeded: workflow '${workflow.id}' ran ${stepCount} steps (max_steps: ${maxSteps}). ` +
+          `This usually means an unbounded cycle, e.g. a back-edge with no 'max_iterations' or a route that keeps ` +
+          `looping. Add 'max_iterations' to the offending edge or raise 'max_steps' if the workflow legitimately ` +
+          `needs more steps.`,
+      );
+    }
 
     const iteration = (nodeRunCounts.get(currentId) ?? 0) + 1;
     nodeRunCounts.set(currentId, iteration);
@@ -292,26 +327,35 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
       // validation. Type mismatches, formats, additionalProperties, etc.
       // stay the workflow author's problem and don't have the same
       // routing-correctness blast radius.
+      // A missing required field is a contract violation handled on the same
+      // footing as an eval failure: an otherwise-recoverable one-off omission
+      // should self-heal on a second attempt when the node has `retry`
+      // configured. We synthesize an eval-shaped failure so the retry preamble
+      // and trace bookkeeping below treat it identically. When no retry is
+      // configured (or the budget is exhausted), it still hard-fails the node.
       const missingRequired = findMissingRequiredFields(result.data, node.output);
+
+      let outcome: AggregateOutcome;
       if (missingRequired.length > 0) {
         const msg = `output schema violation: required field(s) missing from emitted data: ${missingRequired.join(", ")}`;
-        result.status = "failed";
-        result.data = { ...(result.data ?? {}), error: msg };
-        logger.warn(`  ${msg}`, { node: currentId });
-        break;
+        const failure: EvalResult = { name: "output_required", kind: "value", pass: false, reasoning: msg };
+        outcome = { pass: false, error: msg, failures: [failure] };
+        // Still record the synthesized failure as the node's eval result so
+        // observers and downstream context see the contract violation.
+        result.evals = [failure];
+      } else {
+        const evalResults = await evaluateAll(node.eval, result, {
+          aliases: toolAliases,
+          claude,
+          node,
+          workflow,
+        });
+        result.evals = evalResults;
+        outcome = aggregateEval(evalResults, node.eval_policy ?? "all_pass");
       }
-
-      const evalResults = await evaluateAll(node.eval, result, {
-        aliases: toolAliases,
-        claude,
-        node,
-        workflow,
-      });
-      result.evals = evalResults;
-      const outcome = aggregateEval(evalResults, node.eval_policy ?? "all_pass");
       if (outcome.pass) break;
 
-      // Apply eval failure to the result.
+      // Apply the failure to the result.
       result.status = "failed";
       result.data = { ...result.data, error: outcome.error };
 
@@ -714,14 +758,23 @@ function resolveSkillInstructions(
 /**
  * Resolve config values: check explicit overrides first, then env vars.
  * Throws if a required field is missing.
+ *
+ * `env` is the environment map to read `field.env` from. Callers thread
+ * `options.env ?? process.env` so an explicit env map is honored consistently
+ * with Source resolution (which reads the same map). Defaults to
+ * `process.env` when omitted.
  */
-function resolveConfig(skills: Map<string, Skill>, overrides?: Record<string, string>): Record<string, string> {
+function resolveConfig(
+  skills: Map<string, Skill>,
+  overrides?: Record<string, string>,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   const config: Record<string, string> = {};
   const missing: string[] = [];
 
   for (const skill of skills.values()) {
     for (const [key, field] of Object.entries(skill.config)) {
-      const value = overrides?.[key] ?? (field.env ? process.env[field.env] : undefined);
+      const value = overrides?.[key] ?? (field.env ? env[field.env] : undefined);
       if (value) {
         config[key] = value;
       } else if (field.required) {
@@ -876,9 +929,36 @@ async function resolveNext(
     choices,
   });
 
-  // Validate that Claude returned a valid target
+  // Validate that Claude returned a valid target.
   const validTargets = new Set(outEdges.map((e) => e.to));
-  const resolved = validTargets.has(chosen) ? chosen : (defaultEdge?.to ?? outEdges[0].to); // fall back to default or first edge
+  if (!validTargets.has(chosen)) {
+    // The evaluator returned a target that is not a live out-edge. If there's
+    // an explicit default (unconditional) edge, take it as the documented
+    // fallback. Otherwise this is a hard error: silently jumping to
+    // `outEdges[0]` (often the loop-back edge) launders garbage model output
+    // into a plausible-looking route and, combined with an unbounded cycle,
+    // produces an infinite loop. Stop loudly instead.
+    if (!defaultEdge) {
+      logger?.warn(
+        `  route eval: evaluator returned invalid target '${chosen}' for node '${current}' and there is no ` +
+          `default (unconditional) edge; terminating this branch. Valid targets: ${[...validTargets].join(", ")}`,
+        { node: current, chosen, validTargets: [...validTargets] },
+      );
+      safeObserve(
+        observer,
+        {
+          type: "route",
+          from: current,
+          to: "(end)",
+          reason: `invalid route target '${chosen}' with no default edge`,
+        },
+        logger,
+      );
+      return null;
+    }
+  }
+
+  const resolved = validTargets.has(chosen) ? chosen : defaultEdge!.to;
 
   // Track edge usage for max_iterations
   if (edgeCounts) {
@@ -886,6 +966,9 @@ async function resolveNext(
     edgeCounts.set(key, (edgeCounts.get(key) ?? 0) + 1);
   }
 
+  // Report the matched choice's description. The `?? "default"` fallback now
+  // only fires when a default edge genuinely exists (the no-default invalid
+  // case returned null above), so it can no longer mislabel a garbage route.
   safeObserve(
     observer,
     {


### PR DESCRIPTION
Fixes five correctness/safety bugs in the workflow executor and eval layer (issue #212). Scope limited to `executor.ts`, `eval/value.ts`, and their tests; `eval/path.ts` was left unchanged (the empty-wildcard fix lives in `value.ts`).

## What changed

1. **Unbounded execution.** Added a workflow-level `max_steps` execute option (default 200, exported as `DEFAULT_MAX_STEPS`). The main loop counts total node executions and throws a clear `step budget exceeded` error when the budget is blown. Per-edge `max_iterations` behavior is unchanged.
2. **Invalid-route fallback.** In `resolveNext`, when the evaluator returns a target that is not a live out-edge AND there is no default (unconditional) edge, the run now ends the branch loudly: returns `null` and emits a terminal `route` event with an explicit reason, instead of silently jumping to `outEdges[0]` (often the loop-back edge). The `route` event can no longer report `reason: "default"` when no default edge exists.
3. **Missing-required-field retry.** The missing-required-field failure is now synthesized as an eval-shaped failure and flows through the same retry path as eval failures, so a node with `retry` configured can self-heal a one-off omission. With no retry (or budget exhausted) it still hard-fails.
4. **Vacuous output_required.** `checkOutputRequired` now FAILS an empty wildcard expansion in "all" mode (e.g. `findings[*].severity` when `findings` is `[]`) instead of vacuously passing. This also covers the `requires` gate, which shares the helper.
5. **resolveConfig env threading.** `resolveConfig` now reads from `options.env ?? process.env`, matching Source resolution. `execute()` threads `options.env` through.

## Tests

- `executor.test.ts`: self-loop and routed-loop hit the step cap and throw; bounded workflow completes under the default budget; invalid route with no default edge terminates loudly (asserts terminal route event, no `reason: "default"`); `resolveConfig` reads from `options.env` and throws when a required field is absent; missing-required-field retries and self-heals, hard-fails after exhausting retries, and hard-fails with no retry config. Updated the stale "falls back to first valid edge" test to the new terminal behavior.
- `value.test.ts`: updated the stale "vacuously passes" case to assert the empty wildcard now fails.
- `requires.test.ts`: empty wildcard in default mode fails through the `requires` gate.
- `path.test.ts`: unchanged; existing tests already assert the empty-wildcard resolution shape, which still holds.

Full core suite green (1791 passed, 5 skipped), build and typecheck pass.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)