### PR TITLE
[IN-01][IN-04] release.yml: publish create-sweny + honor deliberate version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           npm run build --workspace=packages/core
           npm run build:lib --workspace=packages/studio
           npm run build --workspace=packages/mcp
+          npm run build --workspace=packages/create-sweny
       - name: Test
         run: npm run test
 
@@ -58,6 +59,7 @@ jobs:
           npm run build --workspace=packages/core
           npm run build:lib --workspace=packages/studio
           npm run build --workspace=packages/mcp
+          npm run build --workspace=packages/create-sweny
 
       - name: Configure git
         run: |
@@ -74,14 +76,18 @@ jobs:
           CHANGED_CORE=$(git diff --name-only "$DIFF_BASE"..HEAD -- packages/core/ | head -1)
           CHANGED_STUDIO=$(git diff --name-only "$DIFF_BASE"..HEAD -- packages/studio/ | head -1)
           CHANGED_MCP=$(git diff --name-only "$DIFF_BASE"..HEAD -- packages/mcp/ | head -1)
+          CHANGED_CREATE_SWENY=$(git diff --name-only "$DIFF_BASE"..HEAD -- packages/create-sweny/ | head -1)
 
           PUBLISHED=false
 
-          # Bump from whichever is higher (LOCAL or NPM) +1 patch.
-          # Guards against the race where a prior Release run published to npm
-          # but its post-publish git push lost to a concurrent merge — leaving
-          # main's package.json behind npm. Without this max(), the next run
-          # would retry the same already-published version and 403.
+          # Version selection:
+          #  - local strictly ahead of npm  -> publish LOCAL as-is (honors a
+          #    deliberate minor/major bump set in package.json).
+          #  - local behind-or-equal to npm -> cut npm+1 patch. This is the
+          #    stale/already-taken case and also the race where a prior Release
+          #    run published to npm but its post-publish git push lost to a
+          #    concurrent merge, leaving main's package.json behind npm. Without
+          #    it the next run would retry an already-published version and 403.
           bump_and_publish() {
             local pkg_dir="$1"
             local pkg_name="$2"
@@ -90,8 +96,13 @@ jobs:
             LOCAL_VER=$(node -p "require('./package.json').version")
             NPM_VER=$(npm view "$pkg_name" version 2>/dev/null || echo "0.0.0")
             HIGHER=$(printf '%s\n%s\n' "$LOCAL_VER" "$NPM_VER" | sort -V | tail -1)
-            NEXT=$(echo "$HIGHER" | awk -F. '{$NF=$NF+1; print}' OFS=.)
-            if [ "$NEXT" != "$LOCAL_VER" ]; then
+            if [ "$LOCAL_VER" = "$HIGHER" ] && [ "$LOCAL_VER" != "$NPM_VER" ]; then
+              # local > npm: a deliberate version; publish exactly what is set.
+              echo "Publishing local version $LOCAL_VER for $pkg_name (ahead of npm $NPM_VER)"
+            else
+              # local <= npm: stale/taken; cut npm+1 patch so we never 403 a
+              # version already on the registry nor republish a behind version.
+              NEXT=$(echo "$NPM_VER" | awk -F. '{$NF=$NF+1; print}' OFS=.)
               npm version "$NEXT" --no-git-tag-version
             fi
             # Surface which package failed (the failure alert links the run, but
@@ -114,6 +125,16 @@ jobs:
 
           if [ -n "$CHANGED_MCP" ]; then
             bump_and_publish packages/mcp "@sweny-ai/mcp"
+            PUBLISHED=true
+          fi
+
+          # create-sweny is a published public package (npx create-sweny). Its
+          # only runtime change is a bumped @sweny-ai/core floor. We publish on
+          # its own source changes and keep the "^" core range, which floats to
+          # the latest core on a fresh install. (Follow-up if the floor must
+          # track core minors: rewrite the dep to the just-published core ver.)
+          if [ -n "$CHANGED_CREATE_SWENY" ]; then
+            bump_and_publish packages/create-sweny "create-sweny"
             PUBLISHED=true
           fi
 


### PR DESCRIPTION
Bundled because both edit `.github/workflows/release.yml` in the same `publish` job (IN-04 rewrites the `bump_and_publish` body, IN-01 adds a caller of it). Separate concurrent PRs would conflict.

## Problem

**IN-01:** `release.yml` only detected and published `core`/`studio`/`mcp` (`grep -c create-sweny release.yml` = 0). `create-sweny` is a published public package and the documented `npx create-sweny` onboarding entrypoint, but it had no automated release path, so it stayed frozen at the last hand-published version (0.1.51) and its `@sweny-ai/core` floor never advanced.

**IN-04:** `bump_and_publish` computed `NEXT = max(local, npm) + 1 patch` unconditionally. A contributor who set `package.json` to a deliberate minor/major (local `0.2.0` > npm `0.1.51`) got `0.2.1` published and the intended `0.2.0` was silently discarded. The pipeline could only ever cut patches.

## Fix

**IN-01:**
- Add `CHANGED_CREATE_SWENY` detection alongside the other three.
- Add a `bump_and_publish packages/create-sweny "create-sweny"` branch (option 1: keep the `^` core range, which floats to latest core on a fresh install; publish on create-sweny source changes).
- Build `packages/create-sweny` in both the verify and publish jobs so a fresh CI checkout has its `dist/` before publish.

**IN-04:** Replace the unconditional `+1` with:
- local strictly ahead of npm (`LOCAL = HIGHER && LOCAL != NPM`) -> publish `LOCAL` as-is (honors deliberate bumps).
- local behind-or-equal -> cut `npm + 1` patch (preserves the already-published race guard that prevents 403 retries).

## Testing

- Version selection validated with a local bash harness across all scenarios: stale (`0.1.40` vs `0.1.51` -> `0.1.52`), equal (`0.1.51`/`0.1.51` -> `0.1.52`), minor (`0.2.0` vs `0.1.51` -> `0.2.0`), major (`1.0.0` -> `1.0.0`), patch-ahead, first-publish (`0.1.0` vs `0.0.0` -> `0.1.0`), and first-zero guard (`0.0.0` -> `0.0.1`). All pass; the if/else in the file is byte-identical to the validated harness.
- `release.yml` parses cleanly under js-yaml (jobs: verify, publish, tag-action). The embedded publish script passes `bash -n`.
- actionlint not available in this environment. CI-verified on merge.

## Acceptance criteria

- [x] A push changing `packages/create-sweny/` results in a new `create-sweny` version on npm, independent of core/studio/mcp.
- [x] A create-sweny publish failure does not block the others (each `bump_and_publish` is an independent call; the `||` guard names the failing package).
- [x] A merged PR setting a package to a new minor/major publishes exactly that version.
- [x] A merged PR with no version change still auto-patches above npm.
- [x] The already-published race guard still prevents a 403 retry.
- [x] `release.yml` still parses.

## Risk

Touches the version selection of every publish and adds a new publish path. Logic validated against the full scenario matrix before shipping; a slip could double-publish or 403, which is why each case was tested. create-sweny build added to both jobs so its `dist/` is fresh. Low blast radius: create-sweny failures are isolated from core/studio/mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)