### PR TITLE
fix(mcp): deterministic shutdown, never orphan a workflow child

### DIFF
--- a/.changeset/mcp-deterministic-shutdown.md
+++ b/.changeset/mcp-deterministic-shutdown.md
@@ -1,0 +1,9 @@
+---
+"@sweny-ai/mcp": patch
+---
+
+Shut the MCP server down deterministically and never orphan a workflow child.
+
+`index.ts` connected the stdio transport and returned, leaving cleanup to whatever the event loop happened to do after stdin closed. A client that exited or was force-killed mid-run could orphan the server plus its in-flight `sweny` workflow subprocess (re-parented to launchd/init), where it would keep running for up to the 10-minute workflow timeout long after the session that started it was gone.
+
+The server now installs an explicit, idempotent shutdown: it traps `SIGINT`/`SIGTERM` and wires the transport's `onclose` (stdin EOF when the client disconnects) to terminate every active workflow child with `SIGTERM`, close the server, and exit. `run-workflow.ts` tracks in-flight children in a registry and exposes `terminateActiveWorkflows()` for the server to call.

--- a/packages/mcp/src/__tests__/run-workflow.test.ts
+++ b/packages/mcp/src/__tests__/run-workflow.test.ts
@@ -13,7 +13,7 @@ import { createRequire } from "node:module";
 import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
-import { runWorkflow, resolveSwenyInvocation } from "../handlers/run-workflow.js";
+import { runWorkflow, resolveSwenyInvocation, terminateActiveWorkflows } from "../handlers/run-workflow.js";
 
 const mockSpawn = vi.mocked(spawn);
 
@@ -492,5 +492,30 @@ describe("runWorkflow custom workflows (file-run path)", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("was not found in .sweny/workflows/");
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  describe("terminateActiveWorkflows", () => {
+    it("signals an in-flight child and stops tracking it once it closes", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc);
+
+      const promise = runWorkflow({ workflow: "triage" });
+
+      // Child is in flight: terminate should signal it.
+      terminateActiveWorkflows();
+      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+
+      // After it settles it must be untracked, so a later shutdown is a no-op.
+      proc._emit("close", 0);
+      await promise;
+
+      (proc.kill as ReturnType<typeof vi.fn>).mockClear();
+      terminateActiveWorkflows();
+      expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when no workflow is running", () => {
+      expect(() => terminateActiveWorkflows()).not.toThrow();
+    });
   });
 });

--- a/packages/mcp/src/handlers/run-workflow.ts
+++ b/packages/mcp/src/handlers/run-workflow.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants, readFileSync } from "node:fs";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,30 @@ export interface RunWorkflowResult {
 
 const TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_STDERR_BUFFER = 10 * 1024 * 1024; // 10 MB — stderr is error output, not verbose logs
+
+/**
+ * In-flight `sweny` CLI subprocesses, tracked so the MCP server can terminate
+ * them during shutdown. A workflow run can hold a child for up to 10 minutes;
+ * without this registry, a client that exits or is killed mid-run would orphan
+ * that child (re-parented to launchd/init), leaking a process that keeps
+ * running long after the server it served is gone.
+ */
+const activeChildren = new Set<ChildProcess>();
+
+/**
+ * Send a signal to every in-flight workflow child. Called by the server on
+ * shutdown (SIGINT/SIGTERM, or stdin EOF when the client disconnects).
+ * Best-effort: a child that has already exited is a harmless no-op.
+ */
+export function terminateActiveWorkflows(signal: NodeJS.Signals = "SIGTERM"): void {
+  for (const child of activeChildren) {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already gone — nothing to terminate.
+    }
+  }
+}
 
 /**
  * How to invoke the `sweny` CLI: a command plus any leading args.
@@ -131,6 +155,9 @@ export async function runWorkflow(opts: RunWorkflowInput): Promise<RunWorkflowRe
       // Inherit env — sweny CLI needs API keys, .env vars, PATH, etc.
     });
 
+    // Track for shutdown-time termination; removed when the child settles below.
+    activeChildren.add(child);
+
     let stderr = "";
     let lineBuf = "";
     let lastJsonLine = "";
@@ -175,6 +202,7 @@ export async function runWorkflow(opts: RunWorkflowInput): Promise<RunWorkflowRe
     }, TIMEOUT_MS);
 
     child.on("error", (err) => {
+      activeChildren.delete(child);
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -182,6 +210,7 @@ export async function runWorkflow(opts: RunWorkflowInput): Promise<RunWorkflowRe
     });
 
     child.on("close", (code) => {
+      activeChildren.delete(child);
       if (settled) return;
       settled = true;
       clearTimeout(timer);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerTools } from "./tools.js";
+import { terminateActiveWorkflows } from "./handlers/run-workflow.js";
 
 const _require = createRequire(import.meta.url);
 const { version } = _require("../package.json") as { version: string };
@@ -14,6 +15,31 @@ async function main() {
   });
 
   registerTools(server);
+
+  // Deterministic shutdown. Otherwise the process relies on the event loop
+  // happening to drain after stdin closes, and a client that exits or is killed
+  // mid-run leaves this server (and any in-flight `sweny` workflow subprocess)
+  // orphaned. We make shutdown explicit and idempotent, and always terminate
+  // active workflow children first so nothing keeps running past the client.
+  let shuttingDown = false;
+  const shutdown = async (code = 0) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    terminateActiveWorkflows();
+    try {
+      await server.close();
+    } catch {
+      // Already closing/closed — fall through to exit.
+    }
+    process.exit(code);
+  };
+
+  // Transport close fires on stdin EOF, i.e. when the client disconnects or is
+  // force-killed and the stdio pipe breaks. This is the primary exit signal for
+  // a stdio MCP server.
+  server.server.onclose = () => void shutdown(0);
+  process.on("SIGINT", () => void shutdown(0));
+  process.on("SIGTERM", () => void shutdown(0));
 
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## What

The MCP server (`@sweny-ai/mcp`) connected the stdio transport and returned, leaving cleanup to whatever the event loop happened to do after stdin closed. There was no `SIGINT`/`SIGTERM` handling, no `onclose` hook, and no tracking of the workflow subprocess that `run_workflow` spawns.

A client that exits or is force-killed mid-run could orphan the server **and** its in-flight `sweny` workflow child (re-parented to launchd/init), where it keeps running for up to the 10-minute workflow timeout, long after the session that started it is gone. That is exactly how stale `sweny-mcp` process trees accumulate.

## Change

- `index.ts`: explicit, idempotent `shutdown()`. Traps `SIGINT`/`SIGTERM` and wires the transport's `onclose` (stdin EOF when the client disconnects) to terminate active workflow children, close the server, then exit.
- `run-workflow.ts`: track in-flight children in a registry; export `terminateActiveWorkflows(signal?)` for the server to call on shutdown. Children are removed from the registry when they settle (`close`/`error`).

Shutdown is now deterministic instead of incidental, and no workflow subprocess outlives the client.

## Test

- New `terminateActiveWorkflows` tests: signals an in-flight child with `SIGTERM`, and confirms a settled child is untracked so later shutdown is a no-op.
- Full package suite green (38 tests), typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)