### PR TITLE
[SW-09] Lazy-import MockClaude out of the eager SPA graph

### DIFF
--- a/packages/studio/src/components/SimulationPanel.tsx
+++ b/packages/studio/src/components/SimulationPanel.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useEditorStore } from "../store/editor-store.js";
 import { execute, createSkillMap } from "@sweny-ai/core";
-import { MockClaude } from "@sweny-ai/core/testing";
 import type { NodeResult } from "@sweny-ai/core";
 
 export function SimulationPanel() {
@@ -12,7 +11,7 @@ export function SimulationPanel() {
   const currentNode = currentNodeId ? workflow.nodes[currentNodeId] : null;
   const completedList = Object.entries(completedNodes);
 
-  function handleAutoRun() {
+  async function handleAutoRun() {
     setSimError(null);
     setIsRunning(true);
 
@@ -25,16 +24,21 @@ export function SimulationPanel() {
       responses[id] = { status: "success" };
     }
 
-    const claude = new MockClaude({ responses, workflow: wf });
-    const skills = createSkillMap([]);
+    try {
+      // `@sweny-ai/core/testing` (MockClaude) transitively pulls `node:fs` /
+      // `node:path` via createFileSkill. Lazy-import it so `testing.js` is not
+      // in the eager SPA module graph — it loads only when the user actually
+      // runs the simulation, shrinking the initial bundle.
+      const { MockClaude } = await import("@sweny-ai/core/testing");
+      const claude = new MockClaude({ responses, workflow: wf });
+      const skills = createSkillMap([]);
 
-    execute(wf, {}, { skills, claude, observer: applyEvent })
-      .catch((err: unknown) => {
-        setSimError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        setIsRunning(false);
-      });
+      await execute(wf, {}, { skills, claude, observer: applyEvent });
+    } catch (err: unknown) {
+      setSimError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsRunning(false);
+    }
   }
 
   const statusColor = {


### PR DESCRIPTION
## Problem
`SimulationPanel.tsx` statically imports `MockClaude` from `@sweny-ai/core/testing`. `testing.js` transitively pulls `node:fs` / `node:path` (lazy `await import` inside `createFileSkill`), and `SimulationPanel` is eagerly imported by `App.tsx`, so `core/testing` sits in the production SPA module graph — the browser-safety smell the alias-to-dist setup is meant to prevent.

## Fix
Lazy-import `MockClaude` inside `handleAutoRun` (made async) so `core/testing` is no longer in the eager module graph; it loads on demand only when the user clicks Simulate. `createSkillMap` (browser-safe) stays a static import.

## Honest scope note
During verification I confirmed the `node:fs`/`node:path` externalization warnings are **not** fully eliminated by this change alone. The simulate path also runs the real `execute`, which is Node-only and transitively imports the whole Node entry tree (`source-resolver.js`, `loader.js`, `templates.js`, `cli/config-file.js`, `skills/custom-loader.js`, **and** `testing.js`). So `testing.js` enters the bundle via `execute` regardless of how `MockClaude` is imported. Fully removing the warnings requires a browser-clean executor in core, which the validated spec marks out of scope ("larger alternative"). This PR delivers the in-scope improvement: `core/testing` is removed from the *eager* graph and confined to the on-demand simulate chunk, shrinking the initial bundle.

## Testing
- `npm run typecheck` → exit 0.
- `npm run build:lib` → exit 0.
- Verified (by transiently stacking the SW-01 build fix in the worktree to get a completing SPA build) that `core/testing` no longer appears as an *eager* import; the residual `testing.js` warning is the `execute`-pulled one described above.

## Acceptance criteria
- [x] `core/testing` removed from the eager SPA module graph (loads only in the simulate async chunk).
- [x] Simulate mode still constructs `MockClaude` and runs the mock execution.
- [ ] Zero `node:fs`/`node:path` warnings — partially: the residual warning is intrinsic to the Node `execute` path (see scope note); requires a core-side change to fully clear.

## Risk
Simulate mode only. The mock still resolves via the same `@sweny-ai/core/testing` alias, now dynamically. Conflicts with [SW-01](https://github.com/swenyai/sweny/pull/233) in `SimulationPanel.tsx` `handleAutoRun` (both rewrite it to async lazy-import); trivial to reconcile — the converged state lazy-imports both `MockClaude` and `execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)