### PR TITLE
test: pin the no-token privacy contract and the cloud docs positioning

### DIFF
--- a/packages/core/src/__tests__/docs-cloud-positioning.test.ts
+++ b/packages/core/src/__tests__/docs-cloud-positioning.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The hosted cloud service is an experiment that is not running and not open
+ * for sign-ups. Documenting it as a shipped product costs credibility: a
+ * reader who follows the instructions finds nothing behind them.
+ *
+ * This guard separates the two things that look similar in a grep:
+ *
+ *  - PROMOTION — "sign up", "copy your token", a dashboard link in a nav or a
+ *    docs index. Not allowed anywhere.
+ *  - DISCLOSURE — naming the endpoint the CLI posts to when the operator opts
+ *    in. Required in PRIVACY.md, because a privacy policy that omits real
+ *    network behavior is worse than one that mentions an unreleased service.
+ *
+ * If the service launches, delete this file rather than weakening it.
+ */
+
+const repoRoot = (() => {
+  // Walk up from this test file until the directory holding the root docs.
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, "PRIVACY.md")) && existsSync(join(dir, "ARCHITECTURE.md"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error("could not locate repo root from test file");
+})();
+
+function read(rel: string): string {
+  return readFileSync(join(repoRoot, rel), "utf8");
+}
+
+/** Docs a prospective user reads. None of these may sell the service. */
+const USER_FACING_DOCS = ["README.md", "ARCHITECTURE.md", "SECURITY.md", "docs/README.md"];
+
+/** Phrases that only make sense if the service is open for business. */
+const PROMOTIONAL_PATTERNS: Array<{ pattern: RegExp; why: string }> = [
+  { pattern: /\bsign up\b/i, why: "there is no sign-up" },
+  {
+    pattern: /copy the \*\*CI reporting token\*\*|copy your (?:project |cloud )?token/i,
+    why: "no token can be obtained",
+  },
+  { pattern: /\[Cloud Dashboard\]/i, why: "links a product that is not running" },
+  { pattern: /link your repo/i, why: "implies an onboarding flow that does not exist" },
+  { pattern: /what sweny cloud is/i, why: "frames the experiment as a shipped product" },
+];
+
+describe("docs do not promote the unreleased cloud service", () => {
+  for (const doc of USER_FACING_DOCS) {
+    for (const { pattern, why } of PROMOTIONAL_PATTERNS) {
+      it(`${doc} avoids /${pattern.source}/ (${why})`, () => {
+        expect(read(doc)).not.toMatch(pattern);
+      });
+    }
+  }
+
+  it("README does not link the cloud host", () => {
+    // A bare mention is fine in prose; a clickable link is an advertisement.
+    expect(read("README.md")).not.toMatch(/\]\(https:\/\/cloud\.sweny\.ai/);
+  });
+
+  it("README states the reporting path is unavailable", () => {
+    const readme = read("README.md");
+    expect(readme).toMatch(/not yet available|not open for sign-ups/i);
+  });
+});
+
+describe("privacy disclosure is preserved", () => {
+  // The inverse guard. Someone tidying up cloud references could strip the
+  // policy that documents a real, shipping code path.
+  it("PRIVACY.md still names the endpoint the CLI posts to", () => {
+    expect(read("PRIVACY.md")).toMatch(/cloud\.sweny\.ai\/api\/report/);
+  });
+
+  it("PRIVACY.md still enumerates what the payload contains", () => {
+    const privacy = read("PRIVACY.md");
+    for (const field of ["Repository owner and name", "duration", "PR / issue URLs"]) {
+      expect(privacy).toContain(field);
+    }
+  });
+
+  it("PRIVACY.md flags that the service is not currently available", () => {
+    expect(read("PRIVACY.md")).toMatch(/not currently available/i);
+  });
+
+  it("SECURITY.md states the opt-in gate rather than describing a dashboard", () => {
+    const security = read("SECURITY.md");
+    expect(security).toMatch(/SWENY_CLOUD_TOKEN/);
+    expect(security).toMatch(/no outbound request|returns immediately/i);
+  });
+});

--- a/packages/core/src/cli/__tests__/cloud-privacy-contract.test.ts
+++ b/packages/core/src/cli/__tests__/cloud-privacy-contract.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NodeResult } from "../../types.js";
+import type { CliConfig } from "../config.js";
+
+/**
+ * Privacy contract: a default install makes zero outbound requests.
+ *
+ * PRIVACY.md, SECURITY.md, README.md and action.yml all state that reporting
+ * is inert unless the operator sets `SWENY_CLOUD_TOKEN` themselves. That is a
+ * promise to users, so it is pinned here rather than left to the individual
+ * unit tests of each module.
+ *
+ * Two layers:
+ *
+ *  1. Behavior — every entry point the CLI calls with a user-supplied config
+ *     is exercised token-free, and `fetch` must never be reached.
+ *  2. Inventory — the exported surface of both cloud modules is locked, so a
+ *     newly exported function fails this suite until someone classifies it as
+ *     a gated entry point or an internal primitive. Without this, layer 1
+ *     silently stops being exhaustive the moment the surface grows.
+ */
+
+/** Entry points reachable from `main.ts` with the operator's own config. Each MUST self-gate. */
+const GATED_ENTRY_POINTS = [
+  "reportToCloud",
+  "beginCloudLifecycle",
+  "finishCloudLifecycle",
+  "createCloudStreamObserver",
+] as const;
+
+/**
+ * Primitives that issue a request unconditionally, by design. They take a
+ * `CloudReportConfig` whose `cloudToken` is required, and are only reachable
+ * through a gated entry point above. They are NOT part of the no-token
+ * guarantee — the gate lives in their callers.
+ */
+const UNGATED_PRIMITIVES = ["startRun", "finishRun", "postNodeEvent"] as const;
+
+/** Pure helpers: no I/O, safe to call with anything. */
+const PURE_HELPERS = [
+  "detectTriggerSource",
+  "buildTriggerMetadata",
+  "newRunUuid",
+  "buildStartRunPayload",
+  "deriveGenericMetrics",
+] as const;
+
+describe("cloud privacy contract", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+    // A stray SWENY_CLOUD_URL must not be enough to trigger a request on its
+    // own — only the token opts in.
+    delete process.env.SWENY_CLOUD_TOKEN;
+    process.env.SWENY_CLOUD_URL = "https://should-never-be-called.invalid";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.SWENY_CLOUD_URL;
+  });
+
+  /** A config with no cloud token, i.e. what every default install produces. */
+  function tokenlessConfig(): CliConfig {
+    return { repository: "acme/widgets" } as unknown as CliConfig;
+  }
+
+  function sampleResults(): Map<string, NodeResult> {
+    return new Map<string, NodeResult>([
+      ["investigate", { status: "success", data: { recommendation: "ship it" }, toolCalls: [] }],
+      ["create_pr", { status: "failed", data: {}, toolCalls: [] }],
+    ]);
+  }
+
+  describe("no token, no network", () => {
+    it("reportToCloud issues no request", async () => {
+      const { reportToCloud } = await import("../cloud-report.js");
+
+      await reportToCloud(sampleResults(), 1234, tokenlessConfig(), "triage");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("beginCloudLifecycle issues no request and yields no handle", async () => {
+      const { beginCloudLifecycle } = await import("../cloud-lifecycle.js");
+
+      const handle = await beginCloudLifecycle(tokenlessConfig(), {
+        id: "triage",
+        workflow_type: "generic",
+      });
+
+      expect(handle).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("finishCloudLifecycle issues no request, even when handed a live handle", async () => {
+      const { finishCloudLifecycle } = await import("../cloud-lifecycle.js");
+
+      // Deliberately pass a non-null handle: the token check must stand on its
+      // own, not lean on the handle being null.
+      await finishCloudLifecycle(
+        tokenlessConfig(),
+        { runUuid: "uuid-1", runId: "run-1" },
+        sampleResults(),
+        999,
+        "success",
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("createCloudStreamObserver returns undefined, so the engine streams nowhere", async () => {
+      const { createCloudStreamObserver } = await import("../cloud-lifecycle.js");
+
+      const observer = createCloudStreamObserver(tokenlessConfig(), {
+        runUuid: "uuid-1",
+        runId: "run-1",
+      });
+
+      expect(observer).toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("a full triage-shaped run touches the network zero times end to end", async () => {
+      const { reportToCloud } = await import("../cloud-report.js");
+      const { beginCloudLifecycle, finishCloudLifecycle, createCloudStreamObserver } =
+        await import("../cloud-lifecycle.js");
+
+      // Mirrors the call order in main.ts: begin -> observe -> finish -> report.
+      const config = tokenlessConfig();
+      const workflow = { id: "triage", workflow_type: "generic" } as const;
+      const results = sampleResults();
+
+      const handle = await beginCloudLifecycle(config, workflow);
+      const observer = createCloudStreamObserver(config, handle);
+      observer?.({ type: "workflow:start", workflow: "triage" } as never);
+      observer?.({ type: "node:enter", node: "investigate" } as never);
+      observer?.({ type: "workflow:end", results: {} } as never);
+      await finishCloudLifecycle(config, handle, results, 4321, "success");
+      await reportToCloud(results, 4321, config, "triage");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("an empty-string token is treated as absent, not as a credential", async () => {
+      const { reportToCloud } = await import("../cloud-report.js");
+      const { beginCloudLifecycle } = await import("../cloud-lifecycle.js");
+
+      const config = { ...tokenlessConfig(), cloudToken: "" } as unknown as CliConfig;
+
+      await reportToCloud(sampleResults(), 1, config, "triage");
+      const handle = await beginCloudLifecycle(config, { id: "triage", workflow_type: "generic" });
+
+      expect(handle).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("exported surface inventory", () => {
+    // Guards the completeness of the suite above. If this fails, a cloud
+    // function was added or renamed: decide whether it is a gated entry point
+    // (add a no-token test above, then list it in GATED_ENTRY_POINTS) or an
+    // internal primitive (list it in UNGATED_PRIMITIVES).
+    it("cloud-lifecycle exports nothing unclassified", async () => {
+      const mod = await import("../cloud-lifecycle.js");
+      const runtimeFns = Object.keys(mod)
+        .filter((k) => typeof (mod as Record<string, unknown>)[k] === "function")
+        .sort();
+
+      const classified = [...GATED_ENTRY_POINTS, ...UNGATED_PRIMITIVES, ...PURE_HELPERS];
+
+      expect(runtimeFns.filter((fn) => !classified.includes(fn as never))).toEqual([]);
+    });
+
+    it("cloud-report exports nothing unclassified", async () => {
+      const mod = await import("../cloud-report.js");
+      const runtimeFns = Object.keys(mod)
+        .filter((k) => typeof (mod as Record<string, unknown>)[k] === "function")
+        .sort();
+
+      expect(runtimeFns.filter((fn) => !GATED_ENTRY_POINTS.includes(fn as never))).toEqual([]);
+    });
+
+    it("every gated entry point is actually exported somewhere", async () => {
+      const lifecycle = await import("../cloud-lifecycle.js");
+      const report = await import("../cloud-report.js");
+      const available = new Set([...Object.keys(lifecycle), ...Object.keys(report)]);
+
+      expect(GATED_ENTRY_POINTS.filter((fn) => !available.has(fn))).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #296. That PR made two promises in prose and neither was pinned by a test, so both could rot silently.

## 1. Privacy contract

`packages/core/src/cli/__tests__/cloud-privacy-contract.test.ts`

PRIVACY.md, SECURITY.md, README.md and action.yml all claim a default install makes **no outbound request**. Each module already had its own gate test, but nothing asserted the aggregate, and nothing stopped a *new* ungated entry point from being added later.

**Layer 1 — behavior.** All four entry points the CLI actually calls are exercised token-free and must never reach `fetch`:

| Entry point | Gate |
|---|---|
| `reportToCloud` | `cloud-report.ts:28` |
| `beginCloudLifecycle` | `cloud-lifecycle.ts:308` |
| `finishCloudLifecycle` | `cloud-lifecycle.ts:343` |
| `createCloudStreamObserver` | `cloud-lifecycle.ts:380` |

Includes a full `begin → observe → finish → report` sequence mirroring the call order in `main.ts`, an empty-string-token case, and a check that a stray `SWENY_CLOUD_URL` alone is not enough to trigger a request.

**Layer 2 — inventory lock.** The exported surface of both cloud modules is locked. A new export fails the suite until someone classifies it as a gated entry point or an internal primitive. `startRun` / `finishRun` / `postNodeEvent` fetch unconditionally *by design* — they take a `CloudReportConfig` with a required token and are only reachable through a gated caller, so they are classified rather than "fixed". Without this lock, layer 1 stops being exhaustive the moment the surface grows.

## 2. Docs positioning

`packages/core/src/__tests__/docs-cloud-positioning.test.ts`

Guards **both directions**, because the failure modes are opposite:

- Promotional phrasing ("sign up", "copy your token", a `[Cloud Dashboard]` link) must not return to README / ARCHITECTURE / SECURITY / docs README.
- The PRIVACY.md disclosure naming `cloud.sweny.ai/api/report` and its payload fields must **not** be stripped by a future tidy-up. A privacy policy that omits real network behavior is worse than one that mentions an unreleased service.

## Mutation testing

Every guard was verified by breaking it, not assumed from a green run:

| Mutation | Result |
|---|---|
| Remove the `reportToCloud` token gate | 3 behavior tests fail |
| Add an unclassified exported function | inventory lock fails, names `reportHeartbeat` |
| Re-add promo copy to README | 4 docs assertions fail |
| Delete the PRIVACY.md endpoint line | disclosure assertion fails |

Sources were restored and verified byte-clean via `git diff --stat` after each.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | exit 0 |
| full core suite | 2112 passed, 10 skipped, **0 failed** |
| `eslint` on new files | exit 0 |
| `prettier --check` | clean |

Note: `tsc` initially caught 3 errors in the new test — I had invented `workflow_type: "triage"`, which is not in the enum. Fixed to `"generic"`.

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv4TQg75aDRkfDWTXhLmT8