### PR TITLE
docs: decouple the docs from the unreleased cloud service

### DIFF
--- a/.changeset/cloud-reporting-token-auth.md
+++ b/.changeset/cloud-reporting-token-auth.md
@@ -2,15 +2,17 @@
 "@sweny-ai/core": minor
 ---
 
-Add opt-in cloud reporting via `SWENY_CLOUD_TOKEN`. When set, run summaries
-(status, duration, findings, PR/issue URLs) are sent to cloud.sweny.ai using
-a project-scoped Bearer token. Without the token, the CLI makes zero network
-calls to sweny.ai — no anonymous telemetry, no phone-home.
+Add opt-in run reporting via `SWENY_CLOUD_TOKEN`. When set, run summaries
+(status, duration, findings, PR/issue URLs) are sent to the configured
+reporting endpoint using a project-scoped Bearer token. Without the token, the
+CLI makes zero network calls to sweny.ai. No anonymous telemetry, no
+phone-home. Token minting is not currently exposed, so this path is dormant by
+default; the hosted service is in active development.
 
-**Breaking (security):** The CLI no longer forwards `GITHUB_TOKEN` to
-cloud.sweny.ai for authentication. The only auth paths are `SWENY_CLOUD_TOKEN`
-(project token from cloud.sweny.ai) and GitHub App installation. The deprecated
-`Authorization: token <github-token>` path on the cloud `/api/report` endpoint
-has been removed.
+**Breaking (security):** The CLI no longer forwards `GITHUB_TOKEN` to the
+reporting endpoint for authentication. The only auth paths are
+`SWENY_CLOUD_TOKEN` and GitHub App installation. The deprecated
+`Authorization: token <github-token>` path on the `/api/report` endpoint has
+been removed.
 
 New config: `SWENY_CLOUD_TOKEN` env var or `cloud-token` in `.sweny.yml`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,12 +6,6 @@ SWEny is an open-source framework for building and running AI agent workflows as
 
 The Action and CLI are free and run in **your** environment — your CI runner, your terminal, your compute. SWEny never executes code on our infrastructure.
 
-### What SWEny Cloud is (today)
-
-[cloud.sweny.ai](https://cloud.sweny.ai) is the **analytics and intelligence dashboard**. It collects metadata from Action runs and GitHub webhooks, then shows you what matters: trends, activity, AI-powered insights. It stores metadata only — never source code, diffs, or agent output.
-
-Cloud is to SWEny what Codecov is to testing: the Action does the work, Cloud shows the results.
-
 ### Packages
 
 | Package | Dir | Published | What it does |
@@ -34,7 +28,7 @@ When a workflow runs (via CLI or GitHub Action):
 5. Edges are evaluated — unconditional edges follow deterministically, conditional edges are routed by the AI model
 6. The trace (ordered steps + routing decisions) is emitted as events throughout
 
-All execution happens locally. If `SWENY_CLOUD_TOKEN` is set, a structured summary (status, duration, recommendations) is sent to cloud.sweny.ai — no code, no diffs, no secrets.
+All execution happens locally. The executor has an opt-in reporting path that emits a structured summary (status, duration, recommendations) when `SWENY_CLOUD_TOKEN` is set. No code, no diffs, no secrets. Token minting is not currently exposed, so this path is dormant by default; the hosted service behind it is in active development.
 
 ### What "scoped tools" means
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,6 +11,8 @@ SWEny is an open-source CLI and GitHub Action. It does not collect telemetry by 
 
 ## What we DO do (only when you opt in)
 
+> **Not currently available.** The hosted reporting service is in active development and there is no way to mint a `SWENY_CLOUD_TOKEN` today. Without a token this code path returns immediately and no request is made. The behavior below is documented because the code ships in the CLI, not because the service is open.
+
 If you set `SWENY_CLOUD_TOKEN`, run summaries are sent to `https://cloud.sweny.ai/api/report`:
 
 - Repository owner and name
@@ -24,6 +26,6 @@ Authentication is via your project token only. Your `GITHUB_TOKEN` is never sent
 
 To disable at any time, remove `SWENY_CLOUD_TOKEN` from your workflow. Reporting will immediately stop.
 
-## Self-hosting
+## Pointing reporting elsewhere
 
-Override the reporting endpoint with `SWENY_CLOUD_URL=https://your-own-host` if you run your own SWEny Cloud instance.
+`SWENY_CLOUD_URL=https://your-own-host` overrides the reporting endpoint, so you can send run summaries to your own service instead. The payload shape is the list above.

--- a/README.md
+++ b/README.md
@@ -159,27 +159,13 @@ Focused actions for common use cases:
 | [`swenyai/triage@v1`](https://github.com/swenyai/triage) | SRE triage — observability + issue tracker |
 | [`swenyai/e2e@v1`](https://github.com/swenyai/e2e) | Agentic E2E browser tests |
 
-### Cloud reporting (optional)
+### Run reporting (optional, not yet available)
 
-SWEny runs locally or in CI with zero phone-home behavior by default. To enable the cloud dashboard at [cloud.sweny.ai](https://cloud.sweny.ai):
+SWEny runs locally or in CI with **zero phone-home behavior**. No anonymous telemetry, no pings, nothing.
 
-1. Sign up and link your repo — the GitHub App handles this in one click.
-2. Copy the **CI reporting token** from your project page (starts with `sweny_pk_`).
-3. Add it as a GitHub Actions secret named `SWENY_CLOUD_TOKEN`.
-4. Expose it to the Action:
+The CLI contains an opt-in run reporting path, gated entirely on a `SWENY_CLOUD_TOKEN` project token. Unless you set that variable yourself, every reporting entry point returns before making a request, so a default install sends nothing.
 
-```yaml
-- uses: swenyai/sweny@v5
-  with:
-    workflow: .sweny/workflows/security-audit.yml
-    claude-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-  env:
-    SWENY_CLOUD_TOKEN: ${{ secrets.SWENY_CLOUD_TOKEN }}
-```
-
-Without `SWENY_CLOUD_TOKEN`, the Action performs **no network calls to sweny.ai**. No anonymous telemetry, no pings, nothing.
-
-See [PRIVACY.md](./PRIVACY.md) for the full data policy.
+The hosted service behind it is in active development and **not open for sign-ups**, so there is no token to obtain today. See [PRIVACY.md](./PRIVACY.md) for the exact payload if you point it at your own endpoint.
 
 ## Publish to the marketplace
 
@@ -202,7 +188,6 @@ sweny publish   # interactive CLI — publish a workflow or skill
 - [Documentation](https://docs.sweny.ai) — full docs, guides, and reference
 - [Workflow Spec](https://spec.sweny.ai) — formal YAML specification
 - [Marketplace](https://marketplace.sweny.ai) — browse and share workflows
-- [Cloud Dashboard](https://cloud.sweny.ai) — analytics and scheduling
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,9 @@ SWEny never stores credentials in code. All secrets are read from environment va
 
 ## Execution Model
 
-SWEny runs entirely in your environment — your terminal, your CI runner, your compute. The cloud dashboard ([cloud.sweny.ai](https://cloud.sweny.ai)) receives only structured metadata (run status, duration, recommendations) when explicitly opted in via `SWENY_CLOUD_TOKEN`. No source code, diffs, or secrets are ever sent.
+SWEny runs entirely in your environment: your terminal, your CI runner, your compute.
+
+The CLI ships an opt-in run reporting path that sends structured metadata only (run status, duration, recommendations) and never source code, diffs, or secrets. It is gated on `SWENY_CLOUD_TOKEN` and returns immediately when that variable is unset, so a default install makes no outbound request. Token minting is not currently exposed; the hosted service is in active development. See [PRIVACY.md](./PRIVACY.md) for the exact payload.
 
 ## Open-Source Worker Audit Path (aws-cloud — not yet live)
 

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ inputs:
     default: ""
 
   cloud-token:
-    description: "SWEny Cloud project token (sweny_pk_...) for reporting run results to cloud.sweny.ai. Optional. Equivalent to setting the SWENY_CLOUD_TOKEN env var; either form is accepted."
+    description: "Project token (sweny_pk_...) enabling opt-in run reporting. Optional, and not currently available. Token minting is not yet exposed, so leaving this unset (the default) means no outbound reporting request is made. Equivalent to setting the SWENY_CLOUD_TOKEN env var; either form is accepted."
     required: false
 
 runs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ If you're looking for one of the older root-level docs (`mcp-servers.md`, `provi
 | `docs/provider-authoring.md` | [docs.sweny.ai/skills](https://docs.sweny.ai/skills/) and [docs.sweny.ai/skills/custom](https://docs.sweny.ai/skills/custom/) |
 | `docs/recipe-authoring.md` | [docs.sweny.ai/workflows](https://docs.sweny.ai/workflows/) and [docs.sweny.ai/workflows/custom](https://docs.sweny.ai/workflows/custom/) |
 | `docs/recipes/*` | [docs.sweny.ai/action/examples](https://docs.sweny.ai/action/examples/) |
-| `docs/self-hosted-worker.md` | (the aws-cloud managed-execution architecture is not the current cloud product; see [`ARCHITECTURE.md`](../ARCHITECTURE.md) for what cloud.sweny.ai actually is) |
+| `docs/self-hosted-worker.md` | (the aws-cloud managed-execution architecture; exploratory, not a shipped product. See [`ARCHITECTURE.md`](../ARCHITECTURE.md)) |
 | `docs/studio.md` | [docs.sweny.ai/studio](https://docs.sweny.ai/studio/) |
 
 What does live in this directory:

--- a/packages/core/src/cli/config-file.ts
+++ b/packages/core/src/cli/config-file.ts
@@ -141,8 +141,9 @@ export const STARTER_CONFIG = `# .sweny.yml — SWEny project configuration
 # cache-dir: .sweny/cache
 # cache-ttl: 86400
 
-# ── Cloud reporting ───────────────────────────────────────────────────
-# Opt-in: paste your project token from cloud.sweny.ai to enable run reporting.
+# ── Run reporting ─────────────────────────────────────────────────────
+# Opt-in and not currently available: token minting is not yet exposed, so
+# leaving this unset means no reporting request is ever made.
 # cloud-token: sweny_pk_...
 # Or set SWENY_CLOUD_TOKEN in your environment.
 


### PR DESCRIPTION
cloud.sweny.ai is an experiment that isn't currently running. The docs presented it as a shipped product, which reads as vaporware to anyone who clicks through and finds nothing behind it.

### What changed

| File | Change |
|---|---|
| `README.md` | Replaces the four-step "sign up, copy your token, add the secret" flow with an accurate note that reporting is opt-in and unavailable. Drops the Cloud Dashboard entry from Links. |
| `ARCHITECTURE.md` | Removes the "What SWEny Cloud is (today)" section and the Codecov comparison. Execution-flow line reworded. |
| `PRIVACY.md` | **Keeps** the payload disclosure, adds a "not currently available" callout. Self-hosting section reframed as "pointing reporting elsewhere". |
| `SECURITY.md` | Execution-model paragraph states the gating explicitly instead of describing a dashboard. |
| `action.yml` | `cloud-token` input description no longer advertises a service. |
| `docs/README.md` | Internal index line no longer points at "what cloud.sweny.ai actually is". |
| `config-file.ts` | Generated `.sweny.yml` comment no longer tells users to paste a token from a site they can't reach. |
| `.changeset/*` | Reworded — it becomes a public CHANGELOG entry on the next release. |

### Why PRIVACY.md keeps the endpoint

The obvious move is to strip every mention. I'd push back on that one: `cloud-report.ts:10` still targets `https://cloud.sweny.ai` and the CLI will POST there if `SWENY_CLOUD_TOKEN` is set. A privacy policy that stopped describing real network behavior is a worse credibility problem than the one this PR fixes.

So the disclosure stays and gets more precise. Verified both call sites are genuinely gated:

- `cloud-report.ts:28` — `if (!cloudToken) return;`
- `cloud-lifecycle.ts:343` — `if (!handle || !config.cloudToken) return;`

A default install makes no outbound request, and the docs now say that plainly.

### No functional change

The reporting code, the action input, and the `SWENY_CLOUD_TOKEN` / `SWENY_CLOUD_URL` contract are untouched. This is docs and one generated comment.

### Verification

| Check | Result |
|---|---|
| `tsc --noEmit` (core) | exit 0 |
| `vitest` cloud suites | 60 passed |
| `vitest` full core suite | 2077 passed, 0 failed |

Correction to an earlier draft of this description: I initially reported 2 failures in `workflow-yaml.test.ts > browser bundle`. Those were a stale local `dist/` (7 weeks old), not a real defect. That suite compares the generated browser bundle against source YAML, and CI runs `npm run build --workspace=packages/core` before `npm run test`. After rebuilding locally the file passes 102/102. CI is green on all 10 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv4TQg75aDRkfDWTXhLmT8
