### PR TITLE
Per-node tool filter + fail_soft: stop gather going rogue; Linear magic words in PRs

### DIFF
--- a/.changeset/gather-scope-and-linear-magic-words.md
+++ b/.changeset/gather-scope-and-linear-magic-words.md
@@ -1,0 +1,39 @@
+---
+"@sweny-ai/core": minor
+---
+
+Per-node skill-tool filtering, fail-soft nodes, and Linear magic words in PRs.
+
+New node fields (both additive and backward compatible; absent = previous
+behavior):
+
+- `tools: { allow?, deny? }` filters which skill-provided tools are exposed
+  at a node. Filtered tools are never registered for the run, so the model
+  cannot see or call them. Complements `disallowed_tools`, which covers
+  built-in agent tools only.
+- `fail_soft: true` downgrades an agent-level failure (max turns, early
+  termination, SDK error) to success with `fail_soft: true` and the original
+  `error` preserved in data, so the workflow proceeds with partial output.
+  Eval failures are never softened.
+- `ClaudeClient.run` now preserves the partial result text in `data.summary`
+  when a query terminates early (e.g. `terminal_reason: max_turns`).
+
+Triage workflow hardening (driving incident: a scheduled triage run whose
+gather node created issues and PRs mid-gather and then died at the 50-turn
+cap):
+
+- `gather` is now structurally read-only: all issue/PR/comment write tools
+  denied, `Write`/`Edit`/`NotebookEdit` disallowed, explicit scope boundary
+  in the instruction, and `fail_soft: true` so a turn-cap death proceeds to
+  `investigate` with partial context instead of failing the run.
+- `investigate`, `create_issue`, `skip`, and `implement` get matching
+  structural denies for the write tools their instructions already forbid.
+
+Linear magic words:
+
+- triage `create_pr`: PR body now includes `Fixes {issueIdentifier}` when
+  the tracker is Linear (mirrors the existing Sentry line), so Linear links
+  the PR and moves the issue to Done on merge.
+- implement workflow: identifier-prefixed branch naming
+  (`off-1234-fix-...`), identifier-bracketed commit messages and PR titles
+  (`[OFF-1234] fix: ...`), and the same `Fixes` line in the PR body.

--- a/packages/core/src/__tests__/claude.test.ts
+++ b/packages/core/src/__tests__/claude.test.ts
@@ -458,6 +458,46 @@ describe("ClaudeClient", () => {
       expect(result.data.error).toContain("terminated early");
     });
 
+    it("preserves the partial result text in data.summary on early termination", async () => {
+      // A fail_soft node downgrades this failure and passes data downstream;
+      // the partial text is the gathered work product and must survive.
+      mockQuery.mockReturnValueOnce(
+        makeStream([
+          {
+            type: "result",
+            subtype: "success",
+            result: "partial gather notes",
+            terminal_reason: "max_turns",
+          },
+        ]),
+      );
+
+      const client = new ClaudeClient();
+      const result = await client.run({ instruction: "x", context: {}, tools: [] });
+
+      expect(result.status).toBe("failed");
+      expect(result.data.summary).toBe("partial gather notes");
+    });
+
+    it("omits data.summary when the early-terminated result has no text", async () => {
+      mockQuery.mockReturnValueOnce(
+        makeStream([
+          {
+            type: "result",
+            subtype: "success",
+            result: "   ",
+            terminal_reason: "max_turns",
+          },
+        ]),
+      );
+
+      const client = new ClaudeClient();
+      const result = await client.run({ instruction: "x", context: {}, tools: [] });
+
+      expect(result.status).toBe("failed");
+      expect(result.data).not.toHaveProperty("summary");
+    });
+
     it("returns failed for any non-completed terminal_reason", async () => {
       // Future SDK versions may add new terminal reasons (aborted_tools,
       // blocking_limit, etc.) — treat anything that isn't 'completed' as a

--- a/packages/core/src/__tests__/executor.test.ts
+++ b/packages/core/src/__tests__/executor.test.ts
@@ -3665,3 +3665,261 @@ describe("abort / timeout (CE-01)", () => {
     expect(runCalls).toBe(0);
   });
 });
+
+// ─── Per-node skill-tool filter (Node.tools allow/deny) ──────────
+
+describe("per-node skill-tool filter (tools allow/deny)", () => {
+  function wfWithFilter(tools?: { allow?: string[]; deny?: string[] }): Workflow {
+    return {
+      id: "wf-tool-filter",
+      name: "Tool filter",
+      description: "",
+      entry: "gather",
+      nodes: {
+        gather: {
+          name: "Gather",
+          instruction: "Collect context",
+          skills: ["filesystem"],
+          ...(tools ? { tools } : {}),
+        },
+      },
+      edges: [],
+    };
+  }
+
+  function capturingClaude(captured: string[][]): any {
+    return {
+      async run(opts: any) {
+        captured.push(opts.tools.map((t: any) => t.name));
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+    };
+  }
+
+  it("exposes all skill tools when the node declares no filter (back-compat)", async () => {
+    const dir = freshDir("tool-filter-absent");
+    const captured: string[][] = [];
+    await execute(
+      wfWithFilter(),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {} },
+    );
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual(
+      expect.arrayContaining(["fs_read_json", "fs_read_text", "fs_write_json", "fs_write_markdown", "fs_list_dir"]),
+    );
+    expect(captured[0]).toHaveLength(5);
+  });
+
+  it("deny removes the listed tools and keeps the rest", async () => {
+    const dir = freshDir("tool-filter-deny");
+    const captured: string[][] = [];
+    await execute(
+      wfWithFilter({ deny: ["fs_write_json", "fs_write_markdown"] }),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {} },
+    );
+    expect(captured[0]).toEqual(expect.arrayContaining(["fs_read_json", "fs_read_text", "fs_list_dir"]));
+    expect(captured[0]).not.toContain("fs_write_json");
+    expect(captured[0]).not.toContain("fs_write_markdown");
+    expect(captured[0]).toHaveLength(3);
+  });
+
+  it("allow keeps only the listed tools", async () => {
+    const dir = freshDir("tool-filter-allow");
+    const captured: string[][] = [];
+    await execute(
+      wfWithFilter({ allow: ["fs_read_json", "fs_list_dir"] }),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {} },
+    );
+    expect(captured[0]!.sort()).toEqual(["fs_list_dir", "fs_read_json"]);
+  });
+
+  it("deny wins over allow when both list the same tool", async () => {
+    const dir = freshDir("tool-filter-both");
+    const captured: string[][] = [];
+    await execute(
+      wfWithFilter({ allow: ["fs_read_json", "fs_write_json"], deny: ["fs_write_json"] }),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {} },
+    );
+    expect(captured[0]).toEqual(["fs_read_json"]);
+  });
+
+  it("warns on a filter entry that matches no resolved tool", async () => {
+    const dir = freshDir("tool-filter-typo");
+    const captured: string[][] = [];
+    const warnings: string[] = [];
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: (msg: string) => warnings.push(msg),
+      error: () => {},
+    };
+    await execute(
+      wfWithFilter({ deny: ["fs_wirte_json"] }),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {}, logger },
+    );
+    expect(warnings.some((w) => w.includes("fs_wirte_json"))).toBe(true);
+    // The typo'd entry removes nothing.
+    expect(captured[0]).toHaveLength(5);
+  });
+
+  it("does not trip the missing-skills guard when a filter removes every tool", async () => {
+    const dir = freshDir("tool-filter-all-denied");
+    const captured: string[][] = [];
+    await execute(
+      wfWithFilter({ deny: ["fs_read_json", "fs_read_text", "fs_write_json", "fs_write_markdown", "fs_list_dir"] }),
+      {},
+      { skills: createSkillMap([createFileSkill(dir)]), claude: capturingClaude(captured), config: {} },
+    );
+    // The node still runs (the guard checks pre-filter tools); it just has
+    // no skill tools in context.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual([]);
+  });
+});
+
+// ─── Fail-soft (Node.fail_soft) ──────────────────────────────────
+
+describe("fail_soft", () => {
+  function wfFailSoft(failSoft: boolean): Workflow {
+    return {
+      id: "wf-fail-soft",
+      name: "Fail soft",
+      description: "",
+      entry: "gather",
+      nodes: {
+        gather: {
+          name: "Gather",
+          instruction: "Collect context",
+          skills: [],
+          ...(failSoft ? { fail_soft: true } : {}),
+        },
+        investigate: { name: "Investigate", instruction: "Analyze", skills: [] },
+      },
+      edges: [{ from: "gather", to: "investigate" }],
+    };
+  }
+
+  it("downgrades an agent-level failure to success and routes onward with partial output", async () => {
+    const runs: string[] = [];
+    const claude: any = {
+      async run(opts: any) {
+        runs.push(opts.instruction);
+        if (runs.length === 1) {
+          return {
+            status: "failed",
+            data: { error: "Reached maximum number of turns (50)", summary: "partial gather notes" },
+            toolCalls: [{ tool: "x", input: {} }],
+          };
+        }
+        return { status: "success", data: { verdict: "ok" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+    };
+
+    const { results } = await execute(wfFailSoft(true), {}, { skills: createSkillMap([]), claude, config: {} });
+
+    const gather = results.get("gather")!;
+    expect(gather.status).toBe("success");
+    expect(gather.data).toMatchObject({
+      fail_soft: true,
+      error: "Reached maximum number of turns (50)",
+      summary: "partial gather notes",
+    });
+    // The workflow proceeded to the downstream node.
+    expect(results.get("investigate")?.status).toBe("success");
+    expect(runs).toHaveLength(2);
+  });
+
+  it("leaves the failure intact when fail_soft is not declared", async () => {
+    const claude: any = {
+      async run() {
+        return { status: "failed", data: { error: "Reached maximum number of turns (50)" }, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+    };
+
+    const { results } = await execute(wfFailSoft(false), {}, { skills: createSkillMap([]), claude, config: {} });
+
+    expect(results.get("gather")?.status).toBe("failed");
+    expect(results.get("gather")?.data).not.toHaveProperty("fail_soft");
+  });
+
+  it("does NOT soften an eval failure (evals are correctness gates)", async () => {
+    const wf: Workflow = {
+      id: "wf-fail-soft-eval",
+      name: "Fail soft eval",
+      description: "",
+      entry: "gather",
+      nodes: {
+        gather: {
+          name: "Gather",
+          instruction: "Collect context",
+          skills: [],
+          fail_soft: true,
+          eval: [{ name: "searched", kind: "function", rule: { any_tool_called: ["search_tool"] } }],
+        },
+      },
+      edges: [],
+    };
+
+    const claude: any = {
+      async run() {
+        // The agent run itself succeeds but never calls the required tool.
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+    };
+
+    const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    expect(results.get("gather")?.status).toBe("failed");
+    expect(results.get("gather")?.data).not.toHaveProperty("fail_soft");
+  });
+
+  it("does NOT soften a required-output-field contract violation", async () => {
+    const wf: Workflow = {
+      id: "wf-fail-soft-required",
+      name: "Fail soft required",
+      description: "",
+      entry: "gather",
+      nodes: {
+        gather: {
+          name: "Gather",
+          instruction: "Collect context",
+          skills: [],
+          fail_soft: true,
+          output: { type: "object", properties: { verdict: { type: "string" } }, required: ["verdict"] },
+        },
+      },
+      edges: [],
+    };
+
+    const claude: any = {
+      async run() {
+        return { status: "success", data: {}, toolCalls: [] };
+      },
+      async evaluate(opts: any) {
+        return opts.choices[0]?.id;
+      },
+    };
+
+    const { results } = await execute(wf, {}, { skills: createSkillMap([]), claude, config: {} });
+
+    expect(results.get("gather")?.status).toBe("failed");
+    expect(results.get("gather")?.data).not.toHaveProperty("fail_soft");
+  });
+});

--- a/packages/core/src/__tests__/schema-conformance.test.ts
+++ b/packages/core/src/__tests__/schema-conformance.test.ts
@@ -461,6 +461,58 @@ const fixtures: Fixture[] = [
     },
     expected: true,
   },
+  {
+    name: "node with a skill-tool deny filter",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: {
+        a: { ...baseNode(), tools: { deny: ["linear_create_issue", "github_create_pr"] } },
+      },
+      edges: [],
+    },
+    expected: true,
+  },
+  {
+    name: "node with a skill-tool allow filter",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: {
+        a: { ...baseNode(), tools: { allow: ["linear_search_issues"] } },
+      },
+      edges: [],
+    },
+    expected: true,
+  },
+  {
+    name: "node with both allow and deny in the skill-tool filter",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: {
+        a: { ...baseNode(), tools: { allow: ["a", "b"], deny: ["b"] } },
+      },
+      edges: [],
+    },
+    expected: true,
+  },
+  {
+    name: "node with fail_soft true",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: {
+        a: { ...baseNode(), fail_soft: true },
+      },
+      edges: [],
+    },
+    expected: true,
+  },
 
   // ── Negative — structural (shared by Zod schema parse + structural check) ──
   // These are rejected by Zod parse, so they should also be rejected by the
@@ -541,6 +593,61 @@ const fixtures: Fixture[] = [
       name: "D",
       entry: "a",
       nodes: { a: { ...baseNode(), disallowed_tools: [""] } },
+      edges: [],
+    },
+    expected: false,
+  },
+  {
+    name: "empty skill-tool filter object (must declare allow or deny)",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), tools: {} } },
+      edges: [],
+    },
+    expected: false,
+  },
+  {
+    name: "skill-tool filter with an empty deny array",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), tools: { deny: [] } } },
+      edges: [],
+    },
+    expected: false,
+  },
+  {
+    name: "skill-tool filter with an empty-string allow entry",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), tools: { allow: [""] } } },
+      edges: [],
+    },
+    expected: false,
+  },
+  {
+    name: "skill-tool filter with an unknown key",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), tools: { block: ["x"] } } },
+      edges: [],
+    },
+    expected: false,
+  },
+  {
+    name: "fail_soft with a non-boolean value",
+    input: {
+      id: "d",
+      name: "D",
+      entry: "a",
+      nodes: { a: { ...baseNode(), fail_soft: "yes" } },
       edges: [],
     },
     expected: false,

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -107,6 +107,68 @@ describe("Zod schemas", () => {
       expect(result.disallowed_tools).toBeUndefined();
     });
 
+    it("accepts tools with a deny list", () => {
+      const result = nodeZ.parse({
+        name: "S",
+        instruction: "I",
+        tools: { deny: ["linear_create_issue", "github_create_pr"] },
+      });
+      expect(result.tools).toEqual({ deny: ["linear_create_issue", "github_create_pr"] });
+    });
+
+    it("accepts tools with an allow list", () => {
+      const result = nodeZ.parse({
+        name: "S",
+        instruction: "I",
+        tools: { allow: ["linear_search_issues"] },
+      });
+      expect(result.tools).toEqual({ allow: ["linear_search_issues"] });
+    });
+
+    it("accepts tools with both allow and deny", () => {
+      const result = nodeZ.parse({
+        name: "S",
+        instruction: "I",
+        tools: { allow: ["a", "b"], deny: ["b"] },
+      });
+      expect(result.tools).toEqual({ allow: ["a", "b"], deny: ["b"] });
+    });
+
+    it("rejects an empty tools object (must declare allow or deny)", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", tools: {} })).toThrow();
+    });
+
+    it("rejects tools with an empty allow array", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", tools: { allow: [] } })).toThrow();
+    });
+
+    it("rejects tools with an empty-string deny entry", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", tools: { deny: [""] } })).toThrow();
+    });
+
+    it("rejects tools with unknown keys", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", tools: { block: ["x"] } })).toThrow();
+    });
+
+    it("defaults tools to undefined when omitted", () => {
+      const result = nodeZ.parse({ name: "S", instruction: "I" });
+      expect(result.tools).toBeUndefined();
+    });
+
+    it("accepts fail_soft as a boolean", () => {
+      const result = nodeZ.parse({ name: "S", instruction: "I", fail_soft: true });
+      expect(result.fail_soft).toBe(true);
+    });
+
+    it("rejects a non-boolean fail_soft", () => {
+      expect(() => nodeZ.parse({ name: "S", instruction: "I", fail_soft: "yes" })).toThrow();
+    });
+
+    it("defaults fail_soft to undefined when omitted", () => {
+      const result = nodeZ.parse({ name: "S", instruction: "I" });
+      expect(result.fail_soft).toBeUndefined();
+    });
+
     it("rejects an evaluator missing a name", () => {
       expect(() =>
         nodeZ.parse({

--- a/packages/core/src/__tests__/workflow-yaml.test.ts
+++ b/packages/core/src/__tests__/workflow-yaml.test.ts
@@ -560,3 +560,131 @@ describe("runtime Zod validation in loader", () => {
     }
   });
 });
+
+// ─── Triage gather node: read-only scope enforcement ────────────
+// Driving incident: the 2026-06-08 letsoffload/permit-service scheduled run,
+// where gather created Linear issues OFF-2332/OFF-2333 and PRs #101/#102
+// from inside the gather node and then died at the 50-turn cap.
+
+describe("triage gather node: read-only scope enforcement", () => {
+  const gather = triageWorkflow.nodes.gather;
+
+  it("denies every issue/PR/comment write tool from its skills", () => {
+    expect(gather.tools).toBeDefined();
+    expect(gather.tools!.deny).toEqual(
+      expect.arrayContaining([
+        "linear_create_issue",
+        "linear_add_comment",
+        "linear_update_issue",
+        "github_create_issue",
+        "github_add_comment",
+        "github_create_pr",
+      ]),
+    );
+  });
+
+  it("does not declare an allow list (deny-only keeps new read tools available)", () => {
+    expect(gather.tools!.allow).toBeUndefined();
+  });
+
+  it("disallows the built-in file-editing tools (no code authoring mid-gather)", () => {
+    expect(gather.disallowed_tools).toEqual(expect.arrayContaining(["Write", "Edit", "NotebookEdit"]));
+  });
+
+  it("is fail-soft: a turn-cap death proceeds with partial context", () => {
+    expect(gather.fail_soft).toBe(true);
+  });
+
+  it("instruction declares the read-only scope boundary", () => {
+    const instr = gather.instruction as string;
+    expect(instr).toMatch(/READ-ONLY/);
+    expect(instr).toMatch(/DO NOT create issues, comments, branches, commits, or pull requests/);
+  });
+
+  it("instruction no longer invites using every tool available", () => {
+    const instr = gather.instruction as string;
+    expect(instr).not.toMatch(/Use every tool available/i);
+  });
+
+  it("downstream write nodes keep their write tools", () => {
+    // create_issue must still be able to create issues and comment.
+    const createIssueDeny = triageWorkflow.nodes.create_issue.tools?.deny ?? [];
+    expect(createIssueDeny).not.toContain("linear_create_issue");
+    expect(createIssueDeny).not.toContain("linear_add_comment");
+    // but never PRs
+    expect(createIssueDeny).toContain("github_create_pr");
+
+    // create_pr must still be able to open PRs.
+    const createPrDeny = triageWorkflow.nodes.create_pr.tools?.deny ?? [];
+    expect(createPrDeny).not.toContain("github_create_pr");
+
+    // skip must still be able to +1 and reopen.
+    const skipDeny = triageWorkflow.nodes.skip.tools?.deny ?? [];
+    expect(skipDeny).not.toContain("linear_add_comment");
+    expect(skipDeny).not.toContain("linear_update_issue");
+    expect(skipDeny).toContain("github_create_pr");
+  });
+
+  it("investigate denies the same write tools its instruction forbids", () => {
+    const deny = triageWorkflow.nodes.investigate.tools?.deny ?? [];
+    for (const tool of [
+      "linear_create_issue",
+      "linear_add_comment",
+      "github_create_issue",
+      "github_add_comment",
+      "github_create_pr",
+    ]) {
+      expect(deny).toContain(tool);
+    }
+  });
+
+  it("implement denies the PR tool (create_pr is the only PR-opening node)", () => {
+    const deny = triageWorkflow.nodes.implement.tools?.deny ?? [];
+    expect(deny).toContain("github_create_pr");
+  });
+});
+
+// ─── Linear magic words: triage create_pr ────────────────────────
+
+describe("triage create_pr node: Linear magic words", () => {
+  const instr = triageWorkflow.nodes.create_pr.instruction as string;
+
+  it("keeps the Sentry Fixes line", () => {
+    expect(instr).toMatch(/Fixes \{sentryShortId\}/);
+  });
+
+  it("adds the Linear Fixes line keyed to the created issue identifier", () => {
+    expect(instr).toMatch(/Fixes \{context\.create_issue\.issueIdentifier\}/);
+    expect(instr).toMatch(/Fixes OF{2}-1234/);
+    expect(instr).toMatch(/Linear/);
+  });
+});
+
+// ─── Linear magic words: implement workflow full treatment ───────
+
+describe("implement workflow: identifier branch/title/Fixes treatment", () => {
+  it("implement node mandates identifier-prefixed lowercase branch naming", () => {
+    const instr = implementWorkflow.nodes.implement.instruction as string;
+    expect(instr).toMatch(/context\.input\.issueIdentifier/);
+    expect(instr).toMatch(/lowercased/);
+    expect(instr).toMatch(/off-1234-fix-null-check/);
+  });
+
+  it("implement node mandates identifier-prefixed commit messages", () => {
+    const instr = implementWorkflow.nodes.implement.instruction as string;
+    expect(instr).toMatch(/\[OFF-1234\] fix:/);
+  });
+
+  it("create_pr node mandates the identifier PR title format", () => {
+    const instr = implementWorkflow.nodes.create_pr.instruction as string;
+    expect(instr).toMatch(/\[\{context\.input\.issueIdentifier\}\]/);
+    expect(instr).toMatch(/github_create_pr/);
+  });
+
+  it("create_pr node adds the Linear Fixes line", () => {
+    const instr = implementWorkflow.nodes.create_pr.instruction as string;
+    expect(instr).toMatch(/Fixes \{context\.input\.issueIdentifier\}/);
+    expect(instr).toMatch(/Fixes OF{2}-1234/);
+    expect(instr).toMatch(/Linear/);
+  });
+});

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -40,6 +40,7 @@ export type {
   EvaluatorKind,
   NodeRequires,
   NodeRetry,
+  NodeToolFilter,
   OutputMatch,
   NodeSources,
   EvalPolicy,

--- a/packages/core/src/claude.ts
+++ b/packages/core/src/claude.ts
@@ -386,9 +386,17 @@ export class ClaudeClient implements Claude {
             // incomplete output.
             const terminalReason = (resultMsg as any).terminal_reason as string | undefined;
             if (terminalReason && terminalReason !== "completed") {
+              // Preserve whatever partial text the agent produced before the
+              // early termination. Callers that fail hard ignore it; a node
+              // with `fail_soft: true` passes it downstream as the partial
+              // gather/work product instead of dropping it on the floor.
+              const partial = typeof resultMsg.result === "string" ? resultMsg.result.trim() : "";
               return {
                 status: "failed",
-                data: { error: `Claude query terminated early: ${terminalReason}` },
+                data: {
+                  error: `Claude query terminated early: ${terminalReason}`,
+                  ...(partial !== "" ? { summary: partial } : {}),
+                },
                 toolCalls,
               };
             }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -17,6 +17,7 @@ import type {
   Workflow,
   Node,
   NodeSources,
+  NodeToolFilter,
   Skill,
   SkillDefinition,
   Tool,
@@ -236,8 +237,11 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     safeObserve(observer, { type: "node:enter", node: currentId, instruction: resolvedInstruction }, logger);
     logger.info(`→ ${node.name}`, { node: currentId });
 
-    // Gather tools from the node's skills
-    const tools = resolveTools(node.skills, skills);
+    // Gather tools from the node's skills, then apply the node's optional
+    // skill-tool filter (`tools.allow` / `tools.deny`). Filtered tools are
+    // never registered for the run, so the model cannot see or call them.
+    const resolvedSkillTools = resolveTools(node.skills, skills);
+    const tools = filterNodeTools(resolvedSkillTools, node.tools, currentId, logger);
     const skillInstructions = resolveSkillInstructions(node.skills, skills);
 
     // Runtime guard: if this node declares skills but none resolved, the node
@@ -245,7 +249,7 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     // The startup validate() warns about this possibility, but only throw when
     // the node is actually reached — unreachable nodes with missing skills are fine.
     // Instruction-only skills (no tools) are valid — they inject context into the prompt.
-    if (node.skills.length > 0 && tools.length === 0 && skillInstructions.length === 0) {
+    if (node.skills.length > 0 && resolvedSkillTools.length === 0 && skillInstructions.length === 0) {
       throw new Error(
         `Node "${currentId}" requires skills [${node.skills.join(", ")}] but none are configured. ` +
           `Set the required environment variables and try again.`,
@@ -343,6 +347,11 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
     // Run Claude on this node, with optional eval-failure retry loop.
     let attempt = 0;
     let result: NodeResult;
+    // Distinguishes an agent-level failure (claude.run returned non-success:
+    // max turns, early termination, SDK error) from an eval failure. Only
+    // agent-level failures are eligible for fail_soft below; evals are
+    // correctness gates and are never softened.
+    let agentRunFailed = false;
     let currentInstruction = instruction;
     const retry = node.retry;
     // Per-node execution model: node.model ?? workflow.model. When undefined,
@@ -366,7 +375,10 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
       });
 
       // Retry only triggers on eval failure. Bail on tool/API errors.
-      if (result.status !== "success") break;
+      if (result.status !== "success") {
+        agentRunFailed = true;
+        break;
+      }
 
       // Required-field gate: if the source node's declared output schema
       // marks fields as `required`, those fields are the routing contract.
@@ -443,6 +455,27 @@ export async function execute(workflow: Workflow, input: unknown, options: Execu
         logger,
       );
       attempt++;
+    }
+
+    // Fail-soft: when the node declares `fail_soft: true` and the failure was
+    // agent-level (max turns, early termination, SDK error), downgrade to
+    // success so the workflow proceeds with whatever partial output exists
+    // instead of failing outright. The original error stays in `data.error`
+    // and `data.fail_soft` marks the downgrade for downstream nodes and
+    // observers. Eval failures never take this path (agentRunFailed guards it).
+    if (agentRunFailed && result.status === "failed" && node.fail_soft === true) {
+      const failError = (result.data as Record<string, unknown> | undefined)?.error;
+      logger.warn(
+        `  fail_soft: node failed (${String(failError ?? "unknown error")}); continuing with partial output`,
+        {
+          node: currentId,
+        },
+      );
+      result = {
+        ...result,
+        status: "success",
+        data: { ...((result.data as Record<string, unknown> | undefined) ?? {}), fail_soft: true },
+      };
     }
 
     results.set(currentId, result);
@@ -812,6 +845,36 @@ function resolveTools(skillIds: string[], skills: Map<string, Skill>): Tool[] {
     .map((id) => skills.get(id))
     .filter((s): s is Skill => s != null)
     .flatMap((s) => s.tools);
+}
+
+/**
+ * Apply a node's optional skill-tool filter (`tools.allow` / `tools.deny`).
+ *
+ * - No filter declared: all resolved tools pass through (back-compat).
+ * - `allow` present: only tools whose name is in `allow` survive.
+ * - `deny` present: tools whose name is in `deny` are removed. Applied
+ *   after `allow` when both are declared, so deny always wins.
+ *
+ * Filter entries that match no resolved tool get a warn (typo detection;
+ * also fires legitimately when a skill is unconfigured and its tools are
+ * absent, which is informational rather than fatal).
+ */
+function filterNodeTools(tools: Tool[], filter: NodeToolFilter | undefined, nodeId: string, logger: Logger): Tool[] {
+  if (!filter) return tools;
+
+  const resolvedNames = new Set(tools.map((t) => t.name));
+  for (const name of [...(filter.allow ?? []), ...(filter.deny ?? [])]) {
+    if (!resolvedNames.has(name)) {
+      logger.warn(`  tools filter: '${name}' does not match any tool resolved for node '${nodeId}'`, {
+        node: nodeId,
+        tool: name,
+      });
+    }
+  }
+
+  const allow = filter.allow ? new Set(filter.allow) : null;
+  const deny = new Set(filter.deny ?? []);
+  return tools.filter((t) => (allow ? allow.has(t.name) : true) && !deny.has(t.name));
 }
 
 /** Collect instruction strings from skills that have them, in array order. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export type {
   EvaluatorKind,
   NodeRequires,
   NodeRetry,
+  NodeToolFilter,
   OutputMatch,
   NodeSources,
   EvalPolicy,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -239,6 +239,22 @@ export const nodeRequiresZ = z
     message: "requires must declare at least one check (output_required or output_matches)",
   });
 
+/**
+ * Per-node skill-tool filter. `allow` keeps only the listed skill tools;
+ * `deny` removes the listed skill tools (applied after `allow`). At least
+ * one of the two must be declared. Complements `disallowed_tools`, which
+ * covers built-in agent tools only.
+ */
+export const nodeToolsZ = z
+  .object({
+    allow: z.array(z.string().min(1)).min(1).optional(),
+    deny: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .strict()
+  .refine((t) => t.allow !== undefined || t.deny !== undefined, {
+    message: "tools must declare at least one of allow or deny",
+  });
+
 const retryInstructionAutoZ = z.object({ auto: z.literal(true) }).strict();
 const retryInstructionReflectZ = z.object({ reflect: z.string().min(1) }).strict();
 
@@ -257,6 +273,8 @@ export const nodeZ = z
     output: jsonSchemaZ.optional(),
     max_turns: z.number().int().min(1).optional(),
     disallowed_tools: z.array(z.string().min(1)).optional(),
+    tools: nodeToolsZ.optional(),
+    fail_soft: z.boolean().optional(),
     rules: nodeSourcesZ.optional(),
     context: nodeSourcesZ.optional(),
     eval: z.array(evaluatorZ).min(1).optional(),
@@ -869,6 +887,30 @@ export const workflowJsonSchema = {
             items: { type: "string", minLength: 1 },
             description:
               "Built-in tool names the agent cannot use at this node (e.g. ['Bash']). Forwarded to the Claude Agent SDK's disallowedTools, which removes the tools from the model context entirely.",
+          },
+          tools: {
+            type: "object",
+            description:
+              "Per-node filter over skill-provided tools. 'allow' keeps only the listed skill tools; 'deny' removes the listed skill tools (applied after 'allow'). Filtered tools are never registered for the node's run. Absent field = all skill tools exposed. Complements disallowed_tools, which covers built-in agent tools only.",
+            additionalProperties: false,
+            anyOf: [{ required: ["allow"] }, { required: ["deny"] }],
+            properties: {
+              allow: {
+                type: "array",
+                items: { type: "string", minLength: 1 },
+                minItems: 1,
+              },
+              deny: {
+                type: "array",
+                items: { type: "string", minLength: 1 },
+                minItems: 1,
+              },
+            },
+          },
+          fail_soft: {
+            type: "boolean",
+            description:
+              "When true, an agent-level failure at this node (max turns, early termination, SDK error) is downgraded to success with fail_soft: true and the error preserved in data; routing proceeds with partial output. Eval failures are not softened. Default false.",
           },
           rules: {
             $ref: "#/$defs/NodeSources",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -327,6 +327,44 @@ export interface Node {
    * `git push`. Names follow the SDK's tool naming (e.g. `Bash`, `Write`).
    */
   disallowed_tools?: string[];
+  /**
+   * Per-node filter over skill-provided tools. Complements
+   * `disallowed_tools` (which covers built-in agent tools only): this field
+   * restricts which of the node's skill tools are registered for the run.
+   * Filtered tools are never exposed to the model at all. Structural
+   * enforcement, not prompt-begging.
+   *
+   * - `allow`: when present, ONLY these skill tool names are exposed.
+   * - `deny`: these skill tool names are removed (applied after `allow`).
+   *
+   * Absent field = all skill tools exposed (previous behavior, back-compat).
+   * Driving incident: the triage `gather` node, scoped to read-only context
+   * gathering, created Linear issues and GitHub PRs mid-gather because every
+   * write tool from its skills was in context (letsoffload/permit-service
+   * scheduled run on 2026-06-08, PRs #101/#102).
+   */
+  tools?: NodeToolFilter;
+  /**
+   * When true, an agent-level failure at this node (max turns reached,
+   * early termination, SDK error) does not fail the workflow: the node's
+   * result is downgraded to `success` with `fail_soft: true` set and the
+   * original `error` preserved in `data`, and routing proceeds so
+   * downstream nodes can work with whatever partial output exists.
+   * Eval failures are NOT softened; evals are correctness gates.
+   * Default false (previous behavior, back-compat).
+   */
+  fail_soft?: boolean;
+}
+
+/**
+ * Per-node skill-tool filter. See {@link Node.tools}.
+ * At least one of `allow` / `deny` must be declared (schema-enforced).
+ */
+export interface NodeToolFilter {
+  /** When present, only these skill tool names are exposed at the node. */
+  allow?: string[];
+  /** Skill tool names removed from the node (applied after `allow`). */
+  deny?: string[];
 }
 
 /** An edge connecting two nodes */

--- a/packages/core/src/workflows/implement.yml
+++ b/packages/core/src/workflows/implement.yml
@@ -67,10 +67,13 @@ nodes:
     instruction: |-
       Implement the planned fix:
 
-      1. Create a feature branch.
+      1. Create a feature branch. The branch name MUST start with the issue
+         identifier from `context.input.issueIdentifier`, lowercased, followed
+         by a short kebab-case description: e.g. `off-1234-fix-null-check`.
       2. Make the necessary code changes.
       3. Ensure changes are minimal and focused — fix the bug, nothing more.
-      4. Stage and commit with a clear commit message referencing the issue.
+      4. Stage and commit. Start the commit message with the issue identifier
+         in brackets, e.g. `[OFF-1234] fix: guard null projectId`.
 
       Stop after the commit. Do NOT push or open the PR — the dedicated `create_pr`
       node handles that via `github_create_pr` and its eval gate is what unblocks
@@ -93,9 +96,13 @@ nodes:
 
       1. Push the branch to the remote.
 
-      2. Create a PR with a clear title and description.
+      2. Create the PR using `github_create_pr`. The PR title MUST start with the issue identifier in
+      brackets: `[{context.input.issueIdentifier}] type: short description` (e.g. `[OFF-1234] fix: guard
+      null projectId`).
 
-      3. Reference the original issue in the PR body.
+      3. Reference the original issue in the PR body. If the issue tracker is Linear, include the line
+      "Fixes {context.input.issueIdentifier}" (e.g. "Fixes OFF-1234") so Linear links the PR and moves
+      the issue to Done on merge.
 
       4. Pass `labels: ["sweny", "agent", "task"]` to `github_create_pr` (or `["sweny", "agent", "feature"]` if the issue is a feature request).
 

--- a/packages/core/src/workflows/triage.yml
+++ b/packages/core/src/workflows/triage.yml
@@ -18,13 +18,53 @@ nodes:
       3. **Issue tracker**: Search for similar past issues or known problems.
 
 
-      Be thorough — the investigation step depends on complete context. Use every tool available to you.
+      Be thorough, but stay in scope: read, search, and summarize. The investigation step depends on
+      complete context, not on fixes.
+
+
+      **Scope boundary (this node is READ-ONLY):**
+
+      - DO NOT create issues, comments, branches, commits, or pull requests, and DO NOT implement
+      fixes. Downstream nodes (`create_issue`, `implement`, `create_pr`) handle ALL writes.
+
+      - Your ONLY job is to collect context and report it, then stop. Doing downstream work here
+      burns your turn budget and duplicates what later nodes will do.
     skills:
       - github
       - sentry
       - datadog
       - betterstack
       - linear
+    # Structural enforcement of the read-only scope above: write tools from
+    # the github/linear skills are never registered for this node, so the
+    # model cannot call them no matter what the prompt fails to prevent.
+    # Driving incident: the 2026-06-08 letsoffload/permit-service scheduled
+    # run, where gather created Linear issues OFF-2332/OFF-2333 and PRs
+    # #101/#102 from inside this node and then died at the 50-turn cap.
+    tools:
+      deny:
+        - linear_create_issue
+        - linear_add_comment
+        - linear_update_issue
+        - github_create_issue
+        - github_add_comment
+        - github_create_pr
+    # Same incident: gather authored code changes mid-gather. Write/Edit are
+    # removed from the model context entirely. Bash stays available because
+    # read-side investigation legitimately uses it (git log, grep); blocking
+    # specific Bash invocations (git commit, gh pr create) needs the SDK's
+    # canUseTool callback and is tracked as follow-up work (see the implement
+    # node's note below).
+    disallowed_tools:
+      - Write
+      - Edit
+      - NotebookEdit
+    # When gather still dies early (turn cap, SDK error), proceed with the
+    # partial context instead of failing the whole workflow: investigate has
+    # its own tools and can re-derive what gather missed. The 2026-06-08 run
+    # proved this empirically: after gather "failed", investigate completed
+    # fine and produced a correct no-novel-issues verdict.
+    fail_soft: true
   investigate:
     name: Root Cause Analysis
     instruction: >-
@@ -100,6 +140,16 @@ nodes:
     skills:
       - github
       - linear
+    # Structural enforcement of the scope boundaries above: the write tools
+    # this node is told not to call are not registered for it at all.
+    tools:
+      deny:
+        - linear_create_issue
+        - linear_add_comment
+        - linear_update_issue
+        - github_create_issue
+        - github_add_comment
+        - github_create_pr
     eval:
       # The novelty check REQUIRES searching the issue tracker. If the node finishes
       # with 0 search tool calls, it means the agent skipped the novelty check entirely
@@ -239,6 +289,10 @@ nodes:
     skills:
       - linear
       - github
+    # Structural enforcement: this node manages issues, never PRs.
+    tools:
+      deny:
+        - github_create_pr
     eval:
       # Require a real issue-tracker tool call. linear_create_issue / github_create_issue
       # for novel findings; linear_search_issues / github_search_issues for duplicate-check
@@ -326,6 +380,13 @@ nodes:
     skills:
       - linear
       - github
+    # Structural enforcement: this node comments on and reopens existing
+    # issues only. It never creates issues or PRs.
+    tools:
+      deny:
+        - linear_create_issue
+        - github_create_issue
+        - github_create_pr
   implement:
     name: Implement Fix
     instruction: |-
@@ -490,6 +551,12 @@ nodes:
     disallowed_tools:
       - WebFetch
       - WebSearch
+    # Structural enforcement of the "do NOT open the PR here" boundary: the
+    # PR tool is not registered for this node. The dedicated create_pr node
+    # is the only place github_create_pr exists.
+    tools:
+      deny:
+        - github_create_pr
     output:
       type: object
       properties:
@@ -636,7 +703,9 @@ nodes:
 
       4. In the PR body, include: summary of the bug, what the fix does, and a link to the issue
       (context.create_issue.issueUrl). If the investigation found a Sentry issue, include "Fixes {sentryShortId}"
-      in the PR body so Sentry auto-resolves on merge.
+      in the PR body so Sentry auto-resolves on merge. If the issue tracker is Linear, also include the line
+      "Fixes {context.create_issue.issueIdentifier}" (e.g. "Fixes OFF-1234") so Linear links the PR and moves
+      the issue to Done on merge.
 
       5. Pass `labels: ["sweny", "agent", "triage"]` to `github_create_pr`.
 

--- a/spec/public/schemas/workflow.json
+++ b/spec/public/schemas/workflow.json
@@ -453,6 +453,41 @@
             },
             "description": "Built-in tool names the agent cannot use at this node (e.g. ['Bash']). Forwarded to the Claude Agent SDK's disallowedTools, which removes the tools from the model context entirely."
           },
+          "tools": {
+            "type": "object",
+            "description": "Per-node filter over skill-provided tools. 'allow' keeps only the listed skill tools; 'deny' removes the listed skill tools (applied after 'allow'). Filtered tools are never registered for the node's run. Absent field = all skill tools exposed. Complements disallowed_tools, which covers built-in agent tools only.",
+            "additionalProperties": false,
+            "anyOf": [
+              {
+                "required": ["allow"]
+              },
+              {
+                "required": ["deny"]
+              }
+            ],
+            "properties": {
+              "allow": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              },
+              "deny": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          "fail_soft": {
+            "type": "boolean",
+            "description": "When true, an agent-level failure at this node (max turns, early termination, SDK error) is downgraded to success with fail_soft: true and the error preserved in data; routing proceeds with partial output. Eval failures are not softened. Default false."
+          },
           "rules": {
             "$ref": "#/$defs/NodeSources",
             "description": "Per-node rules. Additive by default; set { only: true } to block cascade."

--- a/spec/src/content/docs/nodes.mdx
+++ b/spec/src/content/docs/nodes.mdx
@@ -16,6 +16,8 @@ A Node represents a single step in a [Workflow](/workflow). Each node contains a
 | `max_turns`        | integer &ge; 1                   | OPTIONAL | implementation&#8209;defined   | Maximum AI model turns for this node's execution.                                                              |
 | `model`            | string                           | OPTIONAL | inherited / impl&#8209;defined | Execution model for this node's AI invocation. Free-text passthrough. See [Model Selection](#model-selection). |
 | `disallowed_tools` | string[]                         | OPTIONAL | `[]`                           | Built-in agent tools removed from the model context at this node. See [Disallowed Tools](#disallowed-tools).   |
+| `tools`            | [ToolFilter](#tool-filter)       | OPTIONAL | all skill tools                | Allowlist/denylist over skill-provided tools at this node. See [Tool Filter](#tool-filter).                    |
+| `fail_soft`        | boolean                          | OPTIONAL | `false`                        | Downgrade an agent-level failure to success and proceed with partial output. See [Fail Soft](#fail-soft).      |
 | `rules`            | [NodeSources](#nodesources-type) | OPTIONAL | inherited                      | Rules for this node. Additive by default; see [cascade](#cascade-semantics).                                   |
 | `context`          | [NodeSources](#nodesources-type) | OPTIONAL | inherited                      | Context for this node. Additive by default; see [cascade](#cascade-semantics).                                 |
 | `eval`             | [Eval](#eval)                    | OPTIONAL | —                              | Named evaluators (value, function, judge) run after the AI finishes the node.                                  |
@@ -78,6 +80,52 @@ implement:
 ```
 
 The exact set of names the runtime recognizes is **implementation-defined** and tracks the agent SDK in use. Workflow authors SHOULD verify a name is honored before relying on it; a typo silently no-ops because there is no built-in tool of that name to remove.
+
+## Tool Filter
+
+The `tools` field restricts which skill-provided tools are exposed at this node. It is the skill-tool counterpart to [`disallowed_tools`](#disallowed-tools), which covers built-in agent tools only.
+
+| Field   | Type     | Required | Description                                                              |
+| ------- | -------- | -------- | ------------------------------------------------------------------------ |
+| `allow` | string[] | OPTIONAL | When present, ONLY these skill tool names are exposed at this node.      |
+| `deny`  | string[] | OPTIONAL | These skill tool names are removed. Applied after `allow` when both set. |
+
+At least one of `allow` / `deny` MUST be declared when the field is present.
+
+A conforming executor:
+
+- **MUST NOT** register a filtered-out tool for the node's run. The model never sees the tool; this is structural enforcement, not call-time rejection.
+- **MUST** expose all skill tools unchanged when the field is absent (back-compat).
+- **SHOULD** warn when a filter entry matches no tool resolved for the node (typo detection; also fires when a skill is unconfigured).
+
+Typical use: a read-only context-gathering node that declares the `github` and `linear` skills for their search tools but must never create issues or pull requests:
+
+```yaml
+gather:
+  name: Gather Context
+  instruction: Collect context about the alert. Read-only.
+  skills:
+    - github
+    - linear
+  tools:
+    deny:
+      - linear_create_issue
+      - github_create_issue
+      - github_create_pr
+```
+
+## Fail Soft
+
+When `fail_soft: true` and the node fails at the agent level (turn cap reached, early termination, runtime error), the executor downgrades the result to `status: "success"`, sets `fail_soft: true` in the result data, preserves the original error under `data.error`, and proceeds with routing so downstream nodes can work with whatever partial output exists.
+
+A conforming executor:
+
+- **MUST** apply `fail_soft` only to agent-level failures. Eval failures are correctness gates and **MUST NOT** be softened.
+- **MUST** preserve the original error message in the result data.
+- **MUST** mark the downgrade (`fail_soft: true` in result data) so downstream nodes and observers can distinguish a soft-failed node from a genuinely successful one.
+- When the field is absent or `false`, a failed node fails the workflow as before.
+
+Typical use: a best-effort context-gathering node whose downstream consumer has its own tools and can compensate for incomplete context.
 
 ## Rules & Context
 


### PR DESCRIPTION
Fixes the rogue-gather incident (swenyai/cloud#44) and adds Linear magic words (swenyai/cloud#43).

## Root cause (from run logs, letsoffload/permit-service run 27147553394)

The Jun 8 scheduled triage "failure" was gather running the entire triage+implement pipeline inside itself: 74 tool calls (healthy baseline: 29), a `git commit` failure at 15:25:07, PRs #101/#102 created from inside the gather window, then "Reached maximum number of turns (50)". Three compounding causes, none of them a regression (same core v0.1.113 and same YAML on the good Jun 4 run):

1. Gather had no scope boundary (the "DO NOT create issues/PRs" text lives in other nodes)
2. Gather's instructions literally said "Use every tool available to you"
3. `resolveTools()` exposes every declared skill tool to every node, so gather held `linear_create_issue` and `github_create_pr`

(The Jun 6 failure was different: Claude usage-limit exhaustion, 0 tool calls. Not this bug.)

## The fix: structural, not prompt-begging

- **Per-node skill-tool filter**: new optional `tools: { allow?, deny? }` node field (schema + types + executor). Filtered tools are never registered on the MCP server, so the model cannot see them. Absent field = current behavior; deny wins; unknown names warn
- **`fail_soft: true`**: agent-level failures (max turns, early termination) downgrade to success with partial output preserved, so a capped gather no longer fails the whole workflow. Eval failures and required-field violations are never softened
- **triage.yml**: gather gets a read-only scope boundary, loses "use every tool", denies all 6 write tools, and is fail_soft; investigate/create_issue/implement/skip get matching structural denies
- **Magic words (#43)**: triage create_pr adds `Fixes {identifier}` for Linear (mirrors the Sentry pattern); implement.yml gets the full treatment: identifier branch naming (`off-1234-fix-...`), `[OFF-1234] type:` titles, Fixes line

## Verification

- @sweny-ai/core: 2,072 tests passing (77 new: schema, executor filter enforcement, fail-soft semantics, YAML contract tests)
- Full workspace green; typecheck, lint, schema-drift check, prettier all clean
- Spec docs updated (nodes.mdx + regenerated workflow.json)

Propagation: the action wrapper installs core@latest at run time, so merge + auto-release is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
