### PR TITLE
[SW-02] Fix current-node pulse in embedded viewer

### DIFF
--- a/packages/studio/src/components/StandaloneViewer.tsx
+++ b/packages/studio/src/components/StandaloneViewer.tsx
@@ -190,7 +190,7 @@ export function WorkflowViewer({
           0%, 100% { box-shadow: 0 0 0 2.5px #3b82f6, 0 0 20px rgba(59,130,246,0.4); }
           50%       { box-shadow: 0 0 0 2.5px #3b82f6, 0 0 30px rgba(59,130,246,0.65); }
         }
-        .react-flow__node[data-exec-status="current"] > div {
+        .sweny-node-pulse {
           animation: node-pulse 2s ease-in-out infinite;
         }
       `}</style>

--- a/packages/studio/src/components/StateNode.tsx
+++ b/packages/studio/src/components/StateNode.tsx
@@ -61,6 +61,11 @@ export function StateNode({ data }: NodeProps<StateNodeType>) {
     >
       {/* Inner wrapper — clips accent bar corners but not handles */}
       <div
+        // When current, the viewer's injected `.sweny-node-pulse` keyframes
+        // animate box-shadow. React Flow never projects `data.execStatus` onto
+        // a DOM attribute, so drive the pulse off a class on this element
+        // directly instead of a (never-set) `data-exec-status` selector.
+        className={execStatus === "current" ? "sweny-node-pulse" : undefined}
         style={{
           display: "flex",
           alignItems: "stretch",


### PR DESCRIPTION
## Problem
The embedded viewer (`@sweny-ai/studio/viewer` → `StandaloneViewer`) advertises a blue pulse on the current node during live execution (docs Live Mode demo). The pulse never fired: the CSS keyed it off `.react-flow__node[data-exec-status="current"] > div`, but React Flow does not project `node.data.execStatus` onto a `data-*` DOM attribute, so the selector matched nothing. Only the static `execStyle.current` ring rendered.

## Fix
- In `StateNode`, apply a `sweny-node-pulse` class to the inner wrapper `<div>` when `execStatus === "current"`.
- Repoint the keyframe rule in `StandaloneViewer`'s injected `<style>` from the dead `data-exec-status` selector to `.sweny-node-pulse`. The `@keyframes node-pulse` definition is unchanged.
- Other states (success / failed / skipped / pending) are untouched and keep their static `execStyle` borders.

## Testing
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.
- `packages/web` build → exit 0 (41 pages); `LiveModeDemo` consumes `@sweny-ai/studio/viewer`, so the docs demo now gets the animated pulse.
- `npx vitest run src/__tests__/editor-store.test.ts` → 47/47.
- Confirmed `data-exec-status` no longer appears as a live selector (only in an explanatory code comment).

## Acceptance criteria
- [x] Current node's box pulses (animated box-shadow) while running.
- [x] success / failed / skipped / pending visuals unchanged.
- [x] No leftover dead `data-exec-status` selector.

## Risk
Visual only, scoped to viewer node rendering. The `.sweny-node-pulse` class is inert in contexts that don't inject the keyframes (e.g. the store-driven `WorkflowViewer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)