### PR TITLE
[IN-07] mcp: robust sweny CLI resolution for npx installs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
     "./workflows": "./dist/workflows/index.js",
     "./testing": "./dist/testing.js",
     "./schema": "./dist/schema.js",
-    "./new": "./dist/cli/new.js"
+    "./new": "./dist/cli/new.js",
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/packages/mcp/src/__tests__/run-workflow.test.ts
+++ b/packages/mcp/src/__tests__/run-workflow.test.ts
@@ -9,7 +9,9 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { spawn } from "node:child_process";
-import { runWorkflow, resolveSwenyBin } from "../handlers/run-workflow.js";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import { runWorkflow, resolveSwenyInvocation } from "../handlers/run-workflow.js";
 
 const mockSpawn = vi.mocked(spawn);
 
@@ -24,17 +26,46 @@ function createMockProcess(): ChildProcess & { _emit: (event: string, ...args: u
   return proc;
 }
 
-const bin = resolveSwenyBin();
+const invocation = resolveSwenyInvocation();
+const { command: cmd, prefixArgs } = invocation;
+
+// The handler spawns `command` with `[...prefixArgs, ...cliArgs]`. Helper to
+// build the expected full argv regardless of which resolution strategy hit.
+const expectArgs = (...cli: string[]): string[] => [...prefixArgs, ...cli];
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("resolveSwenyBin", () => {
-  it("returns a path containing sweny", () => {
-    // In the monorepo this resolves to node_modules/.bin/sweny;
-    // outside, it falls back to bare "sweny". Either way the name is present.
-    expect(bin).toContain("sweny");
+describe("resolveSwenyInvocation", () => {
+  it("resolves a sweny invocation (command + prefix args)", () => {
+    // Primary strategy: { command: process.execPath, prefixArgs: [<core bin>] }.
+    // Fallbacks: monorepo node_modules/.bin/sweny, then bare "sweny". In every
+    // case the resolved argv must point at something named "sweny".
+    const joined = [invocation.command, ...invocation.prefixArgs].join(" ");
+    expect(joined).toContain("sweny");
+  });
+
+  it("when core resolves, runs the resolved @sweny-ai/core bin via process.execPath", () => {
+    // If @sweny-ai/core/package.json is resolvable from the test's module tree,
+    // the primary strategy must be chosen: command is the current Node binary
+    // and the single prefix arg points inside the installed @sweny-ai/core.
+    const require = createRequire(import.meta.url);
+    let corePkgPath: string | null = null;
+    try {
+      corePkgPath = require.resolve("@sweny-ai/core/package.json");
+    } catch {
+      corePkgPath = null;
+    }
+    if (corePkgPath) {
+      expect(invocation.command).toBe(process.execPath);
+      expect(invocation.prefixArgs).toHaveLength(1);
+      const coreRoot = path.dirname(corePkgPath);
+      expect(invocation.prefixArgs[0].startsWith(coreRoot)).toBe(true);
+    } else {
+      // No exported package.json (older core) → falls back to a sweny command.
+      expect([invocation.command, ...invocation.prefixArgs].join(" ")).toContain("sweny");
+    }
   });
 });
 
@@ -46,8 +77,8 @@ describe("runWorkflow", () => {
     const promise = runWorkflow({ workflow: "triage" });
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      bin,
-      ["triage", "--json", "--stream"],
+      cmd,
+      expectArgs("triage", "--json", "--stream"),
       expect.objectContaining({ cwd: expect.any(String), stdio: ["ignore", "pipe", "pipe"] }),
     );
 
@@ -65,8 +96,8 @@ describe("runWorkflow", () => {
     const promise = runWorkflow({ workflow: "implement", input: "ABC-123" });
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      bin,
-      ["implement", "ABC-123", "--json", "--stream"],
+      cmd,
+      expectArgs("implement", "ABC-123", "--json", "--stream"),
       expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
     );
 
@@ -83,7 +114,11 @@ describe("runWorkflow", () => {
 
     const promise = runWorkflow({ workflow: "triage", dryRun: true });
 
-    expect(mockSpawn).toHaveBeenCalledWith(bin, ["triage", "--json", "--stream", "--dry-run"], expect.any(Object));
+    expect(mockSpawn).toHaveBeenCalledWith(
+      cmd,
+      expectArgs("triage", "--json", "--stream", "--dry-run"),
+      expect.any(Object),
+    );
 
     proc._emit("close", 0);
     await promise;
@@ -273,7 +308,11 @@ describe("runWorkflow", () => {
 
     const promise = runWorkflow({ workflow: "implement", input: "  ABC-123  " });
 
-    expect(mockSpawn).toHaveBeenCalledWith(bin, ["implement", "ABC-123", "--json", "--stream"], expect.any(Object));
+    expect(mockSpawn).toHaveBeenCalledWith(
+      cmd,
+      expectArgs("implement", "ABC-123", "--json", "--stream"),
+      expect.any(Object),
+    );
 
     proc.stdout!.emit("data", Buffer.from('{"ok": true}\n'));
     proc._emit("close", 0);

--- a/packages/mcp/src/handlers/run-workflow.ts
+++ b/packages/mcp/src/handlers/run-workflow.ts
@@ -1,5 +1,6 @@
-import { accessSync, constants } from "node:fs";
+import { accessSync, constants, readFileSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,22 +24,59 @@ const TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_STDERR_BUFFER = 10 * 1024 * 1024; // 10 MB — stderr is error output, not verbose logs
 
 /**
- * Resolve the path to the `sweny` CLI binary.
+ * How to invoke the `sweny` CLI: a command plus any leading args.
  *
- * In the monorepo, the workspace-linked bin at node_modules/.bin/sweny is
- * preferred for speed and version consistency. When installed standalone via
- * npm, that path won't exist — fall back to the bare command name so the OS
- * resolves it from PATH (which works because @sweny-ai/core declares a bin).
+ * The preferred form is `{ command: process.execPath, prefixArgs: [absBin] }`,
+ * i.e. run the resolved core CLI entry through the current Node binary. This
+ * does not depend on the file's executable bit, a shebang resolving, or `sweny`
+ * being on PATH — all of which are unreliable under `npx -y @sweny-ai/mcp`.
  */
-export function resolveSwenyBin(): string {
+export interface SwenyInvocation {
+  command: string;
+  prefixArgs: string[];
+}
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Resolve how to invoke the `sweny` CLI, most-robust strategy first:
+ *
+ *  1. Resolve `@sweny-ai/core/package.json` from this module's dependency tree
+ *     (createRequire), read `bin.sweny`, and run it via `process.execPath`.
+ *     This is the only path that works reliably under `npx -y @sweny-ai/mcp`,
+ *     where the bin is in an ephemeral cache not on the spawned child's PATH
+ *     and the monorepo-relative `.bin` arithmetic misses.
+ *  2. Monorepo workspace-linked bin at node_modules/.bin/sweny (dev/local).
+ *  3. Bare command name `sweny`, resolved from PATH (last resort, e.g. a global
+ *     install).
+ */
+export function resolveSwenyInvocation(): SwenyInvocation {
+  // (1) Resolve core's declared bin from the installed dependency tree.
+  try {
+    const corePkgPath = requireFromHere.resolve("@sweny-ai/core/package.json");
+    const corePkg = JSON.parse(readFileSync(corePkgPath, "utf-8")) as {
+      bin?: string | Record<string, string>;
+    };
+    const binRel = typeof corePkg.bin === "string" ? corePkg.bin : corePkg.bin?.sweny;
+    if (binRel) {
+      const absBin = path.resolve(path.dirname(corePkgPath), binRel);
+      accessSync(absBin, constants.R_OK);
+      return { command: process.execPath, prefixArgs: [absBin] };
+    }
+  } catch {
+    // Fall through to the monorepo / PATH fallbacks.
+  }
+
+  // (2) Monorepo workspace-linked bin.
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   // packages/mcp/dist/handlers/ → ../../../../node_modules/.bin/sweny
   const monorepo = path.resolve(__dirname, "..", "..", "..", "..", "node_modules", ".bin", "sweny");
   try {
     accessSync(monorepo, constants.X_OK);
-    return monorepo;
+    return { command: monorepo, prefixArgs: [] };
   } catch {
-    return "sweny";
+    // (3) Bare name from PATH.
+    return { command: "sweny", prefixArgs: [] };
   }
 }
 
@@ -63,10 +101,10 @@ export async function runWorkflow(opts: RunWorkflowInput): Promise<RunWorkflowRe
   if (opts.dryRun) args.push("--dry-run");
 
   const cwd = opts.cwd ?? process.cwd();
-  const bin = resolveSwenyBin();
+  const { command, prefixArgs } = resolveSwenyInvocation();
 
   return new Promise((resolve) => {
-    const child = spawn(bin, args, {
+    const child = spawn(command, [...prefixArgs, ...args], {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
       // Inherit env — sweny CLI needs API keys, .env vars, PATH, etc.


### PR DESCRIPTION
## Problem

The plugin launches the MCP server via `npx -y @sweny-ai/mcp` (`packages/plugin/.mcp.json`). `resolveSwenyBin()` tried a monorepo-relative `node_modules/.bin/sweny` then fell back to bare `"sweny"` on PATH. In a published `npx` install neither works:

- The relative arithmetic `../../../../node_modules/.bin` from `node_modules/@sweny-ai/mcp/dist/handlers/` lands on `node_modules/@sweny-ai/node_modules/.bin` (the scope dir), not the hoisted root.
- npx's ephemeral cache `.bin` is not on the spawned child's inherited PATH.

So `sweny_run_workflow` failed with "Failed to spawn sweny CLI" unless `@sweny-ai/core` happened to be installed globally.

## Fix

Replace `resolveSwenyBin()` with `resolveSwenyInvocation(): { command, prefixArgs }`, most-robust-first:

1. Resolve `@sweny-ai/core/package.json` via `createRequire(import.meta.url)`, read `bin.sweny`, resolve the absolute path, and run it through `process.execPath`. No dependency on PATH, a shebang resolving, or the file's exec bit.
2. Fall back to the monorepo workspace-linked `.bin/sweny`.
3. Fall back to bare `"sweny"` (e.g. a global install).

`runWorkflow` now spawns `command` with `[...prefixArgs, ...cliArgs]`.

This requires `@sweny-ai/core` to expose `./package.json` for `require.resolve` (its `exports` map previously did not, so `require.resolve("@sweny-ai/core/package.json")` threw `ERR_PACKAGE_PATH_NOT_EXPORTED`). Added `"./package.json": "./package.json"` to core's exports. This is the only core touch and is benign (package.json is publicly readable by convention).

## Testing

- `cd packages/mcp && npm run typecheck` — clean.
- `cd packages/mcp && npm test` — 29 passed (was 28; the resolver describe block now covers both the primary `process.execPath` + core-bin path and the fallback).
- Verified the primary path against a simulated published-install layout (`/tmp/node_modules/@sweny-ai/{mcp,core}` with core exporting `./package.json` + a `bin.sweny`): `resolveSwenyInvocation()` returns `command = process.execPath` and `prefixArgs = [<installed @sweny-ai/core>/dist/cli/main.js]`. This is what unblocks `npx -y @sweny-ai/mcp`.

## Acceptance criteria

- [x] When core resolves, the bin path points inside the installed `@sweny-ai/core` and runs via `process.execPath` (verified in a simulated install).
- [x] A unit test asserts the resolved invocation targets the installed core when resolvable, and a sweny command otherwise.
- [x] Existing monorepo behavior preserved; `cd packages/mcp && npm test` stays green (29/29).

## Risk

Medium. Changes process spawning. The end-to-end `npx -y @sweny-ai/mcp` spawn was not reproduced against the live registry (would need a publish/pack), per the validated scoping note. The resolver was verified against a faked published layout and the monorepo path is unchanged in behavior. Spawning via `process.execPath` is strictly more robust than the prior bare-name fallback.

## Notes

Ordering: IN-07 lands before IN-03's full file-run path, which builds on this resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)