### PR TITLE
security(core): per-skill input hardening (github path, betterstack SQL, supabase filters)

### DIFF
--- a/.changeset/skill-input-hardening.md
+++ b/.changeset/skill-input-hardening.md
@@ -1,0 +1,9 @@
+---
+"@sweny-ai/core": patch
+---
+
+Per-skill input hardening for LLM-controlled tool arguments (#226).
+
+- **GitHub**: `github_get_file` now percent-encodes the model-chosen `path` (and `ref`), and rejects `.`/`..` segments, so a crafted path can no longer inject query parameters or escape the contents endpoint.
+- **BetterStack**: `table` is validated as a bare ClickHouse identifier before it reaches `DESCRIBE TABLE remote(...)`. The read-only query guard now accepts `WITH` CTEs, rejects multi-statement input, ignores keywords inside string literals when deciding whether to append the `LIMIT` cap, and is documented as best-effort UX — use a read-only ClickHouse role as the actual security boundary.
+- **Supabase**: table and function names are validated as identifiers, PostgREST filter values are URL-encoded so a single filter cannot smuggle extra query parameters, and the new optional `SUPABASE_ALLOWED_TABLES` / `SUPABASE_ALLOWED_FUNCTIONS` config bounds what the agent can touch. The service-role blast radius is now documented on the skill and in the docs.

--- a/packages/core/src/skills/betterstack.test.ts
+++ b/packages/core/src/skills/betterstack.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { betterstack, assertClickHouseIdentifier, prepareReadOnlyQuery } from "./betterstack.js";
+import type { ToolContext } from "../types.js";
+
+const ctx = (): ToolContext => ({
+  config: {
+    BETTERSTACK_API_TOKEN: "test-token",
+    BETTERSTACK_QUERY_ENDPOINT: "https://eu-test-connect.betterstackdata.com",
+    BETTERSTACK_QUERY_USERNAME: "user",
+    BETTERSTACK_QUERY_PASSWORD: "pass",
+  },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+});
+
+function ndjsonResponse(lines: unknown[]): Response {
+  return new Response(lines.map((l) => JSON.stringify(l)).join("\n"), { status: 200 });
+}
+
+// ─── Input hardening (issue #226) ─────────────────────────────────
+//
+// Threat model: `table` and `query` are LLM-controlled and reach a
+// ClickHouse query string. The identifier must be strictly validated;
+// the read-only query guard is best-effort UX, not a security boundary
+// (that boundary is a read-only ClickHouse role on the connection).
+
+describe("assertClickHouseIdentifier", () => {
+  it("accepts a normal source table name", () => {
+    expect(assertClickHouseIdentifier("t273774_offload_ecs_production")).toBe("t273774_offload_ecs_production");
+  });
+
+  it("rejects identifier injection via parens/spaces", () => {
+    expect(() => assertClickHouseIdentifier("t1) UNION SELECT * FROM system.users --")).toThrow(/identifier/i);
+  });
+
+  it("rejects quotes and backticks", () => {
+    expect(() => assertClickHouseIdentifier("t1`; DROP TABLE x")).toThrow(/identifier/i);
+    expect(() => assertClickHouseIdentifier("t1'_logs")).toThrow(/identifier/i);
+  });
+
+  it("rejects an empty string", () => {
+    expect(() => assertClickHouseIdentifier("")).toThrow(/identifier/i);
+  });
+});
+
+describe("prepareReadOnlyQuery", () => {
+  it("accepts a SELECT and appends a LIMIT cap", () => {
+    expect(prepareReadOnlyQuery("SELECT dt, raw FROM remote(t1_logs)")).toBe(
+      "SELECT dt, raw FROM remote(t1_logs) LIMIT 500",
+    );
+  });
+
+  it("accepts WITH ... CTEs (previously over-rejected)", () => {
+    const sql = "WITH errs AS (SELECT * FROM remote(t1_logs)) SELECT count() FROM errs";
+    expect(prepareReadOnlyQuery(sql)).toBe(`${sql} LIMIT 500`);
+  });
+
+  it("accepts DESCRIBE", () => {
+    expect(prepareReadOnlyQuery("DESCRIBE TABLE remote(t1_logs)")).toBe("DESCRIBE TABLE remote(t1_logs)");
+  });
+
+  it("does not double-append when a real LIMIT is present", () => {
+    const sql = "SELECT * FROM remote(t1_logs) LIMIT 10";
+    expect(prepareReadOnlyQuery(sql)).toBe(sql);
+  });
+
+  it("appends LIMIT when the word LIMIT only appears inside a string literal", () => {
+    const sql = "SELECT * FROM remote(t1_logs) WHERE raw LIKE '%rate LIMIT exceeded%'";
+    expect(prepareReadOnlyQuery(sql)).toBe(`${sql} LIMIT 500`);
+  });
+
+  it("rejects non-read statements", () => {
+    expect(() => prepareReadOnlyQuery("INSERT INTO t1 VALUES (1)")).toThrow(/SELECT|read-only/i);
+    expect(() => prepareReadOnlyQuery("DROP TABLE t1")).toThrow(/SELECT|read-only/i);
+  });
+
+  it("rejects multi-statement queries", () => {
+    expect(() => prepareReadOnlyQuery("SELECT 1; DROP TABLE t1")).toThrow(/multi|single/i);
+  });
+
+  it("tolerates a trailing semicolon", () => {
+    expect(prepareReadOnlyQuery("SELECT 1;")).toBe("SELECT 1 LIMIT 500");
+  });
+
+  it("does not treat a semicolon inside a string literal as a statement separator", () => {
+    const sql = "SELECT * FROM remote(t1_logs) WHERE raw LIKE '%a;b%' LIMIT 5";
+    expect(prepareReadOnlyQuery(sql)).toBe(sql);
+  });
+});
+
+describe("betterstack tool handlers", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const getSourceFields = betterstack.tools.find((t) => t.name === "betterstack_get_source_fields")!;
+  const query = betterstack.tools.find((t) => t.name === "betterstack_query")!;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("get_source_fields sends DESCRIBE for a valid table", async () => {
+    fetchMock.mockResolvedValueOnce(ndjsonResponse([{ name: "dt", type: "DateTime64(6)" }]));
+
+    const result: any = await getSourceFields.handler({ table: "t1_prod" }, ctx());
+
+    expect(result).toEqual([{ name: "dt", type: "DateTime64(6)" }]);
+    const body = fetchMock.mock.calls[0][1].body as string;
+    expect(body).toBe("DESCRIBE TABLE remote(t1_prod_logs) FORMAT JSONEachRow");
+  });
+
+  it("get_source_fields rejects an injected table name without making any request", async () => {
+    await expect(getSourceFields.handler({ table: "t1_logs), (SELECT * FROM system.users" }, ctx())).rejects.toThrow(
+      /identifier/i,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("query appends the LIMIT cap before FORMAT", async () => {
+    fetchMock.mockResolvedValueOnce(ndjsonResponse([]));
+
+    await query.handler({ query: "SELECT dt FROM remote(t1_logs)", source_id: 1, table: "t1" }, ctx());
+
+    const body = fetchMock.mock.calls[0][1].body as string;
+    expect(body).toBe("SELECT dt FROM remote(t1_logs) LIMIT 500 FORMAT JSONEachRow");
+  });
+
+  it("query accepts WITH CTEs", async () => {
+    fetchMock.mockResolvedValueOnce(ndjsonResponse([{ c: 1 }]));
+
+    const result: any = await query.handler(
+      { query: "WITH x AS (SELECT 1 AS c) SELECT * FROM x LIMIT 1", source_id: 1, table: "t1" },
+      ctx(),
+    );
+
+    expect(result).toEqual([{ c: 1 }]);
+  });
+
+  it("query rejects writes without making any request", async () => {
+    await expect(
+      query.handler({ query: "ALTER TABLE t1 DELETE WHERE 1", source_id: 1, table: "t1" }, ctx()),
+    ).rejects.toThrow(/SELECT|read-only/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/skills/betterstack.ts
+++ b/packages/core/src/skills/betterstack.ts
@@ -42,6 +42,66 @@ async function bsQuery(sql: string, ctx: ToolContext): Promise<unknown[]> {
     .map((line) => JSON.parse(line));
 }
 
+// ─── Input hardening (issue #226) ──────────────────────────────
+//
+// Threat model: tool arguments are LLM-controlled at runtime and can be
+// steered by prompt-injected content (issue bodies, fetched logs). The
+// `table` argument reaches a ClickHouse query string, so it is strictly
+// validated as an identifier. The read-only query guard below is
+// best-effort UX — the real security boundary must be a read-only
+// ClickHouse role on the BETTERSTACK_QUERY_USERNAME connection.
+
+/**
+ * Validate an LLM-chosen table name as a bare ClickHouse identifier.
+ * Anything outside [A-Za-z0-9_] is rejected — table names from
+ * BetterStack are always of the form t<id>_<name>.
+ */
+export function assertClickHouseIdentifier(name: string): string {
+  if (!/^[A-Za-z0-9_]+$/.test(name)) {
+    throw new Error(`[BetterStack] Invalid table identifier "${name}" — only letters, digits, and _ are allowed`);
+  }
+  return name;
+}
+
+/** Blank out string literal contents so keyword checks don't match inside them. */
+function stripStringLiterals(sql: string): string {
+  // Handles both '' (SQL) and \' (ClickHouse) quote escaping.
+  return sql.replace(/'(?:[^'\\]|\\.|'')*'/g, "''");
+}
+
+/**
+ * Best-effort read-only guard for `betterstack_query`.
+ *
+ * Accepts SELECT / WITH / DESCRIBE statements, rejects everything else,
+ * rejects multi-statement input, and appends a LIMIT cap when the query
+ * has none. Keyword checks ignore string literal contents so a log
+ * message containing "LIMIT" doesn't skip the cap.
+ *
+ * This is UX, not a security boundary: a determined query can still do
+ * anything the ClickHouse connection's role allows. Use a read-only
+ * role for the configured credentials.
+ */
+export function prepareReadOnlyQuery(query: string): string {
+  let sql = query.trim().replace(/;\s*$/, "").trim();
+  const stripped = stripStringLiterals(sql);
+
+  if (stripped.includes(";")) {
+    throw new Error("[BetterStack] Multi-statement queries are not allowed — send a single statement");
+  }
+
+  if (!/^(SELECT|WITH|DESCRIBE)\b/i.test(stripped)) {
+    throw new Error("[BetterStack] Only read-only queries are allowed (SELECT, WITH, or DESCRIBE)");
+  }
+
+  // Append LIMIT if none present to prevent unbounded result sets.
+  // DESCRIBE output is already bounded by the column count.
+  if (!/^DESCRIBE\b/i.test(stripped) && !/\bLIMIT\b/i.test(stripped)) {
+    sql = `${sql} LIMIT 500`;
+  }
+
+  return sql;
+}
+
 // ─── Skill definition ──────────────────────────────────────────
 
 export const betterstack: Skill = {
@@ -61,7 +121,9 @@ export const betterstack: Skill = {
       env: "BETTERSTACK_QUERY_ENDPOINT",
     },
     BETTERSTACK_QUERY_USERNAME: {
-      description: "ClickHouse connection username",
+      description:
+        "ClickHouse connection username. Use a read-only role — the in-skill query guard is best-effort, " +
+        "not a security boundary",
       required: true,
       env: "BETTERSTACK_QUERY_USERNAME",
     },
@@ -119,7 +181,7 @@ export const betterstack: Skill = {
         required: ["table"],
       },
       handler: async (input: { table: string }, ctx) => {
-        return bsQuery(`DESCRIBE TABLE remote(${input.table}_logs)`, ctx);
+        return bsQuery(`DESCRIBE TABLE remote(${assertClickHouseIdentifier(input.table)}_logs)`, ctx);
       },
     },
     {
@@ -128,30 +190,19 @@ export const betterstack: Skill = {
 Tables: remote(TABLE_logs) for recent logs, s3Cluster(primary, TABLE_s3) for historical (add WHERE _row_type = 1).
 Key fields: dt (timestamp), raw (JSON blob with all log fields).
 Extract nested fields: JSONExtract(raw, 'field_name', 'Nullable(String)').
-Use betterstack_get_source_fields to discover available columns.`,
+Use betterstack_get_source_fields to discover available columns.
+Only single SELECT / WITH / DESCRIBE statements are accepted.`,
       input_schema: {
         type: "object",
         properties: {
-          query: { type: "string", description: "ClickHouse SQL query (SELECT only)" },
+          query: { type: "string", description: "ClickHouse SQL query (single SELECT, WITH, or DESCRIBE statement)" },
           source_id: { type: "number", description: "Source ID (for context)" },
           table: { type: "string", description: "Table name (e.g. t273774_offload_ecs_production)" },
         },
         required: ["query", "source_id", "table"],
       },
       handler: async (input: { query: string; source_id: number; table: string }, ctx) => {
-        const trimmed = input.query.trim();
-        const upper = trimmed.toUpperCase();
-        if (!upper.startsWith("SELECT") && !upper.startsWith("DESCRIBE")) {
-          throw new Error("[BetterStack] Only SELECT and DESCRIBE queries are allowed");
-        }
-
-        // Append LIMIT if none present to prevent unbounded result sets
-        let sql = trimmed;
-        if (!upper.includes("LIMIT")) {
-          sql = `${sql} LIMIT 500`;
-        }
-
-        return bsQuery(sql, ctx);
+        return bsQuery(prepareReadOnlyQuery(input.query), ctx);
       },
     },
   ],

--- a/packages/core/src/skills/github.test.ts
+++ b/packages/core/src/skills/github.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { github } from "./github.js";
+import { github, encodeRepoFilePath } from "./github.js";
 import type { Logger, ToolContext } from "../types.js";
 
 const ctx = (overrides: Partial<ToolContext> = {}): ToolContext => ({
@@ -209,5 +209,84 @@ describe("github_create_pr", () => {
     await createPr.handler({ repo: "o/r", title: "[X-1] fix: y", head: "x-1-fix" }, ctx({ logger }));
 
     expect(logger.warnings).toHaveLength(0);
+  });
+});
+
+// ─── Input hardening (issue #226) ─────────────────────────────────
+//
+// Threat model: tool arguments are LLM-controlled at runtime and can be
+// steered by prompt-injected content. A `path` containing `?`, `#`, or `..`
+// must not be able to alter the request target.
+
+describe("encodeRepoFilePath", () => {
+  it("preserves / between segments and leaves normal paths readable", () => {
+    expect(encodeRepoFilePath("src/lib/file.ts")).toBe("src/lib/file.ts");
+  });
+
+  it("percent-encodes ? so the path cannot inject query parameters", () => {
+    expect(encodeRepoFilePath("file.ts?ref=evil")).toBe("file.ts%3Fref%3Devil");
+  });
+
+  it("percent-encodes # so the path cannot truncate the request via a fragment", () => {
+    expect(encodeRepoFilePath("file#.ts")).toBe("file%23.ts");
+  });
+
+  it("rejects .. segments (path traversal out of the contents endpoint)", () => {
+    expect(() => encodeRepoFilePath("../../../repos/other/secrets")).toThrow(/path segment/i);
+  });
+
+  it("rejects . segments", () => {
+    expect(() => encodeRepoFilePath("./src/file.ts")).toThrow(/path segment/i);
+  });
+
+  it("encodes spaces and unicode within segments", () => {
+    expect(encodeRepoFilePath("docs/my file.md")).toBe("docs/my%20file.md");
+  });
+});
+
+describe("github_get_file input hardening", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const getFile = github.tools.find((t) => t.name === "github_get_file")!;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests the encoded path, not the raw one", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { content: "", encoding: "none" }));
+
+    await getFile.handler({ repo: "o/r", path: "src/a b.ts?x=1" }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("https://api.github.com/repos/o/r/contents/src/a%20b.ts%3Fx%3D1");
+  });
+
+  it("rejects a path containing .. without making any request", async () => {
+    await expect(getFile.handler({ repo: "o/r", path: "../../meta" }, ctx())).rejects.toThrow(/path segment/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("URL-encodes the ref query parameter", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { content: "", encoding: "none" }));
+
+    await getFile.handler({ repo: "o/r", path: "README.md", ref: "main&per_page=100" }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("https://api.github.com/repos/o/r/contents/README.md?ref=main%26per_page%3D100");
+  });
+
+  it("still decodes base64 content on the happy path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { content: Buffer.from("hello").toString("base64"), encoding: "base64" }),
+    );
+
+    const result: any = await getFile.handler({ repo: "o/r", path: "README.md" }, ctx());
+
+    expect(result.decoded_content).toBe("hello");
   });
 });

--- a/packages/core/src/skills/github.ts
+++ b/packages/core/src/skills/github.ts
@@ -38,6 +38,33 @@ function isAlreadyExistsError(err: unknown): err is GitHubApiError {
   return /pull request already exists/i.test(err.body);
 }
 
+/**
+ * Encode an LLM-chosen repo file path for safe interpolation into a
+ * GitHub API request path.
+ *
+ * Trust model (issue #226): tool arguments are runtime-controlled by the
+ * model and can be steered by prompt-injected content. Without encoding,
+ * a `path` containing `?` or `#` rewrites the request (injects query
+ * params / truncates via fragment), and `..` segments walk out of the
+ * `/contents/` endpoint entirely.
+ *
+ * Each `/`-separated segment is percent-encoded (so `/` between segments
+ * is preserved); `.` and `..` segments are rejected outright because
+ * URL normalization resolves them server-side even when encoded.
+ */
+export function encodeRepoFilePath(path: string): string {
+  return path
+    .split("/")
+    .filter((segment) => segment !== "")
+    .map((segment) => {
+      if (segment === "." || segment === "..") {
+        throw new Error(`[GitHub] Invalid path segment "${segment}" — relative path segments are not allowed`);
+      }
+      return encodeURIComponent(segment);
+    })
+    .join("/");
+}
+
 export const github: Skill = {
   id: "github",
   name: "GitHub",
@@ -239,8 +266,8 @@ export const github: Skill = {
         required: ["repo", "path"],
       },
       handler: async (input: { repo: string; path: string; ref?: string }, ctx) => {
-        const ref = input.ref ? `?ref=${input.ref}` : "";
-        const data: any = await gh(`/repos/${input.repo}/contents/${input.path}${ref}`, ctx);
+        const ref = input.ref ? `?ref=${encodeURIComponent(input.ref)}` : "";
+        const data: any = await gh(`/repos/${input.repo}/contents/${encodeRepoFilePath(input.path)}${ref}`, ctx);
         if (data.content && data.encoding === "base64") {
           return { ...data, decoded_content: Buffer.from(data.content, "base64").toString("utf-8") };
         }

--- a/packages/core/src/skills/supabase.test.ts
+++ b/packages/core/src/skills/supabase.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { supabase, assertSupabaseIdentifier, assertSupabaseFunctionName, appendPostgrestFilters } from "./supabase.js";
+import type { ToolContext } from "../types.js";
+
+const ctx = (extra: Record<string, string> = {}): ToolContext => ({
+  config: {
+    SUPABASE_URL: "https://proj.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+    ...extra,
+  },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function tool(name: string) {
+  const t = supabase.tools.find((t) => t.name === name);
+  if (!t) throw new Error(`tool ${name} not found`);
+  return t;
+}
+
+// ─── Input hardening (issue #226) ─────────────────────────────────
+//
+// Threat model: this skill runs with SUPABASE_SERVICE_ROLE_KEY (full RLS
+// bypass), and `table`, `filters[]`, and function names are LLM-controlled.
+// Identifiers are validated, filter values are URL-encoded so a single
+// filter string cannot smuggle extra query parameters, and an optional
+// allowlist bounds which tables/functions the agent can touch.
+
+describe("assertSupabaseIdentifier", () => {
+  it("accepts normal table names", () => {
+    expect(assertSupabaseIdentifier("games")).toBe("games");
+    expect(assertSupabaseIdentifier("course_modules")).toBe("course_modules");
+  });
+
+  it("rejects names that alter the request path or query", () => {
+    expect(() => assertSupabaseIdentifier("games?select=secret")).toThrow(/identifier/i);
+    expect(() => assertSupabaseIdentifier("games/../auth")).toThrow(/identifier/i);
+    expect(() => assertSupabaseIdentifier("rpc/exec")).toThrow(/identifier/i);
+  });
+
+  it("rejects an empty string", () => {
+    expect(() => assertSupabaseIdentifier("")).toThrow(/identifier/i);
+  });
+});
+
+describe("assertSupabaseFunctionName", () => {
+  it("accepts edge function names with hyphens", () => {
+    expect(assertSupabaseFunctionName("agent-gateway")).toBe("agent-gateway");
+  });
+
+  it("rejects path traversal and query injection", () => {
+    expect(() => assertSupabaseFunctionName("../auth/v1/admin")).toThrow(/function name/i);
+    expect(() => assertSupabaseFunctionName("fn?x=1")).toThrow(/function name/i);
+  });
+});
+
+describe("appendPostgrestFilters", () => {
+  it("appends a normal filter as a key/value pair", () => {
+    const params = new URLSearchParams();
+    appendPostgrestFilters(params, ["subject=eq.math"]);
+    expect(params.get("subject")).toBe("eq.math");
+  });
+
+  it("encodes & and = in filter values so they cannot smuggle extra parameters", () => {
+    const params = new URLSearchParams();
+    appendPostgrestFilters(params, ["name=eq.a&select=password"]);
+    // The whole right-hand side stays one value on the `name` key.
+    expect(params.get("name")).toBe("eq.a&select=password");
+    expect(params.get("select")).toBeNull();
+    expect(params.toString()).toContain("eq.a%26select%3Dpassword");
+  });
+
+  it("throws on a filter with no = separator", () => {
+    expect(() => appendPostgrestFilters(new URLSearchParams(), ["not-a-filter"])).toThrow(/filter/i);
+  });
+});
+
+describe("supabase_query hardening", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const query = tool("supabase_query");
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends filters as encoded query parameters", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await query.handler({ table: "games", filters: ["subject=eq.math", "difficulty=eq.easy"] }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/rest/v1/games?");
+    expect(url).toContain("subject=eq.math");
+    expect(url).toContain("difficulty=eq.easy");
+  });
+
+  it("keeps an &-containing filter value on a single parameter", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await query.handler({ table: "games", filters: ["title=eq.a&select=secret_column"] }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    // The smuggled select must appear encoded, never as a standalone parameter.
+    expect(url).toContain("title=eq.a%26select%3Dsecret_column");
+    expect(url).not.toContain("&select=secret_column");
+  });
+
+  it("rejects a table name that is not a bare identifier, without making any request", async () => {
+    await expect(query.handler({ table: "games?select=x" }, ctx())).rejects.toThrow(/identifier/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("enforces SUPABASE_ALLOWED_TABLES when configured", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    const allowCtx = ctx({ SUPABASE_ALLOWED_TABLES: "games, profiles" });
+
+    await query.handler({ table: "games" }, allowCtx);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await expect(query.handler({ table: "users" }, allowCtx)).rejects.toThrow(/allowlist|allowed/i);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("allows any valid table when no allowlist is configured", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await query.handler({ table: "anything_goes" }, ctx());
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("supabase write-tool hardening", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("update encodes filters and validates the table", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await tool("supabase_update").handler(
+      { table: "games", filters: ["id=eq.1&id=eq.2"], data: { title: "x" } },
+      ctx(),
+    );
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("id=eq.1%26id%3Deq.2");
+  });
+
+  it("update still requires filters (full-table update guard preserved)", async () => {
+    await expect(
+      tool("supabase_update").handler({ table: "games", filters: [], data: { a: 1 } }, ctx()),
+    ).rejects.toThrow(/filters are required/i);
+  });
+
+  it("delete still requires filters and validates the table", async () => {
+    await expect(tool("supabase_delete").handler({ table: "games", filters: [] }, ctx())).rejects.toThrow(
+      /filters are required/i,
+    );
+    await expect(tool("supabase_delete").handler({ table: "a/b", filters: ["id=eq.1"] }, ctx())).rejects.toThrow(
+      /identifier/i,
+    );
+  });
+
+  it("insert validates the table against the allowlist", async () => {
+    const allowCtx = ctx({ SUPABASE_ALLOWED_TABLES: "games" });
+    await expect(tool("supabase_insert").handler({ table: "secrets", rows: [{ a: 1 }] }, allowCtx)).rejects.toThrow(
+      /allowlist|allowed/i,
+    );
+  });
+
+  it("count encodes filters", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-range": "0-9/10" } }));
+
+    await tool("supabase_count").handler({ table: "games", filters: ["x=eq.a&y=eq.b"] }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("x=eq.a%26y%3Deq.b");
+  });
+});
+
+describe("supabase function-tool hardening", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rpc rejects function names that escape the /rpc/ path", async () => {
+    await expect(tool("supabase_rpc").handler({ function_name: "../auth/v1/admin/users" }, ctx())).rejects.toThrow(
+      /identifier|function name/i,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rpc enforces SUPABASE_ALLOWED_FUNCTIONS when configured", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const allowCtx = ctx({ SUPABASE_ALLOWED_FUNCTIONS: "get_table_counts" });
+
+    await tool("supabase_rpc").handler({ function_name: "get_table_counts" }, allowCtx);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await expect(tool("supabase_rpc").handler({ function_name: "delete_everything" }, allowCtx)).rejects.toThrow(
+      /allowlist|allowed/i,
+    );
+  });
+
+  it("invoke_function accepts hyphenated names and rejects path traversal", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await tool("supabase_invoke_function").handler({ function_name: "agent-gateway", body: {} }, ctx());
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toBe("https://proj.supabase.co/functions/v1/agent-gateway");
+
+    await expect(
+      tool("supabase_invoke_function").handler({ function_name: "../../auth/v1/admin", body: {} }, ctx()),
+    ).rejects.toThrow(/function name/i);
+  });
+
+  it("invoke_function enforces SUPABASE_ALLOWED_FUNCTIONS when configured", async () => {
+    const allowCtx = ctx({ SUPABASE_ALLOWED_FUNCTIONS: "agent-gateway" });
+    await expect(
+      tool("supabase_invoke_function").handler({ function_name: "seed-content", body: {} }, allowCtx),
+    ).rejects.toThrow(/allowlist|allowed/i);
+  });
+});
+
+// ─── Regression: existing legitimate behavior ─────────────────────
+
+describe("supabase existing behavior", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("query defaults select=* and limit=100", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 1 }]));
+
+    const result: any = await tool("supabase_query").handler({ table: "games" }, ctx());
+
+    expect(result).toEqual([{ id: 1 }]);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("select=*");
+    expect(url).toContain("limit=100");
+  });
+
+  it("query passes order and custom select through", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await tool("supabase_query").handler({ table: "games", select: "id,title", order: "created_at.desc" }, ctx());
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("select=id%2Ctitle");
+    expect(url).toContain("order=created_at.desc");
+  });
+
+  it("insert posts rows with service role auth", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 1 }]));
+
+    await tool("supabase_insert").handler({ table: "games", rows: [{ title: "t" }] }, ctx());
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/rest/v1/games");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers.Authorization).toBe("Bearer service-role-key");
+    expect(JSON.parse(opts.body)).toEqual([{ title: "t" }]);
+  });
+
+  it("rpc posts params to /rpc/<name>", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 3 }));
+
+    await tool("supabase_rpc").handler({ function_name: "get_table_counts", params: { schema: "public" } }, ctx());
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain("/rest/v1/rpc/get_table_counts");
+    expect(JSON.parse(opts.body)).toEqual({ schema: "public" });
+  });
+});

--- a/packages/core/src/skills/supabase.ts
+++ b/packages/core/src/skills/supabase.ts
@@ -8,6 +8,85 @@
 
 import type { Skill, ToolContext } from "../types.js";
 
+// ─── Input hardening (issue #226) ──────────────────────────────
+//
+// Threat model: this skill runs with SUPABASE_SERVICE_ROLE_KEY, which
+// bypasses RLS entirely, and `table`, `filters[]`, and function names are
+// LLM-controlled at runtime (steerable by prompt-injected content).
+// Identifiers are validated before they reach the request path, filter
+// values are URL-encoded so one filter string cannot smuggle extra query
+// parameters, and the optional SUPABASE_ALLOWED_TABLES /
+// SUPABASE_ALLOWED_FUNCTIONS allowlists bound what the agent can touch.
+
+/** Validate an LLM-chosen table/column name as a bare PostgREST identifier. */
+export function assertSupabaseIdentifier(name: string, label = "table"): string {
+  if (!/^[A-Za-z0-9_]+$/.test(name)) {
+    throw new Error(`[Supabase] Invalid ${label} identifier "${name}" — only letters, digits, and _ are allowed`);
+  }
+  return name;
+}
+
+/** Validate an LLM-chosen RPC / edge function name (hyphens allowed for edge functions). */
+export function assertSupabaseFunctionName(name: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(name)) {
+    throw new Error(`[Supabase] Invalid function name "${name}" — only letters, digits, _ and - are allowed`);
+  }
+  return name;
+}
+
+/**
+ * Append PostgREST filter strings ("column=op.value") to query params.
+ * Each filter is split at its first `=`; the value side is appended as a
+ * single parameter value so `&`/`=` inside it are percent-encoded rather
+ * than interpreted as additional parameters.
+ */
+export function appendPostgrestFilters(params: URLSearchParams, filters: string[]): URLSearchParams {
+  for (const filter of filters) {
+    const eq = filter.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(`[Supabase] Invalid filter "${filter}" — expected "column=operator.value" (e.g. "id=eq.1")`);
+    }
+    params.append(filter.slice(0, eq), filter.slice(eq + 1));
+  }
+  return params;
+}
+
+/** Parse an optional comma-separated allowlist config value. Returns null when unset (no restriction). */
+function resolveAllowlist(config: Record<string, string>, key: string): Set<string> | null {
+  const raw = config[key];
+  if (!raw || !raw.trim()) return null;
+  return new Set(
+    raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+/** Validate a table name and check it against SUPABASE_ALLOWED_TABLES (when configured). */
+function checkTable(table: string, ctx: ToolContext): string {
+  assertSupabaseIdentifier(table);
+  const allowlist = resolveAllowlist(ctx.config, "SUPABASE_ALLOWED_TABLES");
+  if (allowlist && !allowlist.has(table)) {
+    throw new Error(
+      `[Supabase] Table "${table}" is not on the SUPABASE_ALLOWED_TABLES allowlist (${[...allowlist].join(", ")})`,
+    );
+  }
+  return table;
+}
+
+/** Validate a function name and check it against SUPABASE_ALLOWED_FUNCTIONS (when configured). */
+function checkFunction(name: string, ctx: ToolContext): string {
+  assertSupabaseFunctionName(name);
+  const allowlist = resolveAllowlist(ctx.config, "SUPABASE_ALLOWED_FUNCTIONS");
+  if (allowlist && !allowlist.has(name)) {
+    throw new Error(
+      `[Supabase] Function "${name}" is not on the SUPABASE_ALLOWED_FUNCTIONS allowlist (${[...allowlist].join(", ")})`,
+    );
+  }
+  return name;
+}
+
 async function supabaseRest(path: string, ctx: ToolContext, init?: RequestInit): Promise<unknown> {
   const url = ctx.config.SUPABASE_URL;
   const key = ctx.config.SUPABASE_SERVICE_ROLE_KEY;
@@ -69,9 +148,26 @@ export const supabase: Skill = {
       env: "SUPABASE_URL",
     },
     SUPABASE_SERVICE_ROLE_KEY: {
-      description: "Supabase service role key (full access, server-side only)",
+      description:
+        "Supabase service role key (full access, bypasses RLS — high blast radius). " +
+        "Prefer a scoped key where possible, and bound exposure with SUPABASE_ALLOWED_TABLES / " +
+        "SUPABASE_ALLOWED_FUNCTIONS",
       required: true,
       env: "SUPABASE_SERVICE_ROLE_KEY",
+    },
+    SUPABASE_ALLOWED_TABLES: {
+      description:
+        "Optional comma-separated table allowlist. When set, data tools (query/count/insert/update/delete) " +
+        "are restricted to these tables",
+      required: false,
+      env: "SUPABASE_ALLOWED_TABLES",
+    },
+    SUPABASE_ALLOWED_FUNCTIONS: {
+      description:
+        "Optional comma-separated function allowlist. When set, supabase_rpc and supabase_invoke_function " +
+        "are restricted to these RPC / edge function names",
+      required: false,
+      env: "SUPABASE_ALLOWED_FUNCTIONS",
     },
   },
   tools: [
@@ -110,19 +206,14 @@ export const supabase: Skill = {
         input: { table: string; select?: string; filters?: string[]; order?: string; limit?: number },
         ctx,
       ) => {
+        const table = checkTable(input.table, ctx);
         const params = new URLSearchParams();
         params.set("select", input.select || "*");
         if (input.order) params.set("order", input.order);
         params.set("limit", String(input.limit || 100));
+        appendPostgrestFilters(params, input.filters ?? []);
 
-        let path = `/${input.table}?${params}`;
-        if (input.filters) {
-          for (const f of input.filters) {
-            path += `&${f}`;
-          }
-        }
-
-        return supabaseRest(path, ctx);
+        return supabaseRest(`/${table}?${params}`, ctx);
       },
     },
 
@@ -144,13 +235,11 @@ export const supabase: Skill = {
       handler: async (input: { table: string; filters?: string[] }, ctx) => {
         const url = ctx.config.SUPABASE_URL;
         const key = ctx.config.SUPABASE_SERVICE_ROLE_KEY;
+        const table = checkTable(input.table, ctx);
 
-        let path = `${url}/rest/v1/${input.table}?select=count`;
-        if (input.filters) {
-          for (const f of input.filters) {
-            path += `&${f}`;
-          }
-        }
+        const params = new URLSearchParams({ select: "count" });
+        appendPostgrestFilters(params, input.filters ?? []);
+        const path = `${url}/rest/v1/${table}?${params}`;
 
         const res = await fetch(path, {
           headers: {
@@ -194,12 +283,13 @@ export const supabase: Skill = {
         required: ["table", "rows"],
       },
       handler: async (input: { table: string; rows: Record<string, unknown>[]; upsert?: boolean }, ctx) => {
+        const table = checkTable(input.table, ctx);
         const headers: Record<string, string> = {};
         if (input.upsert) {
           headers["Prefer"] = "resolution=merge-duplicates,return=representation";
         }
 
-        return supabaseRest(`/${input.table}`, ctx, {
+        return supabaseRest(`/${table}`, ctx, {
           method: "POST",
           headers,
           body: JSON.stringify(input.rows),
@@ -231,11 +321,10 @@ export const supabase: Skill = {
           throw new Error("Filters are required for update operations to prevent accidental full-table updates");
         }
 
-        let path = `/${input.table}`;
-        const filterParts = input.filters.map((f) => f);
-        path += `?${filterParts.join("&")}`;
+        const table = checkTable(input.table, ctx);
+        const params = appendPostgrestFilters(new URLSearchParams(), input.filters);
 
-        return supabaseRest(path, ctx, {
+        return supabaseRest(`/${table}?${params}`, ctx, {
           method: "PATCH",
           body: JSON.stringify(input.data),
         });
@@ -262,8 +351,9 @@ export const supabase: Skill = {
           throw new Error("Filters are required for delete operations");
         }
 
-        const path = `/${input.table}?${input.filters.join("&")}`;
-        return supabaseRest(path, ctx, { method: "DELETE" });
+        const table = checkTable(input.table, ctx);
+        const params = appendPostgrestFilters(new URLSearchParams(), input.filters);
+        return supabaseRest(`/${table}?${params}`, ctx, { method: "DELETE" });
       },
     },
 
@@ -283,7 +373,7 @@ export const supabase: Skill = {
         required: ["function_name"],
       },
       handler: async (input: { function_name: string; params?: Record<string, unknown> }, ctx) => {
-        return supabaseRest(`/rpc/${input.function_name}`, ctx, {
+        return supabaseRest(`/rpc/${checkFunction(input.function_name, ctx)}`, ctx, {
           method: "POST",
           body: JSON.stringify(input.params || {}),
         });
@@ -309,7 +399,7 @@ export const supabase: Skill = {
         required: ["function_name", "body"],
       },
       handler: async (input: { function_name: string; body: Record<string, unknown> }, ctx) => {
-        return supabaseEdgeFunction(input.function_name, input.body, ctx);
+        return supabaseEdgeFunction(checkFunction(input.function_name, ctx), input.body, ctx);
       },
     },
 

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -105,6 +105,7 @@ export default defineConfig({
             { label: "Sentry", slug: "skills/sentry" },
             { label: "Datadog", slug: "skills/datadog" },
             { label: "BetterStack", slug: "skills/betterstack" },
+            { label: "Supabase", slug: "skills/supabase" },
             { label: "Slack", slug: "skills/slack" },
             { label: "Notification", slug: "skills/notification" },
           ],

--- a/packages/web/src/content/docs/skills/betterstack.md
+++ b/packages/web/src/content/docs/skills/betterstack.md
@@ -1,9 +1,9 @@
 ---
 title: BetterStack
-description: Query incidents, monitors, and on-call status from BetterStack.
+description: Query logs and manage telemetry sources in BetterStack.
 ---
 
-The BetterStack skill gives Claude access to your uptime monitoring data. Claude can list active incidents, check monitor health, and see who is currently on-call — useful for triage workflows where you need to understand the operational state of your services.
+The BetterStack skill gives Claude access to your telemetry data. Claude can list log sources, discover their queryable fields, and run read-only ClickHouse SQL queries against them — useful for triage workflows where log evidence is needed to understand an alert or reproduce a bug.
 
 ## Metadata
 
@@ -11,37 +11,48 @@ The BetterStack skill gives Claude access to your uptime monitoring data. Claude
 |-------|-------|
 | **ID** | `betterstack` |
 | **Category** | `observability` |
-| **Required env vars** | `BETTERSTACK_API_TOKEN` |
+| **Required env vars** | `BETTERSTACK_API_TOKEN`, `BETTERSTACK_QUERY_ENDPOINT`, `BETTERSTACK_QUERY_USERNAME`, `BETTERSTACK_QUERY_PASSWORD` |
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `betterstack_list_incidents` | List recent incidents with optional date range filter |
-| `betterstack_get_incident` | Get detailed information about a specific incident including timeline |
-| `betterstack_list_monitors` | List all uptime monitors and their current status |
-| `betterstack_get_monitor` | Get details and recent status of a specific monitor |
-| `betterstack_list_on_call` | List current on-call calendars and who is on-call |
+| `betterstack_list_sources` | List available telemetry sources (id, name, table_name, platform) |
+| `betterstack_get_source` | Get full details for a telemetry source (table name, retention, config) |
+| `betterstack_get_source_fields` | Get queryable fields for a source table (column names and types) |
+| `betterstack_query` | Execute a read-only ClickHouse SQL query against a telemetry source |
 
 ## Setup
 
-1. Go to **BetterStack Uptime > Settings > API** (or `betterstack.com/uptime/api`).
-2. Copy your API token.
-3. Set the environment variable:
+1. Go to **BetterStack Telemetry > Settings > API tokens** and copy your team API token.
+2. Go to **Connect remotely** under your source group to get the ClickHouse connection details.
+3. Set the environment variables:
 
 ```bash
 export BETTERSTACK_API_TOKEN="your-api-token"
+export BETTERSTACK_QUERY_ENDPOINT="https://eu-fsn-3-connect.betterstackdata.com"
+export BETTERSTACK_QUERY_USERNAME="your-connection-username"
+export BETTERSTACK_QUERY_PASSWORD="your-connection-password"
 ```
 
-The token provides read access to incidents, monitors, and on-call schedules through the BetterStack Uptime API.
+:::caution[Use a read-only connection]
+The query credentials should belong to a **read-only ClickHouse role**. The skill rejects statements that are not `SELECT` / `WITH` / `DESCRIBE` and refuses multi-statement input, but this guard is best-effort UX — it is not a security boundary. The agent's tool arguments are model-controlled at runtime and can be influenced by the content it reads (issue bodies, fetched pages, the logs themselves), so least privilege at the connection level is what actually bounds what a query can do.
+:::
+
+## Query model
+
+Logs live in ClickHouse tables named after the source (e.g. `t273774_my_service_production`):
+
+- `remote(TABLE_logs)` — recent logs
+- `s3Cluster(primary, TABLE_s3)` — historical logs (add `WHERE _row_type = 1`)
+
+Key fields: `dt` (timestamp) and `raw` (JSON blob with all log fields). Extract nested fields with `JSONExtract(raw, 'field_name', 'Nullable(String)')`.
+
+Queries with no `LIMIT` clause get `LIMIT 500` appended automatically to keep result sets bounded.
 
 ## Workflow usage
 
 **Triage workflow:**
-- **gather** — Pull active incidents, check which monitors are down, and identify who is on-call. This gives Claude operational context that complements error-level data from Sentry or log data from Datadog.
+- **gather** — Pull recent error logs and correlate them with the alert. This complements error-level data from Sentry or metrics from Datadog.
 
 BetterStack is interchangeable with Sentry and Datadog at the `gather` node. You can configure one, two, or all three observability skills — Claude will use whatever is available to build a complete picture of the alert.
-
-:::note[Uptime API only]
-This skill uses the BetterStack Uptime API. Logtail (BetterStack Logs) is listed in the skill description but log search tools are not yet implemented. For log queries, use the Datadog skill or a custom MCP server.
-:::

--- a/packages/web/src/content/docs/skills/index.md
+++ b/packages/web/src/content/docs/skills/index.md
@@ -43,7 +43,7 @@ Every skill belongs to a category. Categories are used for validation — the ex
 | `tasks` | Issue tracking | [Linear](/skills/linear/) |
 | `notification` | Alerting the team | [Slack](/skills/slack/), [Notification](/skills/notification/) |
 | `data` | Embeddings, vector stores, databases, ETL | (custom skills) |
-| `general` | Catch-all when no other category fits | (custom skills) |
+| `general` | Catch-all when no other category fits | [Supabase](/skills/supabase/), (custom skills) |
 
 ## Built-in skills
 
@@ -53,7 +53,8 @@ Every skill belongs to a category. Categories are used for validation — the ex
 | `linear` | [Linear](/skills/linear/) | tasks | `LINEAR_API_KEY` |
 | `sentry` | [Sentry](/skills/sentry/) | observability | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` |
 | `datadog` | [Datadog](/skills/datadog/) | observability | `DD_API_KEY`, `DD_APP_KEY` |
-| `betterstack` | [BetterStack](/skills/betterstack/) | observability | `BETTERSTACK_API_TOKEN` |
+| `betterstack` | [BetterStack](/skills/betterstack/) | observability | `BETTERSTACK_API_TOKEN`, `BETTERSTACK_QUERY_ENDPOINT`, `BETTERSTACK_QUERY_USERNAME`, `BETTERSTACK_QUERY_PASSWORD` |
+| `supabase` | [Supabase](/skills/supabase/) | general | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` |
 | `slack` | [Slack](/skills/slack/) | notification | `SLACK_WEBHOOK_URL` or `SLACK_BOT_TOKEN` |
 | `notification` | [Notification](/skills/notification/) | notification | `DISCORD_WEBHOOK_URL`, `TEAMS_WEBHOOK_URL`, `NOTIFICATION_WEBHOOK_URL`, or `SMTP_URL` |
 

--- a/packages/web/src/content/docs/skills/supabase.md
+++ b/packages/web/src/content/docs/skills/supabase.md
@@ -1,0 +1,66 @@
+---
+title: Supabase
+description: Query, insert, update data and invoke edge functions on a Supabase project.
+---
+
+The Supabase skill gives Claude access to your Supabase project's data layer. Claude can query and modify rows through PostgREST, call database functions, invoke edge functions, and list auth users — useful for content pipelines, data sync workflows, and seeding test data.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **ID** | `supabase` |
+| **Category** | `general` |
+| **Required env vars** | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` |
+| **Optional env vars** | `SUPABASE_ALLOWED_TABLES`, `SUPABASE_ALLOWED_FUNCTIONS` |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `supabase_query` | Query rows from a table with PostgREST filters, ordering, and limits |
+| `supabase_count` | Count rows in a table, optionally with filters |
+| `supabase_insert` | Insert or upsert rows into a table |
+| `supabase_update` | Update rows matching filters (filters required) |
+| `supabase_delete` | Delete rows matching filters (filters required) |
+| `supabase_rpc` | Call a database function (stored procedure) |
+| `supabase_invoke_function` | Invoke an edge function by name |
+| `supabase_list_users` | List auth users (IDs, emails, metadata) |
+| `supabase_list_tables` | List public tables with row counts |
+
+## Setup
+
+```bash
+export SUPABASE_URL="https://your-project.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+
+# Strongly recommended: bound what the agent can touch
+export SUPABASE_ALLOWED_TABLES="games,profiles,course_modules"
+export SUPABASE_ALLOWED_FUNCTIONS="get_table_counts,agent-gateway"
+```
+
+:::caution[High blast radius]
+This skill runs with the **service role key**, which bypasses Row Level Security entirely. Every tool argument (table names, filters, function names) is model-controlled at runtime and can be influenced by content the agent reads. Treat this skill as full database access:
+
+- Set `SUPABASE_ALLOWED_TABLES` and `SUPABASE_ALLOWED_FUNCTIONS` to restrict the agent to the tables and functions the workflow actually needs.
+- Prefer a key with narrower scope over the service role key where your setup allows it.
+- Never combine this skill with untrusted input sources unless the allowlists are configured.
+:::
+
+## Guardrails
+
+Beyond the optional allowlists, the skill enforces:
+
+- **Identifier validation** — table and function names must be bare identifiers; path traversal and query injection in names are rejected.
+- **Filter encoding** — PostgREST filter values are URL-encoded, so a single filter string cannot smuggle additional query parameters.
+- **Mandatory filters on writes** — `supabase_update` and `supabase_delete` require at least one filter to prevent accidental full-table modification.
+
+## Workflow usage
+
+**Content generation workflow:**
+- **seed** — Insert generated content rows into staging tables
+- **verify** — Query back inserted rows and validate counts
+
+**Data sync workflow:**
+- **extract** — Query source tables with filters
+- **load** — Upsert transformed rows into destination tables


### PR DESCRIPTION
Closes #226.

Follow-up to #222. Hardens LLM-controlled tool arguments in the three skills the security review flagged. Threat model: tool arguments are runtime-controlled by the model and steerable by prompt-injected content (issue bodies, fetched pages, log contents), even when the workflow author is trusted.

## GitHub (`skills/github.ts`)

- `github_get_file` percent-encodes each `path` segment (preserving `/` between segments) and rejects `.` / `..` segments outright, since URL normalization resolves dot segments server-side even when encoded.
- The `ref` query param is now encoded too.
- A path like `file.ts?ref=evil` or `../../meta` can no longer rewrite the request.

## BetterStack (`skills/betterstack.ts`)

- `table` is validated as a bare ClickHouse identifier (`[A-Za-z0-9_]+`) before it reaches `DESCRIBE TABLE remote(...)`. Closes the identifier injection.
- The read-only query guard is now `prepareReadOnlyQuery()`:
  - accepts `WITH ...` CTEs (previously over-rejected)
  - rejects multi-statement input
  - ignores keywords inside string literals, so a log message containing "LIMIT" no longer skips the safety cap
- Guard documented as best-effort UX, not a security boundary. Docs now recommend a read-only ClickHouse role for the connection credentials (least privilege is the real boundary).

## Supabase (`skills/supabase.ts`)

- Table and function names validated as identifiers (hyphens allowed for edge functions); path traversal and query injection in names are rejected.
- PostgREST filter values are URL-encoded via `URLSearchParams`, so a single filter string like `title=eq.a&select=secret` stays one parameter instead of smuggling a second one.
- New optional `SUPABASE_ALLOWED_TABLES` / `SUPABASE_ALLOWED_FUNCTIONS` config bounds what the agent can touch. Unset = no restriction (backward compatible).
- The `update`/`delete` require-filters guard is preserved.
- Service-role blast radius documented on the skill config and in a new docs page.

## Docs

- `skills/betterstack.md` rewritten to match the actual tool set (it documented incident/monitor tools that don't exist in the code) + read-only role guidance.
- New `skills/supabase.md` page with the blast-radius warning and allowlist setup; wired into the sidebar and skills index.

## Acceptance criteria from #226

- [x] github path segments URL-encoded; tested with paths containing `..` / `?`
- [x] betterstack `table` validated as an identifier; guard documented as best-effort; least-privilege role recommended in docs
- [x] supabase filter values encoded; optional allowlist config wired; high-blast-radius documented
- [x] Existing legitimate behavior covered by regression tests (1973 core tests pass, typecheck clean, no schema drift)

Out of scope per the issue: `notification.ts` / `custom-loader.ts` (already hardened in #222) and other packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)