### PR TITLE
[IN-02] create-sweny: pass workflow id arg through to runNew

### DIFF
--- a/packages/create-sweny/package.json
+++ b/packages/create-sweny/package.json
@@ -12,10 +12,16 @@
   ],
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "test": "echo 'create-sweny is a thin wrapper around @sweny-ai/core new — covered by the core test suite' && exit 0"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --exclude 'dist/**'"
   },
   "dependencies": {
     "@sweny-ai/core": "^0.1.51"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^5",
+    "vitest": "^4.1.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-sweny/src/index.test.ts
+++ b/packages/create-sweny/src/index.test.ts
@@ -31,15 +31,42 @@ describe("create-sweny", () => {
   });
 
   describe("module structure", () => {
-    it("calls runNew on load", async () => {
-      const mockRunNew = vi.fn().mockResolvedValue(undefined);
-      vi.doMock("@sweny-ai/core/new", () => ({ runNew: mockRunNew }));
+    const originalArgv = process.argv;
 
+    afterEach(() => {
+      process.argv = originalArgv;
+      vi.doUnmock("@sweny-ai/core/new");
+      vi.resetModules();
+    });
+
+    async function loadWithArgv(argv: string[]): Promise<ReturnType<typeof vi.fn>> {
+      const mockRunNew = vi.fn().mockResolvedValue(undefined);
+      vi.resetModules();
+      vi.doMock("@sweny-ai/core/new", () => ({ runNew: mockRunNew }));
+      process.argv = ["node", "create-sweny", ...argv];
       await import("./index.js");
       await new Promise((r) => setTimeout(r, 10));
+      return mockRunNew;
+    }
 
+    it("calls runNew on load", async () => {
+      const mockRunNew = await loadWithArgv([]);
       expect(mockRunNew).toHaveBeenCalledOnce();
-      vi.doUnmock("@sweny-ai/core/new");
+    });
+
+    it("threads the workflow id arg into runNew as marketplaceId", async () => {
+      const mockRunNew = await loadWithArgv(["release-notes"]);
+      expect(mockRunNew).toHaveBeenCalledWith({ marketplaceId: "release-notes" });
+    });
+
+    it("passes the e2e arg through (matches `sweny new e2e`)", async () => {
+      const mockRunNew = await loadWithArgv(["e2e"]);
+      expect(mockRunNew).toHaveBeenCalledWith({ marketplaceId: "e2e" });
+    });
+
+    it("calls runNew with undefined when no arg is given (interactive picker)", async () => {
+      const mockRunNew = await loadWithArgv([]);
+      expect(mockRunNew).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/packages/create-sweny/src/index.ts
+++ b/packages/create-sweny/src/index.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 import { runNew } from "@sweny-ai/core/new";
 
-runNew().catch((err) => {
+// Mirror `sweny new [id]` (packages/core/src/cli/main.ts): a positional
+// workflow id is threaded through as `marketplaceId` so it installs that
+// workflow non-interactively. With no arg, runNew opens the interactive picker.
+const id = process.argv[2];
+runNew(id ? { marketplaceId: id } : undefined).catch((err) => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Problem

`npx create-sweny <id>` silently dropped its positional argument. `packages/create-sweny/src/index.ts` called `runNew()` with no args and never read `process.argv`, so `npx create-sweny release-notes` opened the interactive picker instead of installing the named workflow. The package self-describes as a thin wrapper around `sweny new [id]`, but `sweny new` threads the positional into `runNew({ marketplaceId: id })` (`packages/core/src/cli/main.ts:111`) and create-sweny did not.

## Fix

- Read `process.argv[2]` and pass it as `marketplaceId` when present, mirroring `sweny new [id]` exactly.
- Wire vitest into the package: add `vitest` devDep, replace the stub `test` script with `vitest run --exclude 'dist/**'`, add a `typecheck` script.
- Extend the test to assert the arg is forwarded as `{ marketplaceId }`, that `e2e` passes through, and that no arg yields `undefined` (interactive picker).

## Testing

- `cd packages/create-sweny && npm run typecheck` — clean.
- `cd packages/create-sweny && npm test` — 14 passed (4 new module-structure cases for arg passthrough).

## Acceptance criteria

- [x] `npx create-sweny e2e` enters the e2e init path via `runNew({ marketplaceId: "e2e" })`.
- [x] `npx create-sweny <marketplace-id>` installs that workflow non-interactively (`new.ts` fast path).
- [x] `npx create-sweny` (no arg) still opens the interactive picker.
- [x] A test asserts `process.argv[2]` is threaded into `runNew`.

## Risk

Tiny. One-line behavior change in the create-sweny entry plus test wiring. No effect on other packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)