### PR TITLE
[CE-01] Thread abort signal + timeout into executor run loop

### DIFF
--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3267,3 +3267,107 @@ describe("missing-required-field retry", () => {
     expect(results.get("a")?.status).toBe("failed");
   });
 });
+
+describe("abort / timeout (CE-01)", () => {
+  const threeNode: Workflow = {
+    id: "abortable",
+    name: "Abortable",
+    description: "a→b→c",
+    entry: "a",
+    nodes: {
+      a: { name: "A", instruction: "Do A", skills: [] },
+      b: { name: "B", instruction: "Do B", skills: [] },
+      c: { name: "C", instruction: "Do C", skills: [] },
+    },
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+
+  it("forwards signal and timeoutMs to claude.run", async () => {
+    const controller = new AbortController();
+    let sawSignal: AbortSignal | undefined;
+    let sawTimeout: number | undefined;
+    const claude: any = {
+      async run(opts: any) {
+        sawSignal = opts.signal;
+        sawTimeout = opts.timeoutMs;
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    await execute(
+      threeNode,
+      {},
+      { skills: createSkillMap([]), claude, config: {}, signal: controller.signal, timeoutMs: 1234 },
+    );
+    expect(sawSignal).toBe(controller.signal);
+    expect(sawTimeout).toBe(1234);
+  });
+
+  it("rejects promptly when the signal aborts mid-run and stops issuing further calls", async () => {
+    const controller = new AbortController();
+    let runCalls = 0;
+    const claude: any = {
+      async run() {
+        runCalls++;
+        // Abort during the first node so the loop should not advance to b/c.
+        controller.abort();
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    await expect(
+      execute(threeNode, {}, { skills: createSkillMap([]), claude, config: {}, signal: controller.signal }),
+    ).rejects.toThrow(/aborted/i);
+    // Only node "a" ran; the loop bailed before "b" and "c".
+    expect(runCalls).toBe(1);
+  });
+
+  it("does not advance past the deadline (no node:enter after abort)", async () => {
+    const controller = new AbortController();
+    const events: ExecutionEvent[] = [];
+    const claude: any = {
+      async run() {
+        controller.abort();
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    await expect(
+      execute(
+        threeNode,
+        {},
+        { skills: createSkillMap([]), claude, config: {}, signal: controller.signal, observer: (e) => events.push(e) },
+      ),
+    ).rejects.toThrow(/aborted/i);
+    // Exactly one node:enter (for "a"); no further nodes after the abort.
+    expect(events.filter((e) => e.type === "node:enter")).toHaveLength(1);
+  });
+
+  it("fails fast when the signal is already aborted before the run starts", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let runCalls = 0;
+    const claude: any = {
+      async run() {
+        runCalls++;
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    await expect(
+      execute(threeNode, {}, { skills: createSkillMap([]), claude, config: {}, signal: controller.signal }),
+    ).rejects.toThrow(/aborted/i);
+    expect(runCalls).toBe(0);
+  });
+});

--- a/packages/core/src/cli/e2e.ts
+++ b/packages/core/src/cli/e2e.ts
@@ -877,9 +877,15 @@ export async function runE2eInit(options: E2eInitOptions = {}): Promise<void> {
 
 // ── Timeout helper ─────────────────────────────────────────────────────
 
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string, onTimeout?: () => void): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms);
+    const timer = setTimeout(() => {
+      // Abort the underlying work first so it stops advancing and the in-flight
+      // model query is interrupted, then reject the wrapper. Without the abort
+      // the execute() promise is abandoned but its model query keeps running.
+      onTimeout?.();
+      reject(new Error(`${label} timed out after ${ms / 1000}s`));
+    }, ms);
     promise
       .then(resolve)
       .catch(reject)
@@ -1042,15 +1048,17 @@ export async function runE2eRun(options: E2eRunOptions): Promise<void> {
       }
     };
 
+    const controller = new AbortController();
     try {
       const { results } = await withTimeout(
         execute(
           workflow,
           { run_id: vars.run_id, base_url: vars.base_url },
-          { skills, claude, observer, logger: consoleLogger },
+          { skills, claude, observer, logger: consoleLogger, signal: controller.signal },
         ),
         timeoutMs,
         `Workflow ${workflow.name}`,
+        () => controller.abort(),
       );
 
       // Extract report

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -442,10 +442,21 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     logger.info(`  ✓ ${result.status}`, { node: currentId, toolCalls: result.toolCalls.length });
 
     // Dry run gate + routing — shared with requires path via advanceFromNode helper.
-    currentId = await advanceFromNode(workflow, currentId, results, input, claude, observer, edgeCounts, logger, trace, {
-      signal,
-      timeoutMs,
-    });
+    currentId = await advanceFromNode(
+      workflow,
+      currentId,
+      results,
+      input,
+      claude,
+      observer,
+      edgeCounts,
+      logger,
+      trace,
+      {
+        signal,
+        timeoutMs,
+      },
+    );
   }
 
   safeObserve(

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -71,6 +71,20 @@ export interface ExecuteOptions {
    * Per-edge `max_iterations` behavior is unchanged.
    */
   max_steps?: number;
+  /**
+   * Caller-supplied abort signal. When it aborts, `execute()` rejects promptly
+   * and issues no further node / eval / route model calls. The signal is also
+   * threaded into every `claude.run` / `claude.evaluate` / `claude.ask` call so
+   * the underlying query is interrupted rather than left running detached.
+   * Default: no signal (back-compat).
+   */
+  signal?: AbortSignal;
+  /**
+   * Per-model-call wall-clock budget in ms, forwarded to every `claude.run` /
+   * `claude.evaluate` / `claude.ask` call. This is a per-call timeout, not a
+   * whole-run budget. Default: no timeout (back-compat).
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -81,6 +95,23 @@ export interface ExecuteOptions {
  */
 export const DEFAULT_MAX_STEPS = 200;
 
+/** Abort/timeout plumbing threaded into routing model calls. */
+interface AbortOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+/**
+ * Throw a clear "workflow aborted" error if the caller's signal has aborted.
+ * Used at the top of the run loop and before issuing any further model call so
+ * an aborted run stops promptly instead of advancing to the next node.
+ */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error("workflow aborted");
+  }
+}
+
 /**
  * Execute a workflow from entry to completion.
  *
@@ -89,7 +120,10 @@ export const DEFAULT_MAX_STEPS = 200;
  * - `trace`: full ordered execution trace including loops and routing decisions
  */
 export async function execute(workflow: Workflow, input: unknown, options: ExecuteOptions): Promise<ExecutionResult> {
-  const { claude, observer } = options;
+  const { claude, observer, signal, timeoutMs } = options;
+
+  // If the caller already aborted before we started, fail fast.
+  throwIfAborted(signal);
 
   // Merge inline workflow skills into the skill map so they resolve at runtime.
   // Inline skills (instruction/mcp only) become Skill objects with empty tools/config.
@@ -161,6 +195,10 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
   let currentId: string | null = workflow.entry;
 
   while (currentId) {
+    // Abort before issuing the next node/eval/route model call. Aborting the
+    // signal mid-run makes execute() reject promptly rather than advancing.
+    throwIfAborted(signal);
+
     const node = workflow.nodes[currentId];
     if (!node) throw new Error(`Unknown node: "${currentId}"`);
 
@@ -246,6 +284,7 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
         edgeCounts,
         logger,
         trace,
+        { signal, timeoutMs },
       );
       currentId = next;
       continue;
@@ -306,6 +345,8 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
         maxTurns: node.max_turns,
         disallowedTools: node.disallowed_tools,
         model: nodeModel,
+        signal,
+        timeoutMs,
         onProgress: (message) => {
           safeObserve(observer, { type: "node:progress", node: currentId!, message }, logger);
         },
@@ -379,6 +420,8 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
         logger,
         context,
         model: nodeModel,
+        signal,
+        timeoutMs,
       });
       currentInstruction = `${preamble}\n\n---\n\n${instruction}`;
       safeObserve(
@@ -399,7 +442,10 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     logger.info(`  ✓ ${result.status}`, { node: currentId, toolCalls: result.toolCalls.length });
 
     // Dry run gate + routing — shared with requires path via advanceFromNode helper.
-    currentId = await advanceFromNode(workflow, currentId, results, input, claude, observer, edgeCounts, logger, trace);
+    currentId = await advanceFromNode(workflow, currentId, results, input, claude, observer, edgeCounts, logger, trace, {
+      signal,
+      timeoutMs,
+    });
   }
 
   safeObserve(
@@ -808,6 +854,7 @@ async function advanceFromNode(
   edgeCounts: Map<string, number>,
   logger: Logger,
   trace: ExecutionTrace,
+  abort?: AbortOptions,
 ): Promise<string | null> {
   // Dry run hard gate — stop at the first conditional routing decision.
   // Unconditional edges are analysis flow (prepare→gather→investigate);
@@ -823,7 +870,7 @@ async function advanceFromNode(
   }
 
   const prevId = currentId;
-  const nextId = await resolveNext(workflow, currentId, results, input, claude, observer, edgeCounts, logger);
+  const nextId = await resolveNext(workflow, currentId, results, input, claude, observer, edgeCounts, logger, abort);
   if (nextId) {
     const reason = workflow.edges.find((e) => e.from === prevId && e.to === nextId)?.when ?? "only path";
     trace.edges.push({ from: prevId, to: nextId, reason });
@@ -849,6 +896,7 @@ async function resolveNext(
   observer?: Observer,
   edgeCounts?: Map<string, number>,
   logger?: Logger,
+  abort?: AbortOptions,
 ): Promise<string | null> {
   // Filter out edges that have exceeded their max_iterations
   const outEdges = workflow.edges.filter((e) => {
@@ -927,6 +975,8 @@ async function resolveNext(
     question: "Based on the results so far, which condition is true?",
     context,
     choices,
+    signal: abort?.signal,
+    timeoutMs: abort?.timeoutMs,
   });
 
   // Validate that Claude returned a valid target.

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -32,6 +32,10 @@ export interface BuildRetryPreambleOptions {
    * runs on the node's model. When undefined, the client default applies.
    */
   model?: string;
+  /** Caller-supplied abort signal, forwarded to the reflection `claude.ask`. */
+  signal?: AbortSignal;
+  /** Per-call wall-clock budget in ms, forwarded to the reflection `claude.ask`. */
+  timeoutMs?: number;
 }
 
 /**
@@ -47,7 +51,7 @@ export interface BuildRetryPreambleOptions {
  * default static preamble and logs a warning.
  */
 export async function buildRetryPreamble(opts: BuildRetryPreambleOptions): Promise<string> {
-  const { retry, evalFailures, toolCalls, nodeInstruction, claude, logger, context, model } = opts;
+  const { retry, evalFailures, toolCalls, nodeInstruction, claude, logger, context, model, signal, timeoutMs } = opts;
   const failureList = formatEvalFailures(evalFailures);
 
   const inst = retry.instruction;
@@ -61,7 +65,7 @@ export async function buildRetryPreamble(opts: BuildRetryPreambleOptions): Promi
       "reflect" in inst && typeof inst.reflect === "string" ? inst.reflect : DEFAULT_REFLECTION_PROMPT;
     const askInstruction = buildReflectionPrompt(reflectPrompt, nodeInstruction, failureList, toolCalls);
     try {
-      const diagnosis = await claude.ask({ instruction: askInstruction, context, model });
+      const diagnosis = await claude.ask({ instruction: askInstruction, context, model, signal, timeoutMs });
       const trimmed = diagnosis.trim();
       if (trimmed.length > 0) {
         return `## Reflection on previous attempt\n\n${trimmed}\n\n${DEFAULT_PREAMBLE_HEADER}\n\n${failureList}`;


### PR DESCRIPTION
**Problem**

`ExecuteOptions` had no `signal` or `timeoutMs`, and the executor never passed either into its `claude.run` / `claude.evaluate` / `claude.ask` calls, even though the `Claude` interface declares both. The e2e batch runner wrapped `execute()` in a `withTimeout` race that only `reject`ed a wrapper promise on timeout, abandoning the in-flight model query (it kept running detached, burning spend). The single-file `workflow run` path had no abort at all, so a wedged node could hang forever.

**Fix**

- Add `signal?: AbortSignal` and `timeoutMs?: number` to `ExecuteOptions`.
- Forward both into every `claude.run`, `claude.evaluate` (via `resolveNext`), and `claude.ask` (via `buildRetryPreamble`) call.
- Check `signal.aborted` before the run starts and at the top of each loop iteration, throwing a clear `workflow aborted` error so the run stops promptly and issues no further node/eval/route calls.
- `withTimeout` now takes an `onTimeout` callback; the e2e runner creates an `AbortController`, passes `controller.signal` into `execute()`, and calls `controller.abort()` on timeout (keeps the existing "timed out after Ns" message).

**Testing**

- 4 new tests in `executor.test.ts`: signal/timeoutMs forwarded to `claude.run`; aborting mid-run rejects and stops issuing calls (call counter); no `node:enter` after abort; already-aborted signal fails fast with zero `run` calls.
- `npm run typecheck` clean. Full core suite green (1923 passing).

**Acceptance criteria**

- [x] `ExecuteOptions` exposes `signal` and `timeoutMs`, forwarded to `run`/`evaluate`/`ask`.
- [x] Aborting mid-run makes `execute()` reject promptly and issue no further model calls.
- [x] e2e: on timeout `controller.abort()` fires and the run stops advancing.
- [x] Existing executor/eval tests still green.

**Risk**

Low. New fields are optional and back-compat. Mocks that ignore `signal` are allowed by the interface contract; the real `ClaudeClient` already honors abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)