### PR TITLE
[IN-06] eslint: lint .tsx, fix stale CLI override, ignore generated/worktree

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,13 +12,19 @@ export default [
       "**/.next/",
       "**/coverage/",
       "packages/web/.astro/**",
+      "spec/.astro/**",
       ".claude/**",
+      "**/*.d.ts",
+      // Local git worktrees (gitignored). Without this, `eslint .` lints
+      // every checkout under .worktrees/ and inflates the warning count.
+      ".worktrees/**",
     ],
   },
 
-  // TypeScript files
+  // TypeScript files (incl. .tsx — studio React source was previously unlinted
+  // because a flat-config block matching no files is skipped).
   {
-    files: ["**/*.ts"],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -48,11 +54,35 @@ export default [
     },
   },
 
-  // CLI — console output is intentional in a CLI tool
+  // CLI — console output is intentional in a CLI tool. The CLI moved from the
+  // removed packages/cli into packages/core/src/cli; this override was dead.
   {
-    files: ["packages/cli/src/**/*.ts"],
+    files: ["packages/core/src/cli/**/*.ts"],
     rules: {
       "no-console": "off",
+    },
+  },
+
+  // Studio React source. Now that .tsx is linted, the existing
+  // `// eslint-disable react-hooks/exhaustive-deps` directives in studio
+  // reference rules that aren't registered, which ESLint reports as an error
+  // ("Definition for rule ... was not found"). Register the react-hooks rule
+  // ids as no-ops (off) so those directives resolve cleanly without pulling in
+  // eslint-plugin-react-hooks or surfacing a wave of new warnings. Swap these
+  // for the real plugin if/when studio adopts full hooks linting.
+  {
+    files: ["packages/studio/src/**/*.{ts,tsx}"],
+    plugins: {
+      "react-hooks": {
+        rules: {
+          "exhaustive-deps": { create: () => ({}) },
+          "rules-of-hooks": { create: () => ({}) },
+        },
+      },
+    },
+    rules: {
+      "react-hooks/exhaustive-deps": "off",
+      "react-hooks/rules-of-hooks": "off",
     },
   },
 


### PR DESCRIPTION
## Problem

`eslint.config.js` had three gaps (`eslint.config.js:21,53` plus `ignores`):

1. The only TS rule block matched `files: ["**/*.ts"]`. In flat config a file matching no block is skipped, so `eslint .` linted 0 of the 19 studio `.tsx` files. (Naming one explicitly, `eslint packages/studio/src/App.tsx`, did parse it, confirming the block was the gap.)
2. The console-allow override targeted `packages/cli/src/**/*.ts`. `packages/cli` was folded into `packages/core/src/cli/`, so the override was dead and 154 CLI `console.*` calls warned under the generic `no-console: warn`.
3. Generated/declaration output (`**/*.d.ts`, `spec/.astro/**`) and local `.worktrees/**` checkouts were linted, inflating the count (the source of the inflated 2219 figure in the original report).

## Fix

- Widen the TS block to `files: ["**/*.{ts,tsx}"]`.
- Retarget the console-allow override to `packages/core/src/cli/**/*.ts`.
- Add `**/*.d.ts`, `spec/.astro/**`, and `.worktrees/**` to `ignores`.
- Enabling `.tsx` surfaced 3 errors: existing `// eslint-disable react-hooks/exhaustive-deps` directives in studio reference a rule that isn't registered, which ESLint reports as `Definition for rule ... was not found`. Per the validated spec ("scope a studio-only relax block rather than disabling globally"), register the `react-hooks` rule ids as no-ops in a studio-scoped block so the directives resolve. Dependency-free, no wave of new warnings. Swap for `eslint-plugin-react-hooks` if studio adopts full hooks linting.

## Testing

- Main-tree `eslint .`: 283 warnings / 0 errors -> **141 warnings / 0 errors** (154 CLI `no-console` silenced; studio `.tsx` now linted). Did not claim the inflated 2219 figure.
- `eslint packages/core/src/cli` -> 0 `no-console` warnings.
- `eslint packages/studio/src/App.tsx` -> linted (surfaces a real warning), confirming `.tsx` coverage.
- `npm run lint` exits 0 (non-failing — rules are `warn`, no errors), so CI does not break.
- `eslint.config.js` is prettier-clean and `node --check` valid.

## Acceptance criteria

- [x] `eslint .` lints studio `.tsx` files.
- [x] CLI `console.*` no longer warns; main-tree warning count drops by ~154 (283 -> 141).
- [x] Generated `.astro`/`.d.ts` output is ignored.
- [x] `npm run lint` stays non-failing.

## Risk

Low-medium. Enabling `.tsx` surfaces studio warnings (all `warn`, none fail CI). The react-hooks no-op block leaves 3 cosmetic "unused eslint-disable directive" warnings, which `--fix` would clear; left in place as a signal to adopt the real plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)