### PR TITLE
[IO-04] Normalize trailing slash on GITLAB_URL

### DIFF
--- a/packages/core/src/mcp-catalog.ts
+++ b/packages/core/src/mcp-catalog.ts
@@ -80,7 +80,10 @@ const gitlab: McpCatalogEntry = {
   wire: (creds) => {
     if (!creds.GITLAB_TOKEN) return undefined;
     const env: Record<string, string> = { GITLAB_PERSONAL_ACCESS_TOKEN: creds.GITLAB_TOKEN };
-    const baseUrl = creds.GITLAB_URL || "https://gitlab.com";
+    // Normalize trailing slash(es) so a pasted "https://gl.corp.com/" (or even
+    // the canonical "https://gitlab.com/") does not produce a double-slash
+    // "//api/v4". The /+$ also collapses accidental multi-trailing-slash input.
+    const baseUrl = (creds.GITLAB_URL || "https://gitlab.com").replace(/\/+$/, "");
     if (baseUrl !== "https://gitlab.com") env.GITLAB_API_URL = `${baseUrl}/api/v4`;
     return {
       type: "stdio",

--- a/packages/core/src/mcp.test.ts
+++ b/packages/core/src/mcp.test.ts
@@ -166,6 +166,37 @@ describe("buildAutoMcpServers", () => {
     });
   });
 
+  it("normalizes a trailing slash on self-hosted GITLAB_URL (no double slash)", () => {
+    const result = buildAutoMcpServers(
+      cfg({
+        sourceControlProvider: "gitlab",
+        credentials: {
+          GITLAB_TOKEN: "glpat_abc",
+          GITLAB_URL: "https://gl.corp.com/",
+        },
+      }),
+    );
+    expect(result["gitlab"]?.env).toEqual({
+      GITLAB_PERSONAL_ACCESS_TOKEN: "glpat_abc",
+      GITLAB_API_URL: "https://gl.corp.com/api/v4",
+    });
+  });
+
+  it("does not set GITLAB_API_URL for gitlab.com with a trailing slash", () => {
+    // "https://gitlab.com/" normalizes to the canonical host, so no API URL is
+    // emitted (and certainly not a double-slash one).
+    const result = buildAutoMcpServers(
+      cfg({
+        sourceControlProvider: "gitlab",
+        credentials: {
+          GITLAB_TOKEN: "glpat_abc",
+          GITLAB_URL: "https://gitlab.com/",
+        },
+      }),
+    );
+    expect(result["gitlab"]?.env).toEqual({ GITLAB_PERSONAL_ACCESS_TOKEN: "glpat_abc" });
+  });
+
   it("injects GitLab MCP without GITLAB_API_URL for gitlab.com", () => {
     const result = buildAutoMcpServers(
       cfg({


### PR DESCRIPTION
## Problem

A self-hosted `GITLAB_URL` with a trailing slash (very common when pasted) produced a double-slash API URL:

```
GITLAB_URL=https://gl.corp.com/  ->  GITLAB_API_URL=https://gl.corp.com//api/v4
```

Separately, the canonical host with a trailing slash (`https://gitlab.com/`) is `!== "https://gitlab.com"`, so it slipped past the gitlab.com guard and emitted `https://gitlab.com//api/v4` even for the default host. Whether `//api/v4` 404s depends on the server's path normalization, so it's a latent footgun.

## Fix

Strip trailing slash(es) before composing the API URL:

```ts
const baseUrl = (creds.GITLAB_URL || "https://gitlab.com").replace(/\/+$/, "");
```

The `\/+$` (one-or-more) also collapses accidental multi-trailing-slash input.

## Testing

`npm run typecheck` clean. `npm test` green (1921 passed). Two new `mcp.test.ts` cases: self-hosted trailing slash yields a single `/api/v4`; `https://gitlab.com/` no longer sets a (double-slash) API URL.

## Acceptance criteria

- [x] Trailing-slash `GITLAB_URL` yields a single-slash `/api/v4`, asserted by a test.

## Risk

Minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)