### PR TITLE
[IN-08] docs: correct release/changeset and package-layout docs to match reality

### DIFF
--- a/.github/workflows/continuous-improvement.yml
+++ b/.github/workflows/continuous-improvement.yml
@@ -100,17 +100,20 @@ jobs:
             - Performance: slow build steps, redundant work in the action entrypoint
 
             The codebase is a TypeScript ESM monorepo (Node 22, Vitest 4):
-              packages/providers  — 30+ provider implementations (observability, issue tracking,
-                                    source control, notification, coding-agent, MCP, storage)
-              packages/engine     — workflow runner (WorkflowDefinition DAG, Learn → Act → Report)
-                                    Key exports: runWorkflow, createWorkflow, validateWorkflow
-              packages/action     — GitHub Action entrypoint (dist/index.js via ncc)
-              packages/agent      — Slack bot + CLI AI assistant (Claude Code SDK)
-              packages/cli        — sweny CLI: triage, implement, check, workflow run/validate/list/export
-              packages/studio     — React component library: WorkflowViewer DAG visualization
+              packages/core          - the engine: skill library, DAG workflow executor, and the
+                                       sweny CLI (triage, implement, check, workflow run/validate/list/export).
+                                       Built-in workflows live here; key exports include the DAG executor and schema.
+              packages/studio        - React component library + SPA: WorkflowViewer/editor DAG visualization
+              packages/mcp           - MCP server for Claude Code / Desktop (sweny_list_workflows, sweny_run_workflow)
+              packages/create-sweny  - npx create-sweny, a thin wrapper around `sweny new`
+              packages/plugin        - Claude Code plugin (skills, MCP tools, agent, hooks); marketplace, not published to npm
+              packages/web           - docs site (Astro), deploys to docs.sweny.ai via Vercel
 
-            Build order matters: providers must build before engine, engine before cli/agent/action.
-            Run `npm run build --workspace=packages/providers` before typechecking engine.
+            The GitHub Action is the composite root action.yml (it forwards to `sweny workflow run`).
+            There is no packages/action JS bundle (no ncc, no dist/index.js) and no packages/{providers,engine,agent,cli}.
+
+            Build order: build packages/core before typechecking studio/mcp, which import from @sweny-ai/core.
+            Run `npm run build --workspace=packages/core` first.
 
             Security: the last push reported 8 Dependabot vulnerabilities (3 high, 4 moderate, 1 low).
             If CI logs don't show a clear target, investigate the security advisories via GitHub MCP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,11 @@
 ## Deployment
 
 Push to `main` auto-deploys everything:
-1. `.github/workflows/release.yml` rebuilds `dist/`, bumps versions, publishes to npm, and updates the `v5` action tag
+1. `.github/workflows/release.yml` builds the publishable packages (`core`, `studio` lib, `mcp`, `create-sweny`), bumps versions, publishes to npm, and moves the `v5` action tag (the action is the composite root `action.yml`, no JS bundle)
 2. GitHub Action consumers (`swenyai/sweny@v5`) pick up changes on their next run — no manual release step
 3. Vercel auto-deploys `packages/web` (docs.sweny.ai) and `spec/` (spec.sweny.ai) on push to `main`
 
-Changesets are handled by a CI backstop (`scripts/auto-changeset.mjs`) that auto-generates one for any published package with unreleased commits. You can also create one explicitly at `.changeset/<slug>.md` with the correct bump level if you want a meaningful description.
+There are no changesets. `release.yml` versions and publishes directly: it diffs each publishable package (`core`, `studio`, `mcp`, `create-sweny`) against the `release-latest` tag, and for any that changed it runs `bump_and_publish`. That picks the version from `max(local package.json, npm)` and publishes it (cutting a patch above npm when the local version is stale or already taken). To ship a specific minor/major, set the version in the package's `package.json` ahead of npm. After publishing it pushes the `v5` and immutable `v5.<core-version>` tags.
 
 ## Package structure
 
@@ -18,7 +18,7 @@ Changesets are handled by a CI backstop (`scripts/auto-changeset.mjs`) that auto
 | `@sweny-ai/studio` | `packages/studio` | npm | Visual workflow viewer/editor |
 | `@sweny-ai/mcp` | `packages/mcp` | npm | MCP server for Claude Code / Desktop |
 | — | `packages/plugin` | no (marketplace) | Claude Code plugin: skills, MCP tools, agent, hooks |
-| `@sweny-ai/action` | `packages/action` | no (private) | GitHub Action entrypoint — bundled into root `dist/` |
+| (composite) | `action.yml` (repo root) | no (private) | GitHub Action entrypoint: a composite action that forwards to `sweny workflow run` (no JS bundle, no `dist/`) |
 | `@sweny-ai/web` | `packages/web` | no (private) | Docs site (Vercel → docs.sweny.ai) |
 
 ## Test framework


### PR DESCRIPTION
## Problem

Two docs described infrastructure that no longer exists:

- `CLAUDE.md` (Deployment): "Changesets are handled by a CI backstop (`scripts/auto-changeset.mjs`)". That file does not exist (`scripts/` has only `generate-brand-pngs.mjs`), no workflow references it, and `release.yml` uses a manual `npm view` + `npm version` diff/bump approach with no changesets at all. It also claimed release.yml "rebuilds `dist/`" and listed `packages/action` as "bundled into root `dist/`" — the action is now the composite root `action.yml` with no JS bundle, and `packages/action` has no tracked source.
- `.github/workflows/continuous-improvement.yml`: the agent prompt described `packages/{providers,engine,action,agent,cli}` and an ncc `dist/index.js`. Those packages were consolidated into `packages/core`; an autonomous agent following the prompt would look for files that aren't there.

## Fix

- `CLAUDE.md`: replace the changeset claim with the real flow (diff each publishable package against `release-latest`, `bump_and_publish` per changed package, push `v5`/`v5.<core>` tags; set version in package.json ahead of npm for a deliberate minor/major). Correct the Deployment step-1 build line and the package-structure table (composite `action.yml`, no root `dist/`).
- `continuous-improvement.yml`: rewrite the package block to the real `packages/{core,studio,mcp,create-sweny,plugin,web}` + composite `action.yml`, and fix the build-order note (build core first; studio/mcp import from `@sweny-ai/core`).

Took the doc-correction option (not implementing a changeset backstop), per the validated spec's recommendation.

## Testing

- `CLAUDE.md` is prettier-clean.
- `continuous-improvement.yml` parses cleanly under js-yaml (the prompt block scalar is intact).
- Grep confirms no remaining references to `auto-changeset`, `ncc`, `dist/index.js`, `packages/action`'s dist, or `packages/{engine,providers,agent,cli}` (the one match is my line stating those explicitly do not exist).
- Package list matches `ls packages/`.

## Acceptance criteria

- [x] No doc/workflow comment references `auto-changeset.mjs`, an ncc bundle, `packages/action`'s `dist/index.js`, or `packages/{engine,providers,cli,agent}`.
- [x] The continuous-improvement prompt's package list matches `ls packages/`.

## Risk

None. Docs/prompt only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)