### PR TITLE
[SW-05] Close EventSource on SSE error to stop reconnect loop

### DIFF
--- a/packages/studio/src/components/LiveConnectPanel.tsx
+++ b/packages/studio/src/components/LiveConnectPanel.tsx
@@ -61,6 +61,10 @@ export function LiveConnectPanel() {
       };
 
       es.onerror = () => {
+        // EventSource auto-reconnects on a transient error. Close it before
+        // nulling the ref so the failed stream stops retrying in the
+        // background (and disconnect() can't reach it once the ref is gone).
+        es.close();
         evsRef.current = null;
         setLiveConnection({ url: connUrl, transport: connTransport, status: "error", error: "SSE error" });
       };


### PR DESCRIPTION
## Problem
In `LiveConnectPanel`, the SSE `es.onerror` handler nulled `evsRef.current` but never called `es.close()`. Per the EventSource spec the browser auto-reconnects on a transient error, so the failed stream kept retrying in the background. And because the ref was nulled first, `disconnect()` (`evsRef.current?.close()`) could no longer stop it. The WebSocket branch already closes correctly via `ws.onclose`; SSE was the gap.

## Fix
Call `es.close()` at the top of `es.onerror`, before nulling the ref — mirroring the WS teardown intent.

## Testing
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.
- No component test harness exists in this package (the sole test file is `editor-store.test.ts`, no jsdom/EventSource mock); the change is a one-line mirror of the proven WS path. Verified by inspection: after error, the EventSource is closed (no further reconnect), and `disconnect()` stays no-op-safe on the nulled ref.

## Acceptance criteria
- [x] After an SSE error, the closed EventSource does not retry.
- [x] `disconnect()` remains safe (no-op on an already-closed/nulled ref).

## Risk
Live mode only; low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)