### PR TITLE
[SW-07] Re-sync NodePanel fields on undo/redo and external rewrite

### DIFF
--- a/packages/studio/src/components/PropertiesPanel.tsx
+++ b/packages/studio/src/components/PropertiesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import type { Node, NodeResult, Source } from "@sweny-ai/core";
 import { validateWorkflow } from "@sweny-ai/core/schema";
 import { getSkillCatalog } from "@sweny-ai/core/studio";
@@ -8,6 +8,29 @@ import { InstructionEditor } from "./InstructionEditor.js";
 import { generateInstruction } from "../lib/generate-instruction.js";
 
 const skillCatalog = getSkillCatalog();
+
+// Derive the editable {sourceKind, value} pair from a node's `instruction`
+// Source (a plain string is inline; an object carries file/url/inline). Kept as
+// pure module-level helpers so both the initial seed and the sync effect agree.
+function deriveSourceKind(src: Node["instruction"]): "inline" | "file" | "url" {
+  if (typeof src === "string") {
+    const t = src.trim();
+    if (t.startsWith("http://") || t.startsWith("https://")) return "url";
+    if (t.startsWith("./") || t.startsWith("../") || t.startsWith("/")) return "file";
+    return "inline";
+  }
+  if ("url" in src) return "url";
+  if ("file" in src) return "file";
+  return "inline";
+}
+
+function deriveInstructionValue(src: Node["instruction"]): string {
+  if (typeof src === "string") return src;
+  if ("inline" in src) return src.inline;
+  if ("file" in src) return src.file;
+  if ("url" in src) return src.url;
+  return "";
+}
 
 export function PropertiesPanel() {
   const {
@@ -199,26 +222,31 @@ function NodePanel({
   const [name, setNodeName] = useState(node.name);
 
   // Source type state — track kind + value separately
-  const [sourceKind, setSourceKind] = useState<"inline" | "file" | "url">(() => {
-    const src = node.instruction;
-    if (typeof src === "string") {
-      const t = src.trim();
-      if (t.startsWith("http://") || t.startsWith("https://")) return "url";
-      if (t.startsWith("./") || t.startsWith("../") || t.startsWith("/")) return "file";
-      return "inline";
+  const [sourceKind, setSourceKind] = useState<"inline" | "file" | "url">(() => deriveSourceKind(node.instruction));
+  const [instruction, setInstruction] = useState(() => deriveInstructionValue(node.instruction));
+
+  // The panel is keyed by node `id`, so switching nodes remounts and re-seeds.
+  // But the *same* node's content can change underneath us without an id change
+  // (undo/redo via temporal, or an external rewrite). Re-seed local state when
+  // the node's committed values change. Guard against clobbering in-progress
+  // typing by tracking the last node values we synced from and only re-seeding
+  // when the incoming node value differs from that snapshot — typing only moves
+  // local state, not `node.*`, so it won't trip this.
+  const lastSyncedName = useRef(node.name);
+  const lastSyncedInstruction = useRef(node.instruction);
+  useEffect(() => {
+    if (node.name !== lastSyncedName.current) {
+      lastSyncedName.current = node.name;
+      setNodeName(node.name);
     }
-    if ("url" in src) return "url";
-    if ("file" in src) return "file";
-    return "inline";
-  });
-  const [instruction, setInstruction] = useState(() => {
-    const src = node.instruction;
-    if (typeof src === "string") return src;
-    if ("inline" in src) return src.inline;
-    if ("file" in src) return src.file;
-    if ("url" in src) return src.url;
-    return "";
-  });
+    if (node.instruction !== lastSyncedInstruction.current) {
+      lastSyncedInstruction.current = node.instruction;
+      setSourceKind(deriveSourceKind(node.instruction));
+      setInstruction(deriveInstructionValue(node.instruction));
+      setEditId(id);
+      setIdError(null);
+    }
+  }, [node.name, node.instruction, id]);
 
   const buildSource = useCallback((kind: "inline" | "file" | "url", value: string): Source => {
     if (kind === "file") return { file: value };


### PR DESCRIPTION
## Problem
`NodePanel` seeds `editId` / `name` / `instruction` / `sourceKind` from props once, in `useState` initializers, and is keyed by `key={id}`. So it re-seeds only when the selected node id changes. When the *same* node's content changes underneath it without an id change, the panel keeps the stale values:
- undo/redo (`temporal` restores `workflow.nodes[id].instruction`/`.name` while the id stays put), and
- any external rewrite.

The textarea then keeps the pre-undo value, and the next `onBlur` (`updateNode(id, { instruction })`) writes it back, silently reverting the undo. The AI path masked this only for itself by calling `setInstruction(text)` directly.

## Fix
- Extract the node-`instruction`-Source → `{sourceKind, value}` derivation into pure module-level helpers (`deriveSourceKind`, `deriveInstructionValue`) used by both the initial seed and the new effect.
- Add a sync `useEffect` keyed on `node.name` / `node.instruction` / `id` that re-seeds local state when those change. Guard against clobbering in-progress typing with refs (`lastSyncedName`, `lastSyncedInstruction`): re-seed only when the incoming node value differs from the last synced snapshot. Typing only moves local state (not `node.*`), so it never trips the effect — no cursor reset mid-edit. No render loop (the effect updates the refs to the value it just synced, so the next pass no-ops).

## Testing
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.
- `npx vitest run src/__tests__/editor-store.test.ts` → 47/47.
- No React component test harness exists in this package (node-env Vitest only, no jsdom/RTL), so the undo/redo behavior is verified by inspection + the type/build gates; the store-level undo (temporal restoring `node.*`) is already covered by the store tests.

## Acceptance criteria
- [x] With a node selected, undo/redo updates the visible ID/Name/Instruction fields.
- [x] Blurring a field after an undo does not re-write the pre-undo value (local state is re-seeded from the store first).
- [x] Typing is not interrupted by the sync effect on unrelated store changes.

## Risk
Properties panel only. Refs prevent re-render loops and typing clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)