### PR TITLE
[SW-03] Declare zustand and yaml as studio dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12457,7 +12457,9 @@
         "@xyflow/react": "^12.10.2",
         "elkjs": "^0.9.0",
         "immer": "^11.1.8",
-        "zundo": "^2.3.0"
+        "yaml": "^2.8.3",
+        "zundo": "^2.3.0",
+        "zustand": "^4.5.7"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -31,7 +31,9 @@
     "@xyflow/react": "^12.10.2",
     "elkjs": "^0.9.0",
     "immer": "^11.1.8",
-    "zundo": "^2.3.0"
+    "yaml": "^2.8.3",
+    "zundo": "^2.3.0",
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",


### PR DESCRIPTION
## Problem
`packages/studio` imports `zustand` (`editor-store.ts`, `Toolbar.tsx`) and `yaml` (`export-yaml.ts`, `ImportModal.tsx`), but neither is declared in `package.json` `dependencies`. Both resolve today only via monorepo-root hoisting. A strict/isolated install (pnpm, pruned `npm ci`, or a source consumer of the published package) fails to resolve them.

## Fix
Add to `packages/studio/package.json` dependencies, pinned to the lockfile-resolved versions:
- `"zustand": "^4.5.7"` — the code uses the v4 API (`create`, `useStore`); not bumped to v5.
- `"yaml": "^2.8.3"`.

`package-lock.json` regenerated with `--package-lock-only`; the only change is adding these two entries to the `packages/studio` node. Both remain hoisted at the root (no nested install), resolved versions unchanged.

## Testing
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.
- (SPA `npm run build` depends on the SW-01 elkjs fix, not in this branch; out of scope for SW-03.)
- Lockfile resolved: zustand 4.5.7, yaml 2.8.3; no major-mismatch.

## Acceptance criteria
- [x] `zustand` and `yaml` appear in `packages/studio` dependencies at the resolved major (4 / 2).
- [x] `build:lib` and `typecheck` pass.
- [x] No version-major mismatch on install.

## Risk
Packaging metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)