### PR TITLE
[CE-05] Distinguish empty-string config from absent in resolveConfig

### DIFF
--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3200,12 +3200,16 @@ describe("resolveConfig env threading", () => {
     };
     const claude = new MockClaude({ responses: { a: { data: {} } } });
     await expect(
-      execute(oneNodeWith(skill), {}, {
-        skills: createSkillMap([skill]),
-        claude,
-        config: {},
-        env: { DEMO_KEY_EMPTY: "" },
-      }),
+      execute(
+        oneNodeWith(skill),
+        {},
+        {
+          skills: createSkillMap([skill]),
+          claude,
+          config: {},
+          env: { DEMO_KEY_EMPTY: "" },
+        },
+      ),
     ).rejects.toThrow(/set to empty/);
   });
 
@@ -3222,12 +3226,16 @@ describe("resolveConfig env threading", () => {
     const claude = new MockClaude({ responses: { a: { data: {} } } });
     let message = "";
     try {
-      await execute(oneNodeWith(skill), {}, {
-        skills: createSkillMap([skill]),
-        claude,
-        config: {},
-        env: {},
-      });
+      await execute(
+        oneNodeWith(skill),
+        {},
+        {
+          skills: createSkillMap([skill]),
+          claude,
+          config: {},
+          env: {},
+        },
+      );
     } catch (err) {
       message = err instanceof Error ? err.message : String(err);
     }
@@ -3246,12 +3254,16 @@ describe("resolveConfig env threading", () => {
       instruction: "ctx",
     };
     const claude = new MockClaude({ responses: { a: { data: {} } } });
-    const { results } = await execute(oneNodeWith(skill), {}, {
-      skills: createSkillMap([skill]),
-      claude,
-      config: {},
-      env: { DEMO_KEY_OPT: "" },
-    });
+    const { results } = await execute(
+      oneNodeWith(skill),
+      {},
+      {
+        skills: createSkillMap([skill]),
+        claude,
+        config: {},
+        env: { DEMO_KEY_OPT: "" },
+      },
+    );
     expect(results.get("a")?.status).toBe("success");
   });
 
@@ -3269,12 +3281,16 @@ describe("resolveConfig env threading", () => {
     };
     const claude = new MockClaude({ responses: { a: { data: {} } } });
     await expect(
-      execute(oneNodeWith(skill), {}, {
-        skills: createSkillMap([skill]),
-        claude,
-        config: { demo_token: "" }, // explicit empty override
-        env: { DEMO_KEY_OV: "would-be-used-if-fell-through" },
-      }),
+      execute(
+        oneNodeWith(skill),
+        {},
+        {
+          skills: createSkillMap([skill]),
+          claude,
+          config: { demo_token: "" }, // explicit empty override
+          env: { DEMO_KEY_OV: "would-be-used-if-fell-through" },
+        },
+      ),
     ).rejects.toThrow(/set to empty/);
   });
 });

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3175,6 +3175,108 @@ describe("resolveConfig env threading", () => {
       execute(oneNode, {}, { skills: createSkillMap([skill]), claude, config: {}, env: {} }),
     ).rejects.toThrow(/Missing required config/);
   });
+
+  // ── CE-05: empty-string config handling ──────────────────────────
+  function oneNodeWith(skill: Skill): Workflow {
+    return {
+      id: "cfg-empty",
+      name: "Cfg Empty",
+      description: "single node using a config-bearing skill",
+      entry: "a",
+      nodes: { a: { name: "A", instruction: "Do A", skills: [skill.id] } },
+      edges: [],
+    };
+  }
+
+  it("required env var set to empty string reports 'set to empty', distinct from 'not provided'", async () => {
+    const skill: Skill = {
+      id: "demoE",
+      name: "DemoE",
+      description: "demo",
+      category: "general",
+      config: { demo_token: { env: "DEMO_KEY_EMPTY", required: true, description: "demo token" } },
+      tools: [],
+      instruction: "ctx",
+    };
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+    await expect(
+      execute(oneNodeWith(skill), {}, {
+        skills: createSkillMap([skill]),
+        claude,
+        config: {},
+        env: { DEMO_KEY_EMPTY: "" },
+      }),
+    ).rejects.toThrow(/set to empty/);
+  });
+
+  it("required env var absent reports 'not provided', not 'set to empty'", async () => {
+    const skill: Skill = {
+      id: "demoA",
+      name: "DemoA",
+      description: "demo",
+      category: "general",
+      config: { demo_token: { env: "DEMO_KEY_ABSENT", required: true, description: "demo token" } },
+      tools: [],
+      instruction: "ctx",
+    };
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+    let message = "";
+    try {
+      await execute(oneNodeWith(skill), {}, {
+        skills: createSkillMap([skill]),
+        claude,
+        config: {},
+        env: {},
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toMatch(/not provided/);
+    expect(message).not.toMatch(/set to empty/);
+  });
+
+  it("optional env var set to empty string passes through (does not throw)", async () => {
+    const skill: Skill = {
+      id: "demoO",
+      name: "DemoO",
+      description: "demo",
+      category: "general",
+      config: { demo_token: { env: "DEMO_KEY_OPT", required: false, description: "demo token" } },
+      tools: [],
+      instruction: "ctx",
+    };
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+    const { results } = await execute(oneNodeWith(skill), {}, {
+      skills: createSkillMap([skill]),
+      claude,
+      config: {},
+      env: { DEMO_KEY_OPT: "" },
+    });
+    expect(results.get("a")?.status).toBe("success");
+  });
+
+  it("an explicit empty-string override wins and does not fall through to env", async () => {
+    // Required field: an explicit "" override is present (not absent), so env
+    // is never consulted. Required + present-but-empty → "set to empty".
+    const skill: Skill = {
+      id: "demoOv",
+      name: "DemoOv",
+      description: "demo",
+      category: "general",
+      config: { demo_token: { env: "DEMO_KEY_OV", required: true, description: "demo token" } },
+      tools: [],
+      instruction: "ctx",
+    };
+    const claude = new MockClaude({ responses: { a: { data: {} } } });
+    await expect(
+      execute(oneNodeWith(skill), {}, {
+        skills: createSkillMap([skill]),
+        claude,
+        config: { demo_token: "" }, // explicit empty override
+        env: { DEMO_KEY_OV: "would-be-used-if-fell-through" },
+      }),
+    ).rejects.toThrow(/set to empty/);
+  });
 });
 
 describe("missing-required-field retry", () => {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -763,6 +763,18 @@ function resolveSkillInstructions(
  * `options.env ?? process.env` so an explicit env map is honored consistently
  * with Source resolution (which reads the same map). Defaults to
  * `process.env` when omitted.
+ *
+ * Presence vs. truthiness: an explicitly-provided empty string is treated as
+ * present, not absent. Resolution rules:
+ *   - An override that is present (any string, including "") wins; the env
+ *     var is not consulted. An explicit "" override does NOT silently fall
+ *     through to env.
+ *   - Otherwise the env var (when declared) is used.
+ *   - A value that is `undefined` (no override, no env var) is absent: a
+ *     required field reports "not provided".
+ *   - A value that is "" is present-but-empty: a required field reports a
+ *     distinct "set to empty" message (you set it, but to an unusable value),
+ *     while an optional field passes the empty string through.
  */
 function resolveConfig(
   skills: Map<string, Skill>,
@@ -774,11 +786,30 @@ function resolveConfig(
 
   for (const skill of skills.values()) {
     for (const [key, field] of Object.entries(skill.config)) {
-      const value = overrides?.[key] ?? (field.env ? env[field.env] : undefined);
-      if (value) {
+      // Explicit override wins, including an empty string — `in` distinguishes
+      // a present "" from an absent key, so an override never falls through to
+      // env in a surprising way.
+      const hasOverride = overrides != null && key in overrides;
+      const value = hasOverride ? overrides![key] : field.env ? env[field.env] : undefined;
+      const source = field.env ? ` (env: ${field.env})` : "";
+
+      const label = `${skill.id}.${key}${source || " (env: none)"}`;
+      if (value === undefined) {
+        // Truly absent: no override and no env value.
+        if (field.required) {
+          missing.push(`${label}: not provided`);
+        }
+      } else if (value === "") {
+        // Present but empty. An empty credential is unusable for a required
+        // field; surface a distinct message so the user can tell "set to empty"
+        // from "forgot it". Optional empty values pass through unchanged.
+        if (field.required) {
+          missing.push(`${label}: set to empty`);
+        } else {
+          config[key] = value;
+        }
+      } else {
         config[key] = value;
-      } else if (field.required) {
-        missing.push(`${skill.id}.${key} (env: ${field.env ?? "none"})`);
       }
     }
   }


### PR DESCRIPTION
**Problem**

`resolveConfig` used `const value = overrides?.[key] ?? (field.env ? env[field.env] : undefined); if (value) { ... }`. The `if (value)` truthiness test treats an explicitly-provided empty string (override `key: ""` or `env[field.env] === ""`) identically to "not provided": a required field reports as missing, an optional empty value is silently dropped, and the user gets a confusing "Missing required config" for a var they did set. The `??` chain also never falls back to env when the override is `""` (not nullish), which can surprise callers.

**Fix**

Distinguish presence from truthiness:
- An override that is present (any string, including `""`) wins; env is not consulted. Uses `key in overrides` so a present `""` is not confused with absent.
- `value === undefined` (no override, no env): required → `"<field>: not provided"`.
- `value === ""` (present but empty): required → `"<field>: set to empty"` (distinct from absent); optional → passes the empty string through.
- Any other value: used as-is.

The documented rule: explicit override wins, including `""`; no silent fall-through to env.

**Testing**

- New tests through `execute()`: required env `""` → "set to empty"; required absent → "not provided" (and not "set to empty"); optional env `""` → run succeeds (passes through); explicit `""` override on a required field → "set to empty" (does not fall through to env).
- `npm run typecheck` clean, full core suite green (1923 passing). Existing "Missing required config" assertions still match.

**Acceptance criteria**

- [x] A required field whose env var is `""` errors with "set to empty", distinct from "not provided".
- [x] Override-`""`-vs-env behavior documented (override wins) and covered by a test.
- [x] Existing config-resolution tests still pass.

**Risk**

Low. Touches only config resolution. Optional empty strings now pass through instead of being dropped; no skill relies on the old drop behavior (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)