### PR TITLE
[SW-06] Clear stale edge selection on edge/node removal

### DIFF
--- a/packages/studio/src/__tests__/editor-store.test.ts
+++ b/packages/studio/src/__tests__/editor-store.test.ts
@@ -277,6 +277,69 @@ describe("editor-store", () => {
       useEditorStore.getState().deleteEdge(999);
       expect(useEditorStore.getState().workflow.edges).toHaveLength(before);
     });
+
+    it("clears a higher-indexed edge selection when a lower-indexed edge is deleted", () => {
+      // Select edge index 1 (step-b→step-c), then delete index 0 (step-a→step-b).
+      useEditorStore
+        .getState()
+        .setSelection({ kind: "edge", id: "edge-1", edgeIndex: 1, from: "step-b", to: "step-c" });
+      useEditorStore.getState().deleteEdge(0);
+      // Index 1 would now point at the wrong (or no) edge — must be cleared.
+      expect(useEditorStore.getState().selection).toBeNull();
+    });
+
+    it("does not clear selection when an out-of-bounds delete removes nothing", () => {
+      useEditorStore
+        .getState()
+        .setSelection({ kind: "edge", id: "edge-1", edgeIndex: 1, from: "step-b", to: "step-c" });
+      useEditorStore.getState().deleteEdge(999);
+      const sel = useEditorStore.getState().selection;
+      expect(sel?.kind).toBe("edge");
+    });
+  });
+
+  describe("edge selection cleanup on node mutations", () => {
+    it("clears edge selection when deleteNode removes a connected edge", () => {
+      // Select edge index 1 (step-b→step-c), then delete step-a which drops
+      // the lower-indexed edge 0 (step-a→step-b).
+      useEditorStore
+        .getState()
+        .setSelection({ kind: "edge", id: "edge-1", edgeIndex: 1, from: "step-b", to: "step-c" });
+      useEditorStore.getState().deleteNode("step-a");
+      expect(useEditorStore.getState().selection).toBeNull();
+    });
+
+    it("clears edge selection when disconnectNode removes a connected edge", () => {
+      useEditorStore
+        .getState()
+        .setSelection({ kind: "edge", id: "edge-1", edgeIndex: 1, from: "step-b", to: "step-c" });
+      useEditorStore.getState().disconnectNode("step-a");
+      expect(useEditorStore.getState().selection).toBeNull();
+    });
+
+    it("leaves edge selection intact when deleteNode removes no edges", () => {
+      // step-c has no outgoing edges; deleting it only removes edge index 1.
+      // Select edge index 0 (step-a→step-b) and delete an unrelated leaf.
+      useEditorStore.getState().setWorkflow({
+        id: "iso",
+        name: "iso",
+        description: "node with no edges",
+        entry: "step-a",
+        nodes: {
+          "step-a": { name: "A", instruction: "", skills: [] },
+          "step-b": { name: "B", instruction: "", skills: [] },
+          orphan: { name: "Orphan", instruction: "", skills: [] },
+        },
+        edges: [{ from: "step-a", to: "step-b" }],
+      });
+      useEditorStore
+        .getState()
+        .setSelection({ kind: "edge", id: "edge-0", edgeIndex: 0, from: "step-a", to: "step-b" });
+      useEditorStore.getState().deleteNode("orphan");
+      const sel = useEditorStore.getState().selection;
+      expect(sel?.kind).toBe("edge");
+      expect(sel?.kind === "edge" && sel.edgeIndex).toBe(0);
+    });
   });
 
   // ── Layout state ────────────────────────────────────────────────────────

--- a/packages/studio/src/store/editor-store.ts
+++ b/packages/studio/src/store/editor-store.ts
@@ -185,14 +185,20 @@ export const useEditorStore = create<EditorState>()(
           produce((s: EditorState) => {
             delete s.workflow.nodes[id];
             // Remove edges that reference this node
+            const edgesBefore = s.workflow.edges.length;
             s.workflow.edges = s.workflow.edges.filter((e) => e.from !== id && e.to !== id);
+            const edgesRemoved = s.workflow.edges.length !== edgesBefore;
             // Fix entry if needed
             if (s.workflow.entry === id) {
               const remaining = Object.keys(s.workflow.nodes);
               s.workflow.entry = remaining[0] ?? "";
             }
-            // Clear selection if this node was selected
+            // Clear selection if this node was selected, or if an edge is
+            // selected and we just dropped one (its positional index may now
+            // point at a different edge).
             if (s.selection?.kind === "node" && s.selection.id === id) {
+              s.selection = null;
+            } else if (edgesRemoved && s.selection?.kind === "edge") {
               s.selection = null;
             }
             s.isLayoutStale = true;
@@ -242,6 +248,10 @@ export const useEditorStore = create<EditorState>()(
             s.workflow.edges = s.workflow.edges.filter((e) => e.from !== id && e.to !== id);
             if (s.workflow.edges.length !== before) {
               s.isLayoutStale = true;
+              // An edge selection's positional index may now be stale.
+              if (s.selection?.kind === "edge") {
+                s.selection = null;
+              }
             }
           }),
         ),
@@ -325,10 +335,16 @@ export const useEditorStore = create<EditorState>()(
       deleteEdge: (edgeIndex: number) =>
         set(
           produce((s: EditorState) => {
+            let removed = false;
             if (edgeIndex >= 0 && edgeIndex < s.workflow.edges.length) {
               s.workflow.edges.splice(edgeIndex, 1);
+              removed = true;
             }
-            if (s.selection?.kind === "edge" && s.selection.edgeIndex === edgeIndex) {
+            // Selection carries a positional edgeIndex. Removing any edge can
+            // shift the indices of the others, so clear an edge selection on
+            // every successful removal — not just an exact-index match — or it
+            // can end up pointing at (and mutating) the wrong edge.
+            if (removed && s.selection?.kind === "edge") {
               s.selection = null;
             }
             s.isLayoutStale = true;


### PR DESCRIPTION
## Problem
Edge selection carries a positional `edgeIndex`. `deleteEdge` cleared selection only on an exact-index match, and `deleteNode` / `disconnectNode` cleared node selection but never touched a live edge selection. Removing a lower-indexed edge (directly, or via a node delete/disconnect that drops one) shifts the array but leaves `selection.edgeIndex` pointing at a different edge. The EdgePanel is keyed by layout `edgeId`, not the index, so it doesn't remount — a subsequent `updateEdge`/`deleteEdge` then mutates the wrong row.

## Fix
Clear an edge selection whenever an edge is actually removed under it:
- `deleteEdge`: clear on any successful removal (track `removed`), not just exact-index match.
- `deleteNode`: clear edge selection if the edge filter dropped at least one edge.
- `disconnectNode`: clear edge selection inside the existing "edges changed" branch.

## Testing
- `npx vitest run src/__tests__/editor-store.test.ts` → 52/52 (47 prior + 5 new).
  New cases: select index 1 + `deleteEdge(0)` → cleared; out-of-bounds `deleteEdge` removes nothing → selection intact; `deleteNode`/`disconnectNode` that drops a lower-indexed edge → cleared; `deleteNode` that removes no edges → edge selection (index 0) intact.
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.

## Acceptance criteria
- [x] Select edge index 1, delete index 0 → selection cleared.
- [x] Edge selected, `deleteNode`/`disconnectNode` removing a lower-indexed edge → cleared.
- [x] Existing 47 src tests still pass.

## Risk
Editor edge editing only. Clearing selection is the safe default (matches the EdgePanel's own delete handler, which already calls `setSelection(null)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)