### PR TITLE
[IN-10] repo: declare core/studio engines + test Node 24 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        # 24 is the action default (action.yml node-version), so the version
+        # most consumers run the action on is exercised in CI.
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,9 @@
   },
   "description": "Skill library, DAG workflow orchestration, and E2E browser testing powered by Claude",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "exports": {
     ".": "./dist/index.js",
     "./browser": "./dist/browser.js",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -2,6 +2,9 @@
   "name": "@sweny-ai/studio",
   "version": "8.0.12",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "files": [
     "dist/lib"
   ],


### PR DESCRIPTION
## Problem

- `@sweny-ai/core` (and `@sweny-ai/studio`) declared no `engines` field, while `mcp`/`create-sweny` declare `>=18` and root declares `>=20`. core ships no engine floor to warn installers on too-old Node.
- The composite action defaults `node-version: "24"` (`action.yml`), but CI only tested Node 20 and 22 (`ci.yml` matrix `[20, 22]`; typecheck/build/release on 22). The version most consumers actually run the action on (24) was never exercised in CI.

## Fix

- Add `"engines": { "node": ">=20" }` to `packages/core/package.json` and `packages/studio/package.json` (matching root; studio was also missing it).
- Add `24` to the `ci.yml` test matrix: `node-version: [20, 22, 24]`, so the shipped default is what CI tests.

## Testing

- `packages/core/package.json` and `packages/studio/package.json` are valid JSON with `engines.node = ">=20"`.
- `ci.yml` parses; test matrix is `[20, 22, 24]`.
- All three files prettier-clean.

## Acceptance criteria

- [x] `packages/core` declares an `engines.node` floor consistent with siblings (and studio too).
- [x] The action's default Node version (24) is covered by the CI test matrix.

## Risk

Low. `engines` is advisory (npm warns, doesn't block under default config). The matrix add costs a few CI minutes per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)