### PR TITLE
[IO-06] Document residual DNS-rebind TOCTOU in the SSRF guard

### DIFF
--- a/packages/core/src/source-resolver.ts
+++ b/packages/core/src/source-resolver.ts
@@ -215,6 +215,10 @@ async function fetchFollowingRedirects(
   let currentUrl = startUrl;
   let headers = startHeaders;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    // NOTE (IO-06): this bare fetch() does its own DNS resolution, independent
+    // of the lookup assertSafeHost() just validated — a residual DNS-rebinding
+    // TOCTOU window. Closing it means pinning to the validated IP via a custom
+    // dispatcher. See the assertSafeHost() doc comment.
     const res = await fetch(currentUrl, {
       headers,
       redirect: "manual",
@@ -301,6 +305,25 @@ function assertAllowedScheme(url: string, fieldPath: string): void {
  * A hostname that fails to resolve is allowed through (the subsequent fetch
  * will simply fail) so that this guard does not turn DNS outages or unknown
  * test hosts into hard validation errors.
+ *
+ * KNOWN RESIDUAL — DNS-rebinding TOCTOU (IO-06). This guard resolves the
+ * hostname here, but `fetchFollowingRedirects` then calls bare `fetch()`, which
+ * performs its OWN independent DNS resolution. The validated address and the
+ * connected address are not pinned to be the same. An attacker-controlled
+ * domain with a short-TTL record can therefore return a public IP to this
+ * lookup and a private/metadata IP to `fetch`'s lookup, slipping past the guard
+ * (classic DNS rebinding). The window is small (the two lookups happen
+ * back-to-back and Node caches within a resolution) but non-zero.
+ *
+ * This is NOT fully closed. Closing it requires pinning the connection to the
+ * validated IP — e.g. an undici `Agent` with a custom `connect`/`lookup` that
+ * returns the pre-validated address while preserving the original `Host` header
+ * and TLS SNI (servername = original hostname), and re-pinning on every redirect
+ * hop. That interacts with TLS and the existing per-hop redirect re-validation,
+ * so it is deferred as a follow-up. Severity is low: it requires an
+ * attacker-controlled domain AND a precisely-timed TTL flip between the two
+ * resolutions. Do not treat the SSRF guard as airtight against rebinding until
+ * the connection is IP-pinned.
  */
 async function assertSafeHost(url: string, ctx: SourceResolutionContext, fieldPath: string): Promise<void> {
   const hostname = new URL(url).hostname;


### PR DESCRIPTION
## Problem

`assertSafeHost` resolves the hostname via the injected DNS lookup and rejects private/loopback/link-local IPs, but `fetchFollowingRedirects` then calls bare `fetch()`, which performs its **own independent** DNS resolution. The validated address and the connected address are not pinned to be the same, so an attacker-controlled domain with a short-TTL record can return a public IP to the guard and a private/metadata IP to `fetch` (classic DNS rebinding). The guard's own "unresolved host — let fetch fail naturally" comment already shows the two resolutions are independent. This is a known residual, not a regression; the rest of the SSRF / redirect work (#220) is comprehensive.

## Fix

Per the validated spec, the documentation-only path is "a defensible v1" for a **low**-severity / **medium**-confidence finding. A full fix means pinning the connection to the validated IP (undici `Agent` with a custom `connect`/`lookup` that returns the pre-validated address while preserving the `Host` header and TLS SNI, re-pinned on each redirect hop), which interacts with TLS and the existing per-hop redirect re-validation and warrants its own PR + tests.

This change documents the residual precisely so it is not mistaken for fully closed:
- A detailed `KNOWN RESIDUAL — DNS-rebinding TOCTOU` note on `assertSafeHost`, describing the window, why it exists, and exactly what the follow-up pin requires.
- A cross-reference comment at the bare `fetch()` call site in `fetchFollowingRedirects`.

No behavior change.

## Testing

`npm run typecheck` clean. Security suite (`sources.security.test.ts`, 29 tests) passes. Comment-only diff.

## Acceptance criteria

- [x] The residual is explicitly documented in `assertSafeHost` (and cross-referenced at the connection site).

## Risk

Zero. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)