### PR TITLE
[CE-06] Opt-in structural pre-validation for execute()

### DIFF
--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3267,3 +3267,79 @@ describe("missing-required-field retry", () => {
     expect(results.get("a")?.status).toBe("failed");
   });
 });
+
+describe("execute() opt-in structural validation (CE-06)", () => {
+  const unboundedCycle: Workflow = {
+    id: "cycle",
+    name: "Cycle",
+    description: "a→b→a with no max_iterations",
+    entry: "a",
+    nodes: {
+      a: { name: "A", instruction: "Do A", skills: [] },
+      b: { name: "B", instruction: "Do B", skills: [] },
+    },
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "a", when: "loop" },
+    ],
+  };
+
+  it("rejects an unbounded-cycle workflow before the first node when validate: true", async () => {
+    let runCalls = 0;
+    const claude: any = {
+      async run() {
+        runCalls++;
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    await expect(
+      execute(unboundedCycle, {}, { skills: createSkillMap([]), claude, config: {}, validate: true }),
+    ).rejects.toThrow(/Workflow validation failed[\s\S]*UNBOUNDED_CYCLE/);
+    expect(runCalls).toBe(0); // failed fast, no model call
+  });
+
+  it("does not pre-validate by default (max_steps remains the backstop)", async () => {
+    const claude: any = {
+      async run() {
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        // Keep choosing the loop-back edge so the cycle runs until max_steps.
+        return opts.choices.find((c: any) => c.id === "a")?.id ?? opts.choices[0].id;
+      },
+    };
+    // Without validate, the unbounded cycle is NOT rejected up front; it runs
+    // until the max_steps backstop trips (existing behavior preserved).
+    await expect(
+      execute(unboundedCycle, {}, { skills: createSkillMap([]), claude, config: {}, max_steps: 3 }),
+    ).rejects.toThrow(/step budget exceeded/);
+  });
+
+  it("validate: true accepts a structurally-valid workflow", async () => {
+    const valid: Workflow = {
+      id: "valid",
+      name: "Valid",
+      description: "a→b",
+      entry: "a",
+      nodes: {
+        a: { name: "A", instruction: "Do A", skills: [] },
+        b: { name: "B", instruction: "Do B", skills: [] },
+      },
+      edges: [{ from: "a", to: "b" }],
+    };
+    const claude: any = {
+      async run() {
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0].id;
+      },
+    };
+    const { results } = await execute(valid, {}, { skills: createSkillMap([]), claude, config: {}, validate: true });
+    expect(results.get("a")?.status).toBe("success");
+    expect(results.get("b")?.status).toBe("success");
+  });
+});

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -42,6 +42,7 @@ import { evaluateRequires } from "./requires.js";
 import { buildRetryPreamble } from "./retry.js";
 import { resolveExecutionModel } from "./model.js";
 import { buildToolAliases } from "./skills/index.js";
+import { validateWorkflow } from "./schema.js";
 
 export interface ExecuteOptions {
   /** Registered skills (id → Skill) */
@@ -71,6 +72,21 @@ export interface ExecuteOptions {
    * Per-edge `max_iterations` behavior is unchanged.
    */
   max_steps?: number;
+  /**
+   * Run the full structural validator ({@link validateWorkflow}) before the
+   * first node and throw on any structural error (unreachable nodes, unbounded
+   * cycles, self-loops, etc.). Defaults to `false` for back-compat.
+   *
+   * `execute()`'s built-in `validate()` only checks entry/edge existence and a
+   * skill-availability warning. It does NOT detect unbounded cycles or
+   * unreachable nodes — for those the only backstop is `max_steps`, which
+   * degrades a structurally-invalid workflow to "ran N wasted steps then
+   * threw" instead of "rejected before any model call". The CLI path already
+   * pre-validates via `loadAndValidateWorkflow`; direct programmatic callers
+   * SHOULD either pre-validate with {@link validateWorkflow} /
+   * `loadAndValidateWorkflow`, or pass `validate: true` here to enforce it.
+   */
+  validate?: boolean;
 }
 
 /**
@@ -87,6 +103,15 @@ export const DEFAULT_MAX_STEPS = 200;
  * Returns an ExecutionResult with:
  * - `results`: map of node ID → final result (last execution if retried)
  * - `trace`: full ordered execution trace including loops and routing decisions
+ *
+ * Pre-validation contract: `execute()` runs only a lightweight built-in check
+ * (entry/edge existence + skill-availability warning). It does NOT detect
+ * unbounded cycles or unreachable nodes — `max_steps` is the only runtime
+ * backstop for a structurally-invalid graph. The CLI pre-validates via
+ * `loadAndValidateWorkflow`. Direct programmatic callers SHOULD pre-validate
+ * with {@link validateWorkflow} / `loadAndValidateWorkflow`, or pass
+ * `options.validate: true` to have `execute()` enforce the full validator and
+ * fail fast before the first node runs.
  */
 export async function execute(workflow: Workflow, input: unknown, options: ExecuteOptions): Promise<ExecutionResult> {
   const { claude, observer } = options;
@@ -104,6 +129,19 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
   const maxSteps = options.max_steps ?? DEFAULT_MAX_STEPS;
   let stepCount = 0; // total node executions across the run (loop iterations included)
   const trace: ExecutionTrace = { steps: [], edges: [], sources: {} };
+
+  // Opt-in full structural validation (unbounded cycles, unreachable nodes,
+  // ambiguous routing, etc.). Off by default for back-compat; the CLI path
+  // already validates upstream. When enabled, fail fast before any node runs
+  // rather than degrading to a wasted run that trips the max_steps backstop.
+  if (options.validate) {
+    const knownSkills = new Set(skills.keys());
+    const errors = validateWorkflow(workflow, knownSkills);
+    if (errors.length > 0) {
+      const lines = errors.map((e) => `  - [${e.code}] ${e.message}`);
+      throw new Error(`Workflow validation failed:\n${lines.join("\n")}`);
+    }
+  }
 
   validate(workflow, skills);
 


### PR DESCRIPTION
**Problem**

`execute()`'s internal `validate()` only checks entry existence, edge-target existence, and warns on missing skills. It does NOT run `validateWorkflow`, so it misses unbounded cycles and unreachable nodes. The CLI path is safe (`loadAndValidateWorkflow`), but a direct programmatic `execute()` caller (public API) can hand in an unbounded-cycle workflow. The only backstop is `max_steps`, so "structurally invalid" degrades to "ran N wasted steps then threw" instead of "rejected before any model call".

**Fix**

Lower-risk option from the spec: add an opt-in `ExecuteOptions.validate?: boolean` (default `false`, fully back-compat). When `true`, `execute()` runs the full `validateWorkflow` (with the loaded skill set) before the first node and throws a clear `Workflow validation failed:` error listing the structural errors. Default behavior is unchanged, so no shipped workflow can be newly rejected. The `execute()` / `ExecuteOptions` JSDoc now documents the pre-validation contract (callers SHOULD pre-validate or pass `validate: true`), and `max_steps` stays as the runtime backstop.

**Testing**

- New tests: `validate: true` on an unbounded-cycle workflow throws `UNBOUNDED_CYCLE` before any `claude.run` (call counter = 0); default (no `validate`) still runs until the `max_steps` backstop trips (existing behavior preserved); `validate: true` accepts a valid workflow.
- `npm run typecheck` clean, full core suite green (1922 passing).

**Acceptance criteria**

- [x] `execute()` on an unbounded-cycle workflow throws a structural error before the first node runs (with `validate: true`).
- [x] The pre-validation contract is documented in JSDoc and asserted by tests.
- [x] Default behavior unchanged; no shipped fixture newly rejected (full suite green).

**Risk**

Low. New field is opt-in and defaults off. When enabled it reuses the same `validateWorkflow` the CLI already runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)