### PR TITLE
[IO-05] Surface configured template/context load failures

### DIFF
--- a/.changeset/surface-template-load-errors.md
+++ b/.changeset/surface-template-load-errors.md
@@ -1,0 +1,5 @@
+---
+"@sweny-ai/core": patch
+---
+
+Surface configured template/context load failures instead of silently using the default. `loadTemplate` and `loadAdditionalContext` now throw when a CONFIGURED source fails to resolve (404, 403, SSRF block, read error), matching the executor's per-node Source handling. A typo'd or unauthorized template URL is a misconfiguration, not a no-op. The default is still returned only for an empty/unset source or a URL source intentionally skipped under `--offline`.

--- a/packages/core/src/__tests__/templates-loader.test.ts
+++ b/packages/core/src/__tests__/templates-loader.test.ts
@@ -88,3 +88,68 @@ describe("loadTemplate honors offline + fetchAuth", () => {
     expect(result).toBe("FALLBACK");
   });
 });
+
+// IO-05: a CONFIGURED template/context source that fails to resolve must NOT
+// silently degrade to the default — it surfaces an error. Only the empty/unset
+// case (and the intentional --offline skip) returns the fallback.
+describe("loadTemplate surfaces configured-source failures (IO-05)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when a configured template URL 403s instead of silently using the default", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response("forbidden", { status: 403 }));
+
+    const { loadTemplate } = await import("../templates.js");
+    await expect(
+      loadTemplate("https://example.com/pr-template.md", "FALLBACK", {
+        fetchAuth: {},
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toThrow(/Failed to load configured template.*403/);
+  });
+
+  it("throws when a configured template URL is blocked by the SSRF guard", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { loadTemplate } = await import("../templates.js");
+    await expect(loadTemplate("http://169.254.169.254/latest/template.md", "FALLBACK", {})).rejects.toThrow(
+      /Failed to load configured template.*SOURCE_URL_BLOCKED/,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the default (no throw) when the source is empty/unset", async () => {
+    const { loadTemplate } = await import("../templates.js");
+    expect(await loadTemplate(undefined, "FALLBACK")).toBe("FALLBACK");
+    expect(await loadTemplate("", "FALLBACK")).toBe("FALLBACK");
+    expect(await loadTemplate("   ", "FALLBACK")).toBe("FALLBACK");
+  });
+});
+
+describe("loadAdditionalContext surfaces configured-source failures (IO-05)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when a configured context URL 403s instead of silently dropping it", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response("forbidden", { status: 403 }));
+
+    const { loadAdditionalContext } = await import("../templates.js");
+    await expect(loadAdditionalContext(["https://example.com/rules.md"], {})).rejects.toThrow(
+      /Failed to load configured context source.*403/,
+    );
+  });
+
+  it("still skips a URL source under --offline (warn, no throw)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const warns: string[] = [];
+    vi.spyOn(console, "warn").mockImplementation((m: unknown) => warns.push(String(m)));
+
+    const { loadAdditionalContext } = await import("../templates.js");
+    const { resolved } = await loadAdditionalContext(["https://example.com/rules.md"], { offline: true });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(resolved).toBe("");
+    expect(warns.some((w) => /offline/i.test(w))).toBe(true);
+  });
+});

--- a/packages/core/src/source-resolver.ts
+++ b/packages/core/src/source-resolver.ts
@@ -17,6 +17,14 @@ import { normalizeSource } from "./sources.js";
 /** Schemes a `url:` source is allowed to use. Everything else is rejected. */
 const ALLOWED_URL_SCHEMES = new Set(["http:", "https:"]);
 
+/**
+ * Error-message prefix used when a `url:` source cannot be fetched in
+ * `--offline` mode. Exported so callers that intentionally degrade to a default
+ * on this one failure (e.g. `templates.ts`) can detect it without coupling to
+ * the full message text.
+ */
+export const SOURCE_OFFLINE_REQUIRES_FETCH = "SOURCE_OFFLINE_REQUIRES_FETCH";
+
 /** Default DNS resolver used when the context does not inject one. */
 const defaultDnsLookup: DnsLookup = async (hostname) => {
   const records = await dns.lookup(hostname, { all: true });
@@ -93,7 +101,7 @@ export async function resolveSource(
   if (kind === "url") {
     if (ctx.offline) {
       throw new Error(
-        `SOURCE_OFFLINE_REQUIRES_FETCH: cannot fetch ${value} in --offline mode (referenced by ${fieldPath}).`,
+        `${SOURCE_OFFLINE_REQUIRES_FETCH}: cannot fetch ${value} in --offline mode (referenced by ${fieldPath}).`,
       );
     }
     // Validate type field on tagged URL forms — v1 only accepts "fetch" (the default).

--- a/packages/core/src/templates.ts
+++ b/packages/core/src/templates.ts
@@ -15,7 +15,7 @@
 import * as path from "node:path";
 
 import { classifySource, type SourceResolutionContext } from "./sources.js";
-import { resolveSource } from "./source-resolver.js";
+import { resolveSource, SOURCE_OFFLINE_REQUIRES_FETCH } from "./source-resolver.js";
 import { consoleLogger } from "./types.js";
 
 export const DEFAULT_ISSUE_TEMPLATE = `## Summary
@@ -98,7 +98,7 @@ function buildCtx(options: SourceLoadOptions): SourceResolutionContext {
  */
 function isOfflineSkip(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return msg.startsWith("SOURCE_OFFLINE_REQUIRES_FETCH");
+  return msg.startsWith(SOURCE_OFFLINE_REQUIRES_FETCH);
 }
 
 /**

--- a/packages/core/src/templates.ts
+++ b/packages/core/src/templates.ts
@@ -89,8 +89,26 @@ function buildCtx(options: SourceLoadOptions): SourceResolutionContext {
 }
 
 /**
+ * True when a resolution error is the intentional `--offline` skip of a URL
+ * source. Offline mode is the one failure we deliberately swallow into the
+ * fallback: the operator explicitly asked to skip URL Sources. Every other
+ * failure (404/403/SSRF block/read error/unreachable) is a real
+ * misconfiguration and must surface, matching the executor's per-node Source
+ * resolution which hard-throws on all of these.
+ */
+function isOfflineSkip(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.startsWith("SOURCE_OFFLINE_REQUIRES_FETCH");
+}
+
+/**
  * Load a template from a file path or URL.
- * Returns the default if source is empty or loading fails.
+ *
+ * Returns the default only when the source is empty/unset, or when a URL source
+ * is intentionally skipped under `--offline`. A CONFIGURED source that fails to
+ * resolve (404, 403, SSRF block, read error) now THROWS instead of silently
+ * degrading to the built-in default — a typo'd or unauthorized template URL is
+ * a misconfiguration, not a no-op. This matches the executor's Source handling.
  *
  * Accepts the legacy `cwd?: string` signature for backward compat.
  */
@@ -106,9 +124,12 @@ export async function loadTemplate(
     const resolved = await resolveSource(source.trim(), "template", buildCtx(opts));
     return resolved.content;
   } catch (err: unknown) {
+    if (isOfflineSkip(err)) {
+      console.warn(`[templates] Skipping URL template in --offline mode, using default.`);
+      return fallback;
+    }
     const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[templates] Failed to load template: ${msg}, using default`);
-    return fallback;
+    throw new Error(`Failed to load configured template "${source.trim()}": ${msg}`);
   }
 }
 
@@ -132,6 +153,9 @@ export async function resolveTemplates(
  * Each source is resolved eagerly (including URLs) and wrapped with a header.
  * Returns { resolved, urls } — resolved text for all sources; urls is kept
  * for API compat but will be empty since URLs now resolve eagerly.
+ *
+ * A configured source that fails to resolve THROWS (matching the executor and
+ * `loadTemplate`); only the intentional `--offline` URL skip is swallowed.
  *
  * Accepts the legacy `cwd?: string` signature for backward compat.
  */
@@ -160,8 +184,15 @@ export async function loadAdditionalContext(
           parts.push(`### ${label}\n\n${resolved.content}`);
         }
       } catch (err: unknown) {
+        // Offline skip of a URL source is intentional; everything else (404,
+        // 403, SSRF block, read error) is a misconfiguration and must surface
+        // rather than silently dropping the configured context document.
+        if (isOfflineSkip(err)) {
+          console.warn(`[templates] Skipping URL context source "${trimmed}" in --offline mode.`);
+          continue;
+        }
         const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`[templates] Failed to load context source: ${msg}`);
+        throw new Error(`Failed to load configured context source "${trimmed}": ${msg}`);
       }
     }
   }


### PR DESCRIPTION
## Problem

`loadTemplate` and `loadAdditionalContext` caught **every** `resolveSource` error (404, 403, SSRF block, read error, unreachable), emitted a bare `console.warn`, and silently degraded to the built-in default (template) or dropped the source (context). A user who configures `issueTemplate: "https://templates.corp/issue.md"` and gets a 403 or types the path wrong sees only a warning that scrolls past, and the run "succeeds" with the **wrong** template. The same failure on a node Source hard-fails the executor, so this was an inconsistency.

## Fix

Scoping decision (the validated spec flagged this as NEEDS-SCOPING on fail-vs-warn): a **configured** source that fails to resolve now **throws** a clear `Failed to load configured template/context source "<src>": <reason>` error. The two cases that legitimately fall back are preserved:

- **Empty / unset** source: unchanged early return of the default, no warning.
- **`--offline` URL skip**: the operator explicitly asked to skip URL Sources, so it stays a warn + fallback (not a throw). Branched on the `SOURCE_OFFLINE_REQUIRES_FETCH` error code.

Everything else (404, 403, SSRF block, read error, unreachable) surfaces, matching the executor's per-node Source handling. The CLI hard-fails on bad config elsewhere; this closes the soft spot.

## Testing

`npm run typecheck` clean. `npm test` green (1924 passed). New `templates-loader.test.ts` coverage:
- Configured template URL that 403s throws (not silent fallback).
- Configured template URL blocked by the SSRF guard throws (no fetch attempted).
- Empty / unset / whitespace source returns the default with no throw.
- Configured context URL that 403s throws.
- `--offline` URL context source still skips (warn, no throw, empty result).

The two pre-existing offline tests still pass unchanged.

## Acceptance criteria

- [x] A configured template URL that 403s produces a visible error (not a silent fallback).
- [x] An unset/empty template returns the default with no warning.
- [x] Same behavior for `loadAdditionalContext` context sources.

## Risk

Low-to-medium behavior change: a misconfigured rules/context/template URL now fails the CLI run loudly (non-zero exit) instead of silently using the wrong content. That is the intended fail-fast posture. The `--offline` skip and the empty/unset fallback are untouched, so no valid configuration regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)