### PR TITLE
[CE-02] Reject unimplemented eval_policy at load time

### DIFF
--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -883,6 +883,60 @@ describe("validateWorkflow", () => {
     expect(errors).toEqual([]);
   });
 
+  it("rejects unimplemented eval_policy at load time (any_pass)", () => {
+    const wf: Workflow = {
+      ...validWorkflow,
+      nodes: {
+        ...validWorkflow.nodes,
+        b: { ...validWorkflow.nodes.b, eval_policy: "any_pass" },
+      },
+    };
+    const errors = validateWorkflow(wf);
+    expect(errors).toContainEqual(expect.objectContaining({ code: "UNSUPPORTED_EVAL_POLICY", nodeId: "b" }));
+  });
+
+  it("rejects unimplemented eval_policy at load time (weighted)", () => {
+    const wf: Workflow = {
+      ...validWorkflow,
+      nodes: {
+        ...validWorkflow.nodes,
+        c: { ...validWorkflow.nodes.c, eval_policy: "weighted" },
+      },
+    };
+    const errors = validateWorkflow(wf);
+    expect(errors).toContainEqual(expect.objectContaining({ code: "UNSUPPORTED_EVAL_POLICY", nodeId: "c" }));
+  });
+
+  it("accepts eval_policy all_pass", () => {
+    const wf: Workflow = {
+      ...validWorkflow,
+      nodes: {
+        ...validWorkflow.nodes,
+        b: { ...validWorkflow.nodes.b, eval_policy: "all_pass" },
+      },
+    };
+    expect(validateWorkflow(wf, new Set(["github"]))).toEqual([]);
+  });
+
+  it("accepts an absent eval_policy", () => {
+    expect(validateWorkflow(validWorkflow, new Set(["github"]))).toEqual([]);
+  });
+
+  it("flags unimplemented eval_policy on a parsed workflow", () => {
+    const parsed = parseWorkflow({
+      id: "p",
+      name: "P",
+      description: "",
+      entry: "a",
+      nodes: {
+        a: { name: "A", instruction: "Do A", skills: [], eval_policy: "weighted" },
+      },
+      edges: [],
+    });
+    const errors = validateWorkflow(parsed);
+    expect(errors).toContainEqual(expect.objectContaining({ code: "UNSUPPORTED_EVAL_POLICY", nodeId: "a" }));
+  });
+
   it("validates triage workflow", () => {
     expect(validateWorkflow(triageWorkflow)).toEqual([]);
   });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -129,6 +129,14 @@ export const evaluatorKindZ = z.enum(EVALUATOR_KINDS);
 
 export const evalPolicyZ = z.enum(EVAL_POLICIES);
 
+/**
+ * Eval policies actually implemented at runtime. The Zod schema and published
+ * JSON schema accept the full {@link EVAL_POLICIES} vocabulary (the others are
+ * reserved), but `validateWorkflow` rejects any policy not in this set so a
+ * workflow fails at load time rather than throwing mid-run from `aggregateEval`.
+ */
+const SUPPORTED_EVAL_POLICIES = new Set<string>(["all_pass"]);
+
 export const evaluatorRuleZ = z
   .object({
     any_tool_called: z.array(z.string().min(1)).min(1).optional(),
@@ -348,6 +356,7 @@ export interface WorkflowError {
     | "UNKNOWN_SKILL"
     | "SELF_LOOP"
     | "UNBOUNDED_CYCLE"
+    | "UNSUPPORTED_EVAL_POLICY"
     | "INVALID_INLINE_SKILL";
   message: string;
   nodeId?: string;
@@ -469,6 +478,24 @@ export function validateWorkflow(
           nodeId: cycleNode,
         });
       }
+    }
+  }
+
+  // Reject eval policies that are reserved in the vocabulary but not yet
+  // implemented. The Zod schema accepts the whole EVAL_POLICIES enum (the
+  // published JSON schema advertises them as reserved), but only `all_pass`
+  // is implemented at runtime. Without this check a workflow declaring
+  // `eval_policy: "any_pass"` or `"weighted"` parses and validates cleanly,
+  // then `aggregateEval` throws uncaught mid-run — a validate-then-crash
+  // failure mode. Reject it at load time instead. The runtime throw in
+  // aggregateEval stays as a defense-in-depth backstop.
+  for (const [nodeId, node] of Object.entries(workflow.nodes)) {
+    if (node.eval_policy != null && !SUPPORTED_EVAL_POLICIES.has(node.eval_policy)) {
+      errors.push({
+        code: "UNSUPPORTED_EVAL_POLICY",
+        message: `Node "${nodeId}" declares eval_policy "${node.eval_policy}", which is reserved but not yet implemented; use "all_pass" (the only supported policy in v1.0)`,
+        nodeId,
+      });
     }
   }
 


### PR DESCRIPTION
**Problem**

The Zod schema accepts the full `eval_policy` vocabulary (`all_pass`, `any_pass`, `weighted`), but only `all_pass` is implemented. A workflow declaring `any_pass` or `weighted` passed `parseWorkflow` and `validateWorkflow` cleanly, then `aggregateEval` threw uncaught mid-run ("reserved in v1.0 but not yet implemented"). Validate-then-crash is a worse failure mode than rejecting up front: no node-level `failed` status, no trace step.

**Fix**

`validateWorkflow` now flags any node whose `eval_policy` is set to a value outside the supported set with a new `UNSUPPORTED_EVAL_POLICY` error. Lower-drift approach: the published JSON schema still advertises the reserved policies (documented as reserved), only `validateWorkflow` rejects them. The runtime throw in `aggregateEval` stays as defense-in-depth.

**Testing**

- New `validateWorkflow` tests: `any_pass` and `weighted` rejected with `UNSUPPORTED_EVAL_POLICY`; `all_pass` and absent policy accepted; a parsed workflow with `weighted` is flagged.
- `npm run typecheck` clean, `npm run check:schema-drift` clean (no regenerated schema), full core suite green (1924 passing).

**Acceptance criteria**

- [x] A workflow declaring `any_pass`/`weighted` fails `validateWorkflow` with a clear message before execution.
- [x] `execute()` never throws from `aggregateEval` for a workflow that passed validation (validation now rejects the only inputs that triggered it).
- [x] `check:schema-drift` still passes.

**Risk**

Low. Tightening validation can only reject workflows that already crash at runtime today. No shipped/marketplace workflow declares a non-`all_pass` policy (full fixture suite still validates clean).

Note: shares `validateWorkflow` with CE-03 (separate PR, adds `AMBIGUOUS_EDGES`). Expected merge-time overlap; both add separate blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)