### PR TITLE
[SW-10] Remove dead 'partial' status and fix duplicate validation keys

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -192,9 +192,9 @@ export function App() {
           <span className="text-amber-600 text-xs font-medium">
             {validationErrors.length} validation {validationErrors.length === 1 ? "error" : "errors"}:
           </span>
-          {validationErrors.map((e) => (
+          {validationErrors.map((e, i) => (
             <button
-              key={e.message}
+              key={`${e.code}:${e.nodeId ?? ""}:${i}`}
               onClick={() => (e.nodeId ? setSelection({ kind: "node", id: e.nodeId }) : undefined)}
               className={`text-amber-700 text-xs ${e.nodeId ? "hover:underline cursor-pointer" : "cursor-default"}`}
             >

--- a/packages/studio/src/components/SimulationPanel.tsx
+++ b/packages/studio/src/components/SimulationPanel.tsx
@@ -42,7 +42,6 @@ export function SimulationPanel() {
     running: "text-blue-400",
     completed: "text-green-400",
     failed: "text-red-400",
-    partial: "text-yellow-400",
   }[executionStatus];
 
   return (

--- a/packages/studio/src/store/editor-store.ts
+++ b/packages/studio/src/store/editor-store.ts
@@ -13,7 +13,7 @@ export interface ExecutionSlice {
   // Results of nodes that have completed
   completedNodes: Record<string, NodeResult>;
   // Overall workflow status
-  executionStatus: "idle" | "running" | "completed" | "failed" | "partial";
+  executionStatus: "idle" | "running" | "completed" | "failed";
   // For live mode: connection info
   liveConnection: {
     url: string;


### PR DESCRIPTION
## Problem
- **Part A:** the `EditorState` `executionStatus` union includes `"partial"` and `SimulationPanel` styles it, but `applyEvent` only ever sets `running` / `failed` / `completed` / `idle` on `workflow:end` — `"partial"` is a dead, unreachable branch with no emitter and no defined semantics.
- **Part B:** the validation-error banner maps with `key={e.message}`. Two errors that share a message (e.g. the same message for two different nodes) collide on the React key, triggering a duplicate-key warning.

## Fix
- **Part A:** drop `"partial"` from the `executionStatus` union (`editor-store.ts:16`) and from the `SimulationPanel` `statusColor` map. (Recommended option (i) from the spec — no emitter exists, so removing is lower-risk than inventing a trigger.)
- **Part B:** switch the banner key to a stable composite ``key={`${e.code}:${e.nodeId ?? ""}:${i}`}`` (added `i` to the map callback). `WorkflowError` carries `code` + optional `nodeId`; the `:${i}` suffix guarantees uniqueness even if `code`+`nodeId` repeat.

## Testing
- `grep -rn '"partial"' packages/studio/src` → zero hits.
- `npm run typecheck` → exit 0 (union narrowing in `SimulationPanel` still valid after dropping `"partial"`).
- `npm run build:lib` → exit 0.
- `npx vitest run src/__tests__/editor-store.test.ts` → 47/47.

## Acceptance criteria
- [x] No dead `"partial"` branch.
- [x] No duplicate React key when two validation errors share a message (composite key with index).
- [x] typecheck passes.

## Risk
Trivial. Conflicts with [SW-06](https://github.com/swenyai/sweny/pull/246) only in `editor-store.ts` (non-overlapping ranges: status union here vs. edge/node delete functions there) — trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)